### PR TITLE
Ugly fix to permit discussion pagination, related to issue #185

### DIFF
--- a/src/backend/defs/rest-api/paths/discussions.yaml
+++ b/src/backend/defs/rest-api/paths/discussions.yaml
@@ -23,7 +23,7 @@ discussions:
       in: query
       type: integer
       required: false
-      description: number of pages to skip from the response
+      description: number of discussions to skip for pagination
     produces:
     - application/json
     responses:


### PR DESCRIPTION
This permit pagination on GET /discussions route, at least for 200 first ones.

This is not a correct fix, as I don't find the way to paginate with a bucket aggregration query on elasticsearch, may it's not possible :/
