### PR TITLE
Remove line with origin because it breaks the docker build

### DIFF
--- a/src/backend/protocols/go.smtp/vendor/vendor.json
+++ b/src/backend/protocols/go.smtp/vendor/vendor.json
@@ -182,7 +182,6 @@
 		},
 		{
 			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",
-			"origin": "github.com/hashicorp/go-multierror/vendor/github.com/hashicorp/errwrap",
 			"path": "github.com/hashicorp/errwrap",
           "revision": "7554cd9344cec97297fa6649b055a8c98c2a1e55",
           "revisionTime": "2014-10-28T05:47:10Z"


### PR DESCRIPTION
This line is necassary ? @sapiens-sapide 
Because it breaks the docker build with this error:

"cd /go/.cache/govendor/github.com/hashicorp/go-multierror; git reset --hard 7554cd9344cec97297fa6649b055a8c98c2a1e55
fatal: Could not parse object '7554cd9344cec97297fa6649b055a8c98c2a1e55'."

I removed the line "origin" and it works well