### PR TITLE
fix/buildReturnObjects

### DIFF
--- a/src/backend/main/py.main/caliopen_main/message/parameters.py
+++ b/src/backend/main/py.main/caliopen_main/message/parameters.py
@@ -20,29 +20,33 @@ class Recipient(Model):
     address = StringType(required=True)
     label = StringType(required=True)
     type = StringType(required=True, choices=RECIPIENT_TYPES)
-    protocol = StringType(choices=MESSAGE_TYPES, serialize_when_none=False)
-    contact_id = UUIDType(serialize_when_none=False)
+    protocol = StringType(choices=MESSAGE_TYPES)
+    contact_id = UUIDType()
+
+    class Options:
+        serialize_when_none = False
 
 
 class Thread(Model):
 
     """Existing thread."""
 
-    user_id = UUIDType(serialize_when_none=False)
+    user_id = UUIDType()
     thread_id = UUIDType(required=True)
-    date_insert = DateTimeType(serialize_when_none=False, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
-    date_update = DateTimeType(serialize_when_none=False, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
+    date_insert = DateTimeType(serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
+    date_update = DateTimeType(serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
     text = StringType(required=True)
     privacy_index = IntType(required=True, default=0)
     importance_level = IntType(required=True, default=0)
-    tags = ListType(StringType(), default=lambda: [], serialize_when_none=False)
-    contacts = ListType(ModelType(Recipient), default=lambda: [], serialize_when_none=False)
+    tags = ListType(StringType(), default=lambda: [])
+    contacts = ListType(ModelType(Recipient), default=lambda: [])
     total_count = IntType(required=True, default=0)
     unread_count = IntType(required=True, default=0)
-    attachment_count = IntType(default=0, serialize_when_none=False)
+    attachment_count = IntType(default=0)
 
     class Options:
         roles = {'default': blacklist('user_id')}
+        serialize_when_none = False
 
 
 class Part(Model):
@@ -50,10 +54,13 @@ class Part(Model):
     """Message part."""
 
     content_type = StringType(required=True)
-    filename = StringType(serialize_when_none=False)
-    data = StringType(serialize_when_none=False)
-    size = IntType(serialize_when_none=False)
-    can_index = BooleanType(serialize_when_none=False)
+    filename = StringType()
+    data = StringType()
+    size = IntType()
+    can_index = BooleanType()
+
+    class Options:
+        serialize_when_none = False
 
 
 class NewMessage(Model):
@@ -61,38 +68,42 @@ class NewMessage(Model):
     """New message parameter."""
 
     recipients = ListType(ModelType(Recipient),
-                          default=lambda: [], serialize_when_none=False)
+                          default=lambda: [])
     from_ = StringType(required=True)
-    subject = StringType(serialize_when_none=False)
+    subject = StringType()
     text = StringType(required=True)
-    privacy_index = IntType(default=0, serialize_when_none=False)
-    importance_level = IntType(default=0, serialize_when_none=False)
+    privacy_index = IntType(default=0)
+    importance_level = IntType(default=0)
     date = DateTimeType(required=True, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
-    tags = ListType(StringType, serialize_when_none=False)
+    tags = ListType(StringType)
     # XXX define a part parameter
-    parts = ListType(ModelType(Part), default=lambda: [], serialize_when_none=False)
-    headers = DictType(ListType(StringType), default=lambda: {}, serialize_when_none=False)
-    external_parent_id = StringType(serialize_when_none=False)
-    external_message_id = StringType(serialize_when_none=False)
-    external_thread_id = StringType(serialize_when_none=False)
+    parts = ListType(ModelType(Part), default=lambda: [])
+    headers = DictType(ListType(StringType), default=lambda: {})
+    external_parent_id = StringType()
+    external_message_id = StringType()
+    external_thread_id = StringType()
     # XXX compute ?
-    size = IntType(serialize_when_none=False)
+    size = IntType()
     type = StringType(required=True, choices=MESSAGE_TYPES)
     # Only initial state allowed and can bypass unread to read directly
     state = StringType(required=True, choices=['unread', 'draft', 'read'])
+
+    class Options:
+        serialize_when_none = False
 
 
 class Message(NewMessage):
 
     """Existing message parameter."""
 
-    user_id = UUIDType(serialize_when_none=False)
+    user_id = UUIDType()
     message_id = UUIDType(required=True)
     raw_msg_id = UUIDType(required=True)
     date_insert = DateTimeType(required=True, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
-    text = StringType(serialize_when_none=False)
+    text = StringType()
     # All states allowed
     state = StringType(required=True, choices=MESSAGE_STATES)
 
     class Options:
         roles = {'default': blacklist('user_id')}
+        serialize_when_none = False

--- a/src/backend/main/py.main/caliopen_main/user/parameters/contact.py
+++ b/src/backend/main/py.main/caliopen_main/user/parameters/contact.py
@@ -34,50 +34,60 @@ class Recipient(Model):
     """Store a contact reference and one of it's address used in a message."""
 
     address = StringType(required=True)
-    contact_id = UUIDType(serialize_when_none=False)
+    contact_id = UUIDType()
     type = StringType(required=True, choices=RECIPIENT_TYPES)
+
+    class Options:
+        serialize_when_none = False
 
 
 class NewOrganization(Model):
 
     """Input structure for a new organization."""
 
-    department = StringType(serialize_when_none=False)
-    is_primary = BooleanType(default=False, serialize_when_none=False)
-    job_description = StringType(serialize_when_none=False)
+    department = StringType()
+    is_primary = BooleanType(default=False)
+    job_description = StringType()
     label = StringType(required=True)
     name = StringType(required=True)
-    title = StringType(serialize_when_none=False)
+    title = StringType()
     # XXX Add enumerated list
-    type = StringType(choices=ORG_TYPES, serialize_when_none=False)
+    type = StringType(choices=ORG_TYPES)
+
+    class Options:
+        serialize_when_none = False
 
 
 class Organization(NewOrganization):
 
     """Existing organization."""
 
-    contact_id = UUIDType(serialize_when_none=False)
-    deleted = BooleanType(default=False, serialize_when_none=False)
+    contact_id = UUIDType()
+    deleted = BooleanType(default=False)
     organization_id = UUIDType(required=True)
-    user_id = UUIDType(serialize_when_none=False)
+    user_id = UUIDType()
 
     class Options:
         roles = {'default': blacklist('user_id', 'contact_id')}
+        serialize_when_none = False
 
 
 class NewPostalAddress(Model):
 
     """Input structure for a new postal address."""
 
-    address_id = StringType(serialize_when_none=False)
+    address_id = StringType()
     city = StringType(required=True)
-    country = StringType(serialize_when_none=False)
-    is_primary = BooleanType(default=False, serialize_when_none=False)
-    label = StringType(serialize_when_none=False)
-    postal_code = StringType(serialize_when_none=False)
-    region = StringType(serialize_when_none=False)
-    street = StringType(serialize_when_none=False)
-    type = StringType(choices=ADDRESS_TYPES, serialize_when_none=False)
+    country = StringType()
+    is_primary = BooleanType(default=False)
+    label = StringType()
+    postal_code = StringType()
+    region = StringType()
+    street = StringType()
+    type = StringType(choices=ADDRESS_TYPES)
+
+    class Options:
+        serialize_when_none = False
 
 
 class PostalAddress(NewPostalAddress):
@@ -85,32 +95,37 @@ class PostalAddress(NewPostalAddress):
     """Existing postal address."""
 
     address_id = UUIDType(required=True)
-    contact_id = UUIDType(serialize_when_none=False)
-    user_id = UUIDType(serialize_when_none=False)
+    contact_id = UUIDType()
+    user_id = UUIDType()
 
     class Options:
         roles = {'default': blacklist('user_id', 'contact_id')}
+        serialize_when_none = False
 
 
 class NewEmail(Model):
 
     """Input structure for a new email."""
     address = InternetAddressType(required=True)
-    is_primary = BooleanType(default=False, serialize_when_none=False)
-    label = StringType(serialize_when_none=False)
-    type = StringType(choices=EMAIL_TYPES, default='other', serialize_when_none=False)
+    is_primary = BooleanType(default=False)
+    label = StringType()
+    type = StringType(choices=EMAIL_TYPES, default='other')
+
+    class Options:
+        serialize_when_none = False
 
 
 class Email(NewEmail):
 
     """Existing email."""
 
-    contact_id = UUIDType(serialize_when_none=False)
+    contact_id = UUIDType()
     email_id = UUIDType(required=True)
-    user_id = UUIDType(serialize_when_none=False)
+    user_id = UUIDType()
 
     class Options:
         roles = {'default': blacklist('user_id', 'contact_id')}
+        serialize_when_none = False
 
 
 class NewIM(Model):
@@ -118,141 +133,164 @@ class NewIM(Model):
     """Input structure for a new IM."""
 
     address = InternetAddressType(required=True)
-    is_primary = BooleanType(default=False, serialize_when_none=False)
-    label = StringType(serialize_when_none=False)
-    protocol = StringType(serialize_when_none=False)
-    type = StringType(choices=IM_TYPES, default='other', serialize_when_none=False)
+    is_primary = BooleanType(default=False)
+    label = StringType()
+    protocol = StringType()
+    type = StringType(choices=IM_TYPES, default='other')
+
+    class Options:
+        serialize_when_none=False
 
 
 class IM(NewIM):
 
     """Existing IM."""
 
-    contact_id = UUIDType(serialize_when_none=False)
+    contact_id = UUIDType()
     im_id = UUIDType(required=True)
-    user_id = UUIDType(serialize_when_none=False)
+    user_id = UUIDType()
 
     class Options:
         roles = {'default': blacklist('user_id', 'contact_id')}
+        serialize_when_none = False
 
 
 class NewPhone(Model):
 
     """Input structure for a new phone."""
 
-    is_primary = BooleanType(default=False, serialize_when_none=False)
+    is_primary = BooleanType(default=False)
     number = PhoneNumberType(required=True)
-    type = StringType(choices=PHONE_TYPES, default='other', serialize_when_none=False)
-    uri = URLType(serialize_when_none=False)
+    type = StringType(choices=PHONE_TYPES, default='other')
+    uri = URLType()
 
+    class Options:
+        serialize_when_none = False
 
 class Phone(NewPhone):
 
     """Existing phone."""
 
-    contact_id = UUIDType(serialize_when_none=False)
+    contact_id = UUIDType()
     phone_id = UUIDType(required=True)
-    user_id = UUIDType(serialize_when_none=False)
+    user_id = UUIDType()
 
     class Options:
         roles = {'default': blacklist('user_id', 'contact_id')}
+        serialize_when_none = False
 
 
 class NewSocialIdentity(Model):
 
     """Input structure for a new social identity."""
 
-    infos = DictType(StringType, default=lambda: {}, serialize_when_none=False)
+    infos = DictType(StringType, default=lambda: {})
     name = StringType(required=True)
-    type = StringType(choices=SOCIAL_TYPES, serialize_when_none=False)
+    type = StringType(choices=SOCIAL_TYPES)
+
+    class Options:
+        serialize_when_none = False
 
 
 class SocialIdentity(NewSocialIdentity):
 
     """Existing social identity."""
 
-    contact_id = UUIDType(serialize_when_none=False)
+    contact_id = UUIDType()
     identity_id = UUIDType(required=True)
-    user_id = UUIDType(serialize_when_none=False)
+    user_id = UUIDType()
 
     class Options:
         roles = {'default': blacklist('user_id', 'contact_id')}
+        serialize_when_none = False
 
 
 class NewPublicKey(Model):
 
     """Input structure for a new public key."""
 
-    expire_date = DateTimeType(serialize_when_none=False, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
-    fingerprint = StringType(serialize_when_none=False)
+    expire_date = DateTimeType(serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
+    fingerprint = StringType()
     key = StringType(required=True)
     name = StringType(required=True)
-    size = IntType(serialize_when_none=False)
-    type = StringType(choices=KEY_CHOICES, serialize_when_none=False)
+    size = IntType()
+    type = StringType(choices=KEY_CHOICES)
+
+    class Options:
+        serialize_when_none = False
 
 
 class PublicKey(NewPublicKey):
 
     """Existing public key."""
 
-    contact_id = UUIDType(serialize_when_none=False)
+    contact_id = UUIDType()
     date_insert = DateTimeType(required=True, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
-    date_update = DateTimeType(serialize_when_none=False, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
-    user_id = UUIDType(serialize_when_none=False)
+    date_update = DateTimeType(serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
+    user_id = UUIDType()
 
     class Options:
         roles = {'default': blacklist('user_id', 'contact_id')}
+        serialize_when_none = False
 
 
 class NewContact(Model):
 
     """Input structure for a new contact."""
 
-    additional_name = StringType(serialize_when_none=False)
-    addresses = ListType(ModelType(NewPostalAddress), default=lambda: [], serialize_when_none=False)
-    emails = ListType(ModelType(NewEmail), default=lambda: [], serialize_when_none=False)
-    family_name = StringType(serialize_when_none=False)
-    given_name = StringType(serialize_when_none=False)
-    groups = ListType(StringType, serialize_when_none=False)
-    identities = ListType(ModelType(NewSocialIdentity), default=lambda: [], serialize_when_none=False)
-    ims = ListType(ModelType(NewIM), default=lambda: [], serialize_when_none=False)
-    infos = DictType(StringType, serialize_when_none=False)
-    name_prefix = StringType(serialize_when_none=False)
-    name_suffix = StringType(serialize_when_none=False)
-    organizations = ListType(ModelType(NewOrganization), default=lambda: [], serialize_when_none=False)
-    phones = ListType(ModelType(NewPhone), default=lambda: [], serialize_when_none=False)
-    privacy_features = DictType(StringType, default=lambda: {}, serialize_when_none=False)
-    privacy_index = IntType(default=0, serialize_when_none=False)
-    public_keys = ListType(ModelType(NewPublicKey), default=lambda: [], serialize_when_none=False)
-    tags = ListType(StringType, serialize_when_none=False)
+    additional_name = StringType()
+    addresses = ListType(ModelType(NewPostalAddress), default=lambda: [])
+    emails = ListType(ModelType(NewEmail), default=lambda: [])
+    family_name = StringType()
+    given_name = StringType()
+    groups = ListType(StringType)
+    identities = ListType(ModelType(NewSocialIdentity), default=lambda: [])
+    ims = ListType(ModelType(NewIM), default=lambda: [], )
+    infos = DictType(StringType)
+    name_prefix = StringType()
+    name_suffix = StringType()
+    organizations = ListType(ModelType(NewOrganization), default=lambda: [])
+    phones = ListType(ModelType(NewPhone), default=lambda: [])
+    privacy_features = DictType(StringType, default=lambda: {})
+    privacy_index = IntType(default=0)
+    public_keys = ListType(ModelType(NewPublicKey), default=lambda: [])
+    tags = ListType(StringType)
+
+    class Options:
+        serialize_when_none = False
 
 
 class Contact(NewContact):
 
     """Existing contact."""
-    addresses = ListType(ModelType(PostalAddress), default=lambda: [], serialize_when_none=False)
-    avatar = StringType(default='avatar.png', serialize_when_none=False)
+    addresses = ListType(ModelType(PostalAddress), default=lambda: [])
+    avatar = StringType(default='avatar.png')
     contact_id = UUIDType(required=True)
-    date_insert = DateTimeType(serialize_when_none=False, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
-    date_update = DateTimeType(serialize_when_none=False, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
-    deleted = BooleanType(serialize_when_none=False)
-    emails = ListType(ModelType(Email), default=lambda: [], serialize_when_none=False)
-    identities = ListType(ModelType(SocialIdentity), default=lambda: [], serialize_when_none=False)
-    ims = ListType(ModelType(IM), default=lambda: [], serialize_when_none=False)
-    organizations = ListType(ModelType(Organization), default=lambda: [], serialize_when_none=False)
-    phones = ListType(ModelType(Phone), default=lambda: [], serialize_when_none=False)
-    public_keys = ListType(ModelType(PublicKey), default=lambda: [], serialize_when_none=False)
+    date_insert = DateTimeType(serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
+    date_update = DateTimeType(serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
+    deleted = BooleanType()
+    emails = ListType(ModelType(Email), default=lambda: [])
+    identities = ListType(ModelType(SocialIdentity), default=lambda: [])
+    ims = ListType(ModelType(IM), default=lambda: [])
+    organizations = ListType(ModelType(Organization), default=lambda: [])
+    phones = ListType(ModelType(Phone), default=lambda: [])
+    public_keys = ListType(ModelType(PublicKey), default=lambda: [])
     # XXX not such default here
-    title = StringType(serialize_when_none=False)
+    title = StringType()
     user_id = UUIDType(required=True)
 
+    class Options:
+        serialize_when_none = False
 
 class ShortContact(Model):
 
     """Input structure for contact in short form."""
 
     contact_id = UUIDType(required=True)
-    family_name = StringType(serialize_when_none=False)
-    given_name = StringType(serialize_when_none=False)
-    tags = ListType(StringType, serialize_when_none=False)
-    title = StringType(serialize_when_none=False)
+    family_name = StringType()
+    given_name = StringType()
+    tags = ListType(StringType, )
+    title = StringType()
+
+    class Options:
+        serialize_when_none = False

--- a/src/backend/main/py.main/caliopen_main/user/parameters/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/parameters/user.py
@@ -20,10 +20,13 @@ class NewUser(Model):
     """
 
     contact = ModelType(NewContact)
-    main_user_id = UUIDType(serialize_when_none=False)
+    main_user_id = UUIDType()
     name = StringType(required=True)
-    params = DictType(StringType(serialize_when_none=False))
+    params = DictType(StringType())
     password = StringType(required=True)
+
+    class Options:
+        serialize_when_none = False
 
 
 class User(NewUser):
@@ -31,29 +34,31 @@ class User(NewUser):
     """Existing user."""
 
     contact = ModelType(Contact)
-    date_insert = DateTimeType(serialize_when_none=True, serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
-    family_name = StringType(serialize_when_none=False)
-    given_name = StringType(serialize_when_none=False)
-    password = StringType(serialize_when_none=False)     # not outpout by default, not required
-    privacy_features = DictType(StringType, default=lambda: {}, serialize_when_none=False)
-    privacy_index = IntType(default=0, serialize_when_none=False)
+    date_insert = DateTimeType(serialized_format="%Y-%m-%dT%H:%M:%S.%f+00:00", tzd=u'utc')
+    family_name = StringType()
+    given_name = StringType()
+    password = StringType()     # not outpout by default, not required
+    privacy_features = DictType(StringType, default=lambda: {}, )
+    privacy_index = IntType(default=0, )
     user_id = UUIDType(required=True)
 
     class Options:
         roles = {'default': blacklist('password')}
+        serialize_when_none = False
 
 
 class Tag(Model):
 
     """Existing user tag."""
 
-    user_id = UUIDType(serialize_when_none=False)
-    label = StringType(serialize_when_none=False)
-    background = StringType(serialize_when_none=False)
-    color = StringType(serialize_when_none=False)
+    user_id = UUIDType()
+    label = StringType()
+    background = StringType()
+    color = StringType()
 
     class Option:
         roles = {'default': blacklist('user_id')}
+        serialize_when_none = False
 
 
 class NewRule(Model):
@@ -62,6 +67,9 @@ class NewRule(Model):
 
     name = StringType(required=True)
     expr = StringType(required=True)
-    position = IntType(serialize_when_none=False)
-    stop_condition = BooleanType(default=False, serialize_when_none=False)
-    tags = ListType(StringType, serialize_when_none=False)
+    position = IntType()
+    stop_condition = BooleanType(default=False)
+    tags = ListType(StringType)
+
+    class Options:
+        serialize_when_none = False

--- a/src/backend/main/py.storage/caliopen_storage/parameters.py
+++ b/src/backend/main/py.storage/caliopen_storage/parameters.py
@@ -57,7 +57,7 @@ class ReturnCoreObject(BaseReturnObject):
         """Main method to build a return object from a core."""
         kls = cls._return_class
         obj = kls()
-        for k, v in obj.serialize().iteritems():
+        for k, v in obj._data.iteritems():
             if cls._aliases.get(k):
                 core_key = cls._aliases[k]
             else:
@@ -107,7 +107,7 @@ class ReturnIndexObject(BaseReturnObject):
         """Main method to build a return object from an index entry."""
         kls = cls._return_class
         obj = kls()
-        for k, v in obj.serialize().iteritems():
+        for k, v in obj._data.iteritems():
             if cls._aliases.get(k):
                 idx_key = cls._aliases[k]
             else:


### PR DESCRIPTION
This fix ensure that returned objects by API don't have 'None' values.
Inside the application, we need to build ReturnObjects from their model instead of the serialize() function