### PR TITLE
Remove global Jasmine calls in unit tests

### DIFF
--- a/src/frontend/web_application/.eslintrc
+++ b/src/frontend/web_application/.eslintrc
@@ -13,7 +13,7 @@
   "env": {
     "browser": true,
     "es6": true,
-    "jasmine": true,
+    "jest": true,
     "protractor": true
   },
   "rules": {
@@ -24,7 +24,6 @@
     "inject": true,
     "Foundation": true,
     "jQuery": true,
-    "jest": true,
     "BUILD_TARGET": true,
     "CALIOPEN_ENV": true
   }

--- a/src/frontend/web_application/package.json
+++ b/src/frontend/web_application/package.json
@@ -74,6 +74,7 @@
     "webpack-dashboard": "^0.2.0"
   },
   "devDependencies": {
+    "@kadira/storybook": "^2.21.0",
     "babel-cli": "^6.18.0",
     "babel-gettext-plugin": "^2.2.0",
     "babel-jest": "^16.0.0",
@@ -91,7 +92,7 @@
     "eslint-plugin-react": "^6.4.1",
     "expose-loader": "^0.7.1",
     "html-webpack-plugin": "^2.22.0",
-    "jest-cli": "^16.0.2",
+    "jest-cli": "^18.0.0",
     "kotatsu": "^0.14.0",
     "nodemon": "^1.11.0",
     "po2json": "^0.4.5",
@@ -102,8 +103,7 @@
     "sasslint-loader": "0.0.1",
     "webpack-dev-middleware": "^1.8.3",
     "webpack-hot-middleware": "^2.12.2",
-    "webpack-target-electron-renderer": "^0.4.0",
-    "@kadira/storybook": "^2.21.0"
+    "webpack-target-electron-renderer": "^0.4.0"
   },
   "babel": {
     "presets": [

--- a/src/frontend/web_application/src/components/Button/index.spec.jsx
+++ b/src/frontend/web_application/src/components/Button/index.spec.jsx
@@ -3,8 +3,8 @@ import { shallow } from 'enzyme';
 import Button from './';
 
 describe('component Button', () => {
-  it('render', () => {
-    const handleClick = jasmine.createSpy('handleClick');
+  it('should render', () => {
+    const handleClick = jest.fn();
 
     const comp = shallow(
       <Button onClick={handleClick}>Foo</Button>

--- a/src/frontend/web_application/src/components/ContactProfile/index.spec.js
+++ b/src/frontend/web_application/src/components/ContactProfile/index.spec.js
@@ -23,7 +23,7 @@ describe('component contact-card-summary', () => {
   //   };
   //   const updatedContact = { ...contact, given_name: 'John' };
   //
-  //   const onChange = jasmine.createSpy('onChange');
+  //   const onChange = jest.fn();
   //   const ctrl = $componentController('contactCardSummary', null, { contact, onChange });
   //
   //   ctrl.handleChanges('given_name', { model: updatedContact.given_name });

--- a/src/frontend/web_application/src/components/form/SelectFieldGroup/index.spec.jsx
+++ b/src/frontend/web_application/src/components/form/SelectFieldGroup/index.spec.jsx
@@ -3,11 +3,11 @@ import { shallow } from 'enzyme';
 import SelectFieldGroup from './';
 
 describe('component SelectFieldGroup', () => {
-  it('render', () => {
+  it('should render', () => {
     const props = {
       label: 'Foo',
       options: [{ label: 'a', value: 1 }, { label: 'b', value: 3 }],
-      onChange: jasmine.createSpy('onChange'),
+      onChange: jest.fn(),
     };
 
     const comp = shallow(

--- a/src/frontend/web_application/src/components/form/TextFieldGroup/index.spec.jsx
+++ b/src/frontend/web_application/src/components/form/TextFieldGroup/index.spec.jsx
@@ -20,7 +20,7 @@ describe('component textFieldGroup', () => {
   //   const label = 'Foo';
   //   const model = 'D.';
   //
-  //   const onChange = jasmine.createSpy('onChange');
+  //   const onChange = jest.fn();
   //   const ctrl = $componentController('textFieldGroup', null, { props, label, model, onChange });
   //
   //   expect(ctrl).toBeDefined();

--- a/src/frontend/web_application/src/components/form/TextareaFieldGroup/index.spec.jsx
+++ b/src/frontend/web_application/src/components/form/TextareaFieldGroup/index.spec.jsx
@@ -3,10 +3,10 @@ import { shallow } from 'enzyme';
 import TextareaFieldGroup from './';
 
 describe('component TextareaFieldGroup', () => {
-  it('render', () => {
+  it('should render', () => {
     const props = {
       label: 'Foo',
-      onChange: jasmine.createSpy('onChange'),
+      onChange: jest.fn(),
     };
 
     const comp = shallow(


### PR DESCRIPTION
Greetings,

this is a following of #89 somehow, where the linting was producing errors on global Jasmine calls.

Jasmine has been removed from Jest, so it's a good idea to start migrating now.
References:
> As part of our effort to remove Jasmine incrementally within Jest, replacing all Jasmine matchers was almost completed.

> We finished the migration of Jasmine assertions to the new Jest matchers

https://facebook.github.io/jest/blog/

I grabbed to occasion to updrade the Jest dependency as well.


