### PR TITLE
Update govendor and use directly errwrap repository

### DIFF
--- a/src/backend/interfaces/REST/go.server/Dockerfile
+++ b/src/backend/interfaces/REST/go.server/Dockerfile
@@ -8,6 +8,7 @@ ADD . /go/src/github.com/CaliOpen/CaliOpen/src/backend/interfaces/REST/go.server
 WORKDIR /go/src/github.com/CaliOpen/CaliOpen/src/backend/interfaces/REST/go.server
 
 RUN govendor sync
+RUN govendor update +vendor
 RUN go build github.com/CaliOpen/CaliOpen/src/backend/interfaces/REST/go.server/cmd/caliopen_rest
 
 

--- a/src/backend/protocols/go.smtp/Dockerfile
+++ b/src/backend/protocols/go.smtp/Dockerfile
@@ -6,7 +6,8 @@ RUN go install github.com/kardianos/govendor
 ADD . /go/src/github.com/CaliOpen/CaliOpen/src/backend/protocols/go.smtp
 WORKDIR /go/src/github.com/CaliOpen/CaliOpen/src/backend/protocols/go.smtp
 
-RUN govendor sync
+RUN govendor sync -v
+RUN govendor update +vendor
 RUN go build github.com/CaliOpen/CaliOpen/src/backend/protocols/go.smtp/cmd/caliopen_lmtpd
 
 ENTRYPOINT /go/src/github.com/CaliOpen/CaliOpen/src/backend/protocols/go.smtp/caliopen_lmtpd serve

--- a/src/backend/protocols/go.smtp/vendor/vendor.json
+++ b/src/backend/protocols/go.smtp/vendor/vendor.json
@@ -182,7 +182,7 @@
 		},
 		{
 			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",
-			"origin": "github.com/hashicorp/go-multierror/vendor/github.com/hashicorp/errwrap",
+			"origin": "github.com/hashicorp/errwrap",
 			"path": "github.com/hashicorp/errwrap",
           "revision": "7554cd9344cec97297fa6649b055a8c98c2a1e55",
           "revisionTime": "2014-10-28T05:47:10Z"


### PR DESCRIPTION
Fix some go build issues, but still one with lmtp: https://github.com/CaliOpen/Caliopen/issues/224