### PR TITLE
Add auth middleware to the go.server. 

### DIFF
--- a/src/backend/configs/caliopen-api.development.ini
+++ b/src/backend/configs/caliopen-api.development.ini
@@ -24,7 +24,8 @@ pyramid.includes =
 kvs.cache = {"kvs": "redis",
              "ttl": 86400,
              "kvs_kwargs": {"host": "localhost"},
-             "key_prefix": "tokens::"}
+             "key_prefix": "tokens::",
+             "codec": "json"}
 
 
 # Caliopen related configuration

--- a/src/backend/configs/caliopen-api.development.ini.sample
+++ b/src/backend/configs/caliopen-api.development.ini.sample
@@ -18,7 +18,8 @@ pyramid.includes =
 
 kvs.cache = {"kvs": "redis",
              "ttl": 86400,
-             "key_prefix": "tokens::"}
+             "key_prefix": "tokens::",
+             "codec": "json"}
 
 
 # Caliopen related configuration

--- a/src/backend/interfaces/REST/go.server/api_server.go
+++ b/src/backend/interfaces/REST/go.server/api_server.go
@@ -6,10 +6,12 @@ package rest_api
 
 import (
 	obj "github.com/CaliOpen/CaliOpen/src/backend/defs/go-objects"
+	"github.com/CaliOpen/CaliOpen/src/backend/interfaces/REST/go.server/middlewares"
 	"github.com/CaliOpen/CaliOpen/src/backend/interfaces/REST/go.server/operations/users"
 	"github.com/CaliOpen/CaliOpen/src/backend/main/go.main"
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/gin-gonic/gin.v1"
+	"gopkg.in/redis.v5"
 )
 
 var (
@@ -20,12 +22,14 @@ var (
 type (
 	REST_API struct {
 		config APIConfig
+		cache  *redis.Client
 	}
 
 	APIConfig struct {
 		Host          string `mapstructure:"host"`
 		Port          string `mapstructure:"port"`
 		BackendConfig `mapstructure:"BackendConfig"`
+		CacheSettings `mapstructure:"CacheConfig"`
 	}
 
 	BackendConfig struct {
@@ -37,6 +41,12 @@ type (
 		Hosts       []string `mapstructure:"hosts"`
 		Keyspace    string   `mapstructure:"keyspace"`
 		Consistency uint16   `mapstructure:"consistency_level"`
+	}
+
+	CacheSettings struct {
+		Host     string `mapstructure:"host"`
+		Password string `mapstructure:"password"`
+		Db       int    `mapstructure:"db"`
 	}
 )
 
@@ -66,6 +76,17 @@ func (server *REST_API) initialize(config APIConfig) error {
 
 	caliop = caliopen.Facilities.RESTfacility
 
+	//TODO : manage credentials & connection with config & backends interface
+	client := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	})
+	_, err = client.Ping().Result()
+	if err != nil {
+		return err
+	}
+	server.cache = client
 	return nil
 }
 
@@ -82,7 +103,7 @@ func (server *REST_API) start() error {
 
 	// adds our routes and handlers
 	api := router.Group("/api/v2")
-	AddHandlers(api)
+	server.AddHandlers(api)
 
 	// listens
 	addr := server.config.Host + ":" + server.config.Port
@@ -93,11 +114,11 @@ func (server *REST_API) start() error {
 	return err
 }
 
-func AddHandlers(api *gin.RouterGroup) {
+func (server *REST_API) AddHandlers(api *gin.RouterGroup) {
 
 	//users API
 	u := api.Group("/users")
-	u.POST("/", func(ctx *gin.Context) {
+	u.POST("", func(ctx *gin.Context) {
 		users.Create(caliop, ctx)
 	})
 	u.GET("/:user_id", func(ctx *gin.Context) {
@@ -107,5 +128,19 @@ func AddHandlers(api *gin.RouterGroup) {
 	//username API
 	api.GET("/username/isAvailable", func(ctx *gin.Context) {
 		users.IsAvailable(caliop, ctx)
+	})
+
+	//messages API
+	//messages := api.Group("/messages", http_middleware.BasicAuthFromCache(server.cache, "caliopen"))
+	draft := api.Group("/draft", http_middleware.BasicAuthFromCache(server.cache, "caliopen"))
+	draft.GET("", func(ctx *gin.Context) {
+		ctx.JSON(200, gin.H{
+			"access": "authorized",
+		})
+	})
+	draft.GET("/test", func(ctx *gin.Context) {
+		ctx.JSON(200, gin.H{
+			"access": "authorized",
+		})
 	})
 }

--- a/src/backend/interfaces/REST/go.server/middlewares/authentication.go
+++ b/src/backend/interfaces/REST/go.server/middlewares/authentication.go
@@ -1,0 +1,72 @@
+package http_middleware
+
+import (
+	"encoding/json"
+	"gopkg.in/gin-gonic/gin.v1"
+	"gopkg.in/redis.v5"
+	"strconv"
+	"time"
+)
+
+type auth_cache struct {
+	Access_token  string    `json:"access_token"`
+	Expires_in    int       `json:"expires_in"`
+	Expires_at    time.Time `json:"expires_at"`
+	Refresh_token string    `json:"refresh_token"`
+}
+
+func BasicAuthFromCache(cache *redis.Client, realm string) gin.HandlerFunc {
+	if realm == "" {
+		realm = "Authorization Required"
+	}
+	realm = "Basic realm=" + strconv.Quote(realm)
+
+	return func(c *gin.Context) {
+		// Get provided auth headers
+		var user_id, access_token string
+		var ok bool
+		if user_id, access_token, ok = c.Request.BasicAuth(); !ok {
+			kickUnauthorizedRequest(c, realm)
+		}
+		// Search user in redis cache of allowed credentials
+		var cache_str string
+		var err error
+		cache_str, err = cache.Get("tokens::" + user_id).Result()
+		if err != nil {
+			kickUnauthorizedRequest(c, realm)
+		}
+		var cache auth_cache
+		err = json.Unmarshal([]byte(cache_str), &cache)
+		if err != nil || cache.Access_token != access_token || time.Since(cache.Expires_at) > 0 {
+			kickUnauthorizedRequest(c, realm)
+		}
+	}
+}
+
+func kickUnauthorizedRequest(c *gin.Context, realm string) {
+	// we return 401 and abort handlers chain.
+	c.Header("WWW-Authenticate", realm)
+	c.AbortWithStatus(401)
+}
+
+//bespoke unmarshaller to workaround the expires_at field that is not RFC in cache (tz is missing, thanks python)
+func (ac *auth_cache) UnmarshalJSON(b []byte) error {
+	var temp struct {
+		Access_token  string `json:"access_token"`
+		Expires_in    int    `json:"expires_in"`
+		Expires_at    string `json:"expires_at"`
+		Refresh_token string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(b, &temp); err != nil {
+		return err
+	}
+	ac.Access_token = temp.Access_token
+	ac.Expires_in = temp.Expires_in
+	expire, err := time.Parse(time.RFC3339Nano, temp.Expires_at+"Z")
+	if err != nil {
+		return err
+	}
+	ac.Expires_at = expire
+	ac.Refresh_token = temp.Refresh_token
+	return nil
+}


### PR DESCRIPTION
The middleware checks authorizations into the running Redis.
Values stored in Redis by python.kvs are now in JSON instead of pickles codec.