### PR TITLE
Fix spacings

### DIFF
--- a/src/frontend/web_application/src/components/SignupForm/index.jsx
+++ b/src/frontend/web_application/src/components/SignupForm/index.jsx
@@ -20,29 +20,30 @@ class SignupForm extends Component {
         <Brand className="s-signup__brand" />
         <FormGrid className="s-signup__form" name="ac_form">
           <FormRow>
-            <FormColumn className="s-signup__title" fluid>
+            <FormColumn className="s-signup__title" bottomSpace>
               <Title>Create your account</Title>
             </FormColumn>
           </FormRow>
           {this.state.errors.length !== 0 && (
           <FormRow>
-            <FormColumn fluid>
+            <FormColumn bottomSpace>
               <FieldErrors className="s-signup__global-errors" errors={this.state.errors} />
             </FormColumn>
           </FormRow>
           )}
           <FormRow>
-            <FormColumn fluid >
+            <FormColumn bottomSpace >
               <TextFieldGroup
                 name="username"
                 label="Username"
                 placeholder="username"
+                errors={['prout']}
                 showLabelforSr
               />
             </FormColumn>
           </FormRow>
           <FormRow>
-            <FormColumn>
+            <FormColumn bottomSpace>
               <TextFieldGroup
                 name="password"
                 label="password"
@@ -56,7 +57,7 @@ class SignupForm extends Component {
             </FormColumn>
           </FormRow>
           <FormRow>
-            <FormColumn className="s-signup__terms m-im-form__action">
+            <FormColumn bottomSpace>
               <SwitchFieldGroup label="I agree Terms and conditions" showTextLabel />
             </FormColumn>
           </FormRow>

--- a/src/frontend/web_application/src/components/SignupForm/index.jsx
+++ b/src/frontend/web_application/src/components/SignupForm/index.jsx
@@ -37,7 +37,7 @@ class SignupForm extends Component {
                 name="username"
                 label="Username"
                 placeholder="username"
-                errors={['lol']}
+                // errors={['lol']}
                 showLabelforSr
               />
             </FormColumn>

--- a/src/frontend/web_application/src/components/SignupForm/index.jsx
+++ b/src/frontend/web_application/src/components/SignupForm/index.jsx
@@ -37,7 +37,7 @@ class SignupForm extends Component {
                 name="username"
                 label="Username"
                 placeholder="username"
-                errors={['prout']}
+                errors={['lol']}
                 showLabelforSr
               />
             </FormColumn>

--- a/src/frontend/web_application/src/components/SignupForm/style.scss
+++ b/src/frontend/web_application/src/components/SignupForm/style.scss
@@ -17,17 +17,10 @@ $switch_height: 2rem;
     @include breakpoint(medium) {
       padding-right: 0;
     }
-
   }
 
   &__title {
-    margin-bottom: map-get($co-form__spacing, 'medium');
     text-align: center;
   }
-
-  &__terms {
-    margin-bottom: map-get($co-form__spacing, 'medium');
-  }
-
 
 }

--- a/src/frontend/web_application/src/components/form/FieldErrors/style.scss
+++ b/src/frontend/web_application/src/components/form/FieldErrors/style.scss
@@ -1,8 +1,8 @@
 @import '../../../styles/common';
 
 .m-field-errors {
-  padding-top: map-get($co-form__spacing, 'xsmall');
   list-style: none;
+  padding-top: map-get($co-form__spacing, 'xsmall');
   color:  map-get($caliopen-palette, 'alert');
   font-size: $co-font__size--small;
   font-weight: 700;

--- a/src/frontend/web_application/src/components/form/FieldErrors/style.scss
+++ b/src/frontend/web_application/src/components/form/FieldErrors/style.scss
@@ -1,6 +1,7 @@
 @import '../../../styles/common';
 
 .m-field-errors {
+  padding-top: map-get($co-form__spacing, 'xsmall');
   list-style: none;
   color:  map-get($caliopen-palette, 'alert');
   font-size: $co-font__size--small;

--- a/src/frontend/web_application/src/components/form/FieldErrors/style.scss
+++ b/src/frontend/web_application/src/components/form/FieldErrors/style.scss
@@ -2,7 +2,6 @@
 
 .m-field-errors {
   list-style: none;
-  padding: $co-component__spacing 0;
   color:  map-get($caliopen-palette, 'alert');
   font-size: $co-font__size--small;
   font-weight: 700;

--- a/src/frontend/web_application/src/components/form/FormGrid/index.jsx
+++ b/src/frontend/web_application/src/components/form/FormGrid/index.jsx
@@ -2,9 +2,10 @@ import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import './style.scss';
 
-export const FormColumn = ({ className, size, fluid = false, ...props }) => {
+export const FormColumn = ({ className, bottomSpace, size, fluid = false, ...props }) => {
   const colClassName = classnames('m-form-grid__column', {
     'm-form-grid__column--fluid': fluid,
+    'm-form-grid__column--bottom-space': bottomSpace,
     'm-form-grid__column--shrink': size === 'shrink',
     'm-form-grid__column--small': size === 'small',
     'm-form-grid__column--medium': size === 'medium',
@@ -20,6 +21,7 @@ FormColumn.propTypes = {
   className: PropTypes.string,
   size: PropTypes.oneOf(['shrink', 'small', 'medium', 'large']),
   fluid: PropTypes.bool,
+  bottomSpace: PropTypes.bool,
 };
 
 export const FormRow = ({ className, ...props }) => (

--- a/src/frontend/web_application/src/components/form/FormGrid/style.scss
+++ b/src/frontend/web_application/src/components/form/FormGrid/style.scss
@@ -14,6 +14,10 @@
       @include flex-grid-size;
     }
 
+    &--bottom-space {
+      margin-bottom: map_get($co-form__spacing, 'medium');
+    }
+
     @include breakpoint(medium) {
 
       padding-right: map_get($co-form__spacing, 'medium');

--- a/src/frontend/web_application/src/components/form/InputText/index.jsx
+++ b/src/frontend/web_application/src/components/form/InputText/index.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import './style.scss';
 
-const InputText = ({ expanded, theme, bottomSpace = true, className, hasError, ...props }) => {
+const InputText = ({ expanded, theme, bottomSpace, className, hasError, ...props }) => {
   const inputTextClassName = classnames(
     'm-input-text',
     {

--- a/src/frontend/web_application/src/components/form/TextFieldGroup/style.scss
+++ b/src/frontend/web_application/src/components/form/TextFieldGroup/style.scss
@@ -6,8 +6,4 @@
   &__label {
     display: block;
   }
-
-  &__errors {
-
-  }
 }

--- a/src/frontend/web_application/src/components/form/TextFieldGroup/style.scss
+++ b/src/frontend/web_application/src/components/form/TextFieldGroup/style.scss
@@ -8,6 +8,6 @@
   }
 
   &__errors {
-    margin-top: -(map-get($co-form__spacing, 'medium'));
+
   }
 }

--- a/src/frontend/web_application/src/styles/base/reset.scss
+++ b/src/frontend/web_application/src/styles/base/reset.scss
@@ -17,6 +17,9 @@ legend {
 }
 
 dd,
-dl {
+dl,
+ul,
+li {
   margin: 0;
+  padding: 0;
 }

--- a/src/frontend/web_application/src/styles/config/config.scss
+++ b/src/frontend/web_application/src/styles/config/config.scss
@@ -24,6 +24,7 @@ $co-form__height: (
 );
 
 $co-form__spacing: (
+  xsmall: .25rem, // 4 px
   small: .625rem, // 10 px
   medium: .9375rem, // 15 px
   large:  1.5625rem, // 25 px


### PR DESCRIPTION
This removes bottom margins for inputs (bottomSpace = false) and create new prop for FormColumn component (bottomSpace). Now bottom margins are optional for both inputs and columns, so we can choose to apply bottomSpace to containers instead of items.
Updated FieldErrors to fit the fix.