### PR TITLE
api authentication does not crash if auth token has expired

### DIFF
--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/authentication.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/authentication.py
@@ -40,7 +40,7 @@ class AuthenticatedUser(object):
 
         user_id, token = auth.split(':')
         infos = self.request.cache.get(user_id)
-        if infos.get('access_token') != token:
+        if infos is None or infos.get('access_token') != token:
             raise AuthenticationError
 
         self.user_id = user_id


### PR DESCRIPTION
fix a bug that prevent application to respond with 403 code if auth cache has expired