### PR TITLE
Add version printer to caliopen_rest cli

### DIFF
--- a/src/backend/interfaces/REST/go.server/cmd/caliopen_rest/cli_cmds/root.go
+++ b/src/backend/interfaces/REST/go.server/cmd/caliopen_rest/cli_cmds/root.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	verbose bool
-
+	version bool
 	RootCmd = &cobra.Command{
 		Use:   "caliopen_rest",
 		Short: "Caliopen REST HTTP API",
@@ -20,10 +20,19 @@ var (
 	}
 )
 
+const __version__ = "0.1.0"
+
 func init() {
 	cobra.OnInitialize()
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false,
 		"print out more debug information")
+	RootCmd.PersistentFlags().BoolVarP(&version, "version", "V", false,
+		"print out the version of this program")
+	RootCmd.Run = func(cmd *cobra.Command, args []string) {
+		if version {
+			log.Infof("Caliopen SMTPd version %s", __version__)
+		}
+	}
 	RootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if verbose {
 			log.SetLevel(log.DebugLevel)
@@ -31,4 +40,14 @@ func init() {
 			log.SetLevel(log.InfoLevel)
 		}
 	}
+	RootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of Caliopen REST api",
+	Long:  `All software has versions. This is Caliopen API's`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Infof("Caliopen REST API version %s", __version__)
+	},
 }


### PR DESCRIPTION
usage :
caliopen_rest -V
caliopen_rest --version
caliopen_rest version

Version number is now a constant : __version__ = "xx.xx.xx"