### PR TITLE
fix form errors UX

### DIFF
--- a/src/frontend/web_application/src/components/form/FieldErrors/style.scss
+++ b/src/frontend/web_application/src/components/form/FieldErrors/style.scss
@@ -6,5 +6,4 @@
   color:  map-get($caliopen-palette, 'alert');
   font-size: $co-font__size--small;
   font-weight: 700;
-  text-transform: uppercase;
 }

--- a/src/frontend/web_application/src/components/form/InputText/style.scss
+++ b/src/frontend/web_application/src/components/form/InputText/style.scss
@@ -13,11 +13,10 @@
   &--expanded { width: 100%; }
 
   &--error {
-    background: $co-color__alert;
+    box-shadow: inset 0 0 0 1px $co-color__alert;
     color: $co-color__fg__text;
 
     &:focus {
-      background-color: $co-color__alert;
       color: $co-color__fg__text;
     }
   }

--- a/src/frontend/web_application/stories/CHANGELOG.md
+++ b/src/frontend/web_application/stories/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   - Settings - DevicesManagement
 
+### Changed
+
+  - Form - Field with error: no more uppercase for the message & replace background color by a red border (inset)
+
 ## [2017-01-19]
 
 ### Added


### PR DESCRIPTION
+ no uppercase for error messages
+ replace red background for input by a border

OLD -> NEW

![capture d ecran de 2017-02-02 17 03 26](https://cloud.githubusercontent.com/assets/65737/22558117/e2e72572-e96c-11e6-8726-561e3700bcd0.png)
![capture d ecran de 2017-02-02 17 19 27](https://cloud.githubusercontent.com/assets/65737/22558158/015af84e-e96d-11e6-8def-421b4d8d4d0d.png)

![capture d ecran de 2017-02-02 17 20 37](https://cloud.githubusercontent.com/assets/65737/22558179/16e13886-e96d-11e6-8412-adc878fdc9d9.png)

