### PR TITLE
change backend's REST API listening port from 3141 to 31415.

### DIFF
--- a/src/backend/configs/caliopen-go-api_dev.yaml
+++ b/src/backend/configs/caliopen-go-api_dev.yaml
@@ -10,7 +10,7 @@ ApiConfig:
       consistency_level: 1
 ProxyConfig:
   host: 127.0.0.1
-  port: 3141
+  port: 31415
   routes:
   - /api/v2/: 127.0.0.1:6544
   - /: 127.0.0.1:6543         # route "/" catch all other requests


### PR DESCRIPTION
Proposal to change backend's REST API listening port from 3141 to 31415, as 3141 is a (old) referenced port instead of 31415 which is free..