### PR TITLE
Feature/backend/remove counter

### DIFF
--- a/devtools/docker-compose.yml
+++ b/devtools/docker-compose.yml
@@ -33,13 +33,17 @@ services:
   #
   # Cassandra is used as the reference storage for business data
   cassandra:
-      image: cassandra:3.0
+      image: scylladb/scylla
       ports:
           - "9042:9042"
           - "9160:9160"
           - "7000:7000"
       volumes:
-          - .data/cassandra:/var/lib/cassandra
+          - .data/scylla:/var/lib/scylla
+      entrypoint:
+          - /docker-entrypoint.py
+          - --memory
+          - 512M
 
   # ### Elasticsearch
   #

--- a/src/backend/main/py.main/caliopen_main/discussion/core/__init__.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/core/__init__.py
@@ -2,7 +2,11 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from .discussion import MainView, Discussion, ReturnDiscussion
+from .discussion import DiscussionExternalLookup, DiscussionRecipientLookup
+from .discussion import DiscussionMessageLookup
 
 __all__ = [
-    'Discussion', 'MainView', 'ReturnDiscussion'
+    'Discussion', 'MainView', 'ReturnDiscussion',
+    'DiscussionExternalLookup', 'DiscussionRecipientLookup',
+    'DiscussionMessageLookup'
 ]

--- a/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
@@ -15,8 +15,7 @@ from ..store.discussion import \
      DiscussionRecipientLookup as ModelRecipientLookup,
      DiscussionMessageLookup as ModelMessageLookup,
      Discussion as ModelDiscussion)
-from ..store.discussion_index import \
-    DiscussionIndexManager as DIM
+from ..store.discussion_index import DiscussionIndexManager as DIM
 
 from caliopen_main.discussion.parameters import Discussion as DiscussionParam
 from caliopen_main.message.parameters.participant import Participant
@@ -55,56 +54,57 @@ class DiscussionMessageLookup(BaseUserCore):
     _pkey_name = 'external_message_id'
 
 
-
-def build_discussion(discussion, index_message):
+def build_discussion(core, index):
     """Temporary build of output Discussion return parameter."""
     discuss = DiscussionParam()
-    discuss.user_id = discussion.user_id
-    discuss.discussion_id = index_message.discussion_id
-    discuss.date_insert = discussion.date_insert
-    discuss.date_update = index_message.date_insert
-    discuss.excerpt = index_message.body[:100]
+    discuss.user_id = core.user_id
+    discuss.discussion_id = core.discussion_id
+    discuss.date_insert = core.date_insert
+    discuss.date_update = index.last_message.date_insert
+    discuss.excerpt = index.last_message.body[:100]
+    discuss.total_count = index.total_count
+
     # TODO
     # discussion.privacy_index = index_message.privacy_index
     # XXX Only last message recipient at this time
 
-    for part in index_message.participants:
+    for part in index.last_message.participants:
         participant = Participant()
         participant.address = part['address']
         participant.label = part['label']
         participant.type = part['type']
-        if 'contact_id' in part:  # 'recipient' of type 'from' may not be Contact
+        if 'contact_id' in part:
             participant.contact_id = part['contact_id']
         participant.protocol = part['protocol']
         discuss.participants.append(participant)
+
     # XXX Missing values (at least other in parameter to fill)
-    discuss.total_count = discussion.total_count
-    discuss.unread_count = discussion.unread_count
-    discuss.attachment_count = discussion.attachment_count
+    discuss.unread_count = index.unread_count
+    discuss.attachment_count = index.attachment_count
     return discuss.serialize()
 
 
 class MainView(object):
     """Build main view return structure from index messages."""
 
-    def build_responses(self, user, messages):
+    def build_responses(self, user, discussions):
         """Build list of responses using core and related index message."""
-        for message in messages:
+        for discussion in discussions:
             try:
-                discussion = Discussion.get(user, message['discussion_id'])
+                core = Discussion.get(user, discussion.discussion_id)
             except NotFound:
                 continue
-            if discussion:
-                yield build_discussion(discussion, message)
+            if core:
+                yield build_discussion(core, discussion)
 
     def get(self, user, min_pi, max_pi, limit, offset):
         """Build the main view results."""
         # XXX use of correct pagination and correct datasource (index)
         dim = DIM(user.user_id)
-        messages, total = dim.list_discussions(limit=limit, offset=offset,
-                                               min_pi=min_pi, max_pi=max_pi)
-        discussions = self.build_responses(user, messages)
-        return {'discussions': list(discussions), 'total': total}
+        discussions, total = dim.list_discussions(limit=limit, offset=offset,
+                                                  min_pi=min_pi, max_pi=max_pi)
+        responses = self.build_responses(user, discussions)
+        return {'discussions': list(responses), 'total': total}
 
 
 class Discussion(BaseUserCore):
@@ -142,21 +142,6 @@ class Discussion(BaseUserCore):
         except NotFound:
             return None
         return cls.get(user, lookup.discussion_id)
-
-    @property
-    def total_count(self):
-        """Total messages counter."""
-        return 0
-
-    @property
-    def unread_count(self):
-        """Unread messages counter."""
-        return 0
-
-    @property
-    def attachment_count(self):
-        """Total number of attachments."""
-        return 0
 
 
 class ReturnDiscussion(ReturnCoreObject):

--- a/src/backend/main/py.main/caliopen_main/discussion/store/discussion.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/store/discussion.py
@@ -19,16 +19,6 @@ class Discussion(BaseModel):
     excerpt = columns.Text()
 
 
-class DiscussionCounter(BaseModel):
-
-    """Counters related to Discussion."""
-    user_id = columns.UUID(primary_key=True)
-    discussion_id = columns.UUID(primary_key=True)
-    total_count = columns.Counter()
-    unread_count = columns.Counter()
-    attachment_count = columns.Counter()
-
-
 class DiscussionRecipientLookup(BaseModel):
 
     """Lookup discussion by a recipient name."""

--- a/src/backend/main/py.main/caliopen_main/discussion/store/discussion_index.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/store/discussion_index.py
@@ -40,7 +40,7 @@ class DiscussionIndexManager(object):
         agg = dsl.A('terms', field='discussion_id', size=0, shard_size=0)
         search.aggs.bucket('discussions', agg)
         # XXX add sorting on message date_insert
-        log.warn('Search is {}'.format(search.to_dict()))
+        log.debug('Search is {}'.format(search.to_dict()))
         result = search.execute()
         if hasattr(result, 'aggregations'):
             # Something found

--- a/src/backend/main/py.main/caliopen_main/discussion/store/discussion_index.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/store/discussion_index.py
@@ -17,6 +17,18 @@ from caliopen_main.message.store.message_index import IndexedMessage
 log = logging.getLogger(__name__)
 
 
+class DiscussionIndex(object):
+    """Informations from index about a discussion."""
+
+    total_count = 0
+    unread_count = 0
+    attachment_count = 0
+    last_message = None
+
+    def __init__(self, id):
+        self.discussion_id = id
+
+
 class DiscussionIndexManager(object):
     """Manager for building discussions from index storage layer."""
 
@@ -70,7 +82,11 @@ class DiscussionIndexManager(object):
         discussions = []
         for id, count in ids.items():
             message = self._get_last_message(id, min_pi, max_pi)
-            discussions.append(message)
+            discussion = DiscussionIndex(id)
+            discussion.total_count = count
+            discussion.last_message = message
+            # XXX build others values from index
+            discussions.append(discussion)
         # XXX total do not work completly, hack a bit
         return discussions, total + len(discussions)
 

--- a/src/backend/main/py.main/caliopen_main/message/qualifier.py
+++ b/src/backend/main/py.main/caliopen_main/message/qualifier.py
@@ -97,11 +97,7 @@ class UserMessageQualifier(object):
         lkp = self.lookup(user, lookup_sequence)
 
         # Create or update existing discussion
-        if lkp:
-            log.debug('Found discussion %r' % lkp.discussion_id)
-            discussion = Discussion.get(user, lkp.discussion_id)
-            discussion.update_from_message(message)
-        else:
+        if not lkp:
             log.debug('Creating new discussion')
             discussion = Discussion.create_from_message(user, message)
 

--- a/src/backend/main/py.main/caliopen_main/message/qualifier.py
+++ b/src/backend/main/py.main/caliopen_main/message/qualifier.py
@@ -7,10 +7,10 @@ from uuid import UUID
 from caliopen_storage.exception import NotFound
 from ..user.core import User
 
-from caliopen_main.discussion.core.discussion import (Discussion,
-                                                      DiscussionMessageLookup,
-                                                      DiscussionRecipientLookup,
-                                                      DiscussionExternalLookup)
+from caliopen_main.discussion.core import (Discussion,
+                                           DiscussionMessageLookup,
+                                           DiscussionRecipientLookup,
+                                           DiscussionExternalLookup)
 
 # XXX use a message formatter registry not directly mail format
 from caliopen_main.parsers import MailMessage
@@ -100,6 +100,8 @@ class UserMessageQualifier(object):
         if not lkp:
             log.debug('Creating new discussion')
             discussion = Discussion.create_from_message(user, message)
+        else:
+            discussion = Discussion.get(user, lkp.discussion_id)
 
         discussion_id = discussion.discussion_id if discussion else None
         message.discussion_id = UUID(discussion_id)

--- a/src/backend/main/py.main/caliopen_main/user/core/__init__.py
+++ b/src/backend/main/py.main/caliopen_main/user/core/__init__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from .user import User, Counter, Tag, FilterRule
+from .user import User, Tag, FilterRule
 from .contact import Contact, ContactLookup, PublicKey
 from .device import Device, DevicePublicKey
 
 
 __all__ = [
-    'User', 'Counter', 'Tag', 'FilterRule',
+    'User', 'Tag', 'FilterRule',
     'Contact', 'ContactLookup', 'PublicKey',
     'Device', 'DevicePublicKey',
 ]

--- a/src/backend/main/py.main/caliopen_main/user/core/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/core/user.py
@@ -16,7 +16,6 @@ from caliopen_storage.exception import NotFound, CredentialException
 from ..store import (User as ModelUser,
                      UserName as ModelUserName,
                      IndexUser,
-                     Counter as ModelCounter,
                      UserTag as ModelUserTag,
                      FilterRule as ModelFilterRule,
                      ReservedName as ModelReservedName,
@@ -37,17 +36,6 @@ class LocalIdentity(BaseCore):
 
     _model_class = ModelLocalIdentity
     _pkey_name = 'identifier'
-
-
-class Counter(BaseCore):
-    """
-    Counter core object.
-
-    Store all counters related to an user
-    """
-
-    _model_class = ModelCounter
-    _pkey_name = 'user_id'
 
 
 class Tag(BaseUserCore):
@@ -226,8 +214,6 @@ class User(BaseCore):
         # Setup index
         core._setup_user_index()
 
-        # Create counters
-        Counter.create(user_id=core.user_id)
         core.setup_system_tags()
 
         # Add a default local identity on a default configured domain
@@ -328,33 +314,6 @@ class User(BaseCore):
             tag['type'] = 'system'
             tag['date_insert'] = datetime.utcnow()
             Tag.create(self, **tag)
-
-    def new_message_id(self):
-        """Create a new message_id from ``Counter``."""
-        counter = Counter.get(self.user_id)
-        # XXX : MUST be handled by core object correctly
-        counter.model.message_id += 1
-        counter.save()
-        return counter.message_id
-
-    def new_thread_id(self):
-        """Create a new thread_id from ``Counter``."""
-        counter = Counter.get(self.user_id)
-        # XXX : MUST be handled by core object correctly
-        counter.model.thread_id += 1
-        counter.save()
-        return counter.thread_id
-
-    def new_rule_id(self):
-        """Create a new rule_id from ``counter``."""
-        counter = Counter.get(self.user_id)
-        counter.model.rule_id += 1
-        counter.save()
-        return counter.rule_id
-
-    def get_thread_id(self, external_id):
-        """Get a new thread_id counter value."""
-        return self.new_thread_id()
 
     @property
     def contact(self):

--- a/src/backend/main/py.main/caliopen_main/user/store/local_identity.py
+++ b/src/backend/main/py.main/caliopen_main/user/store/local_identity.py
@@ -18,7 +18,7 @@ class LocalIdentity(BaseModel):
     identifier = columns.Text(primary_key=True)  # for now,the address of an e-mailbox
     status = columns.Text()  # active, inactive, etc.
     type =columns.Text()  # email, IM, etc.
-    user_id = columns.UUID(index=True)
+    user_id = columns.UUID()
 
 
 class Identity(BaseUserType):


### PR DESCRIPTION
This feature remove usage of cassandra counters, a feature that will disappear anyway in the future (and have many corner cases for consistency guaranty).

This permit to replace cassandra backend by Scylladb and take less memory to run the development stack (512MB instead of 2GB for cassandra).

For the moment 2 properties on discussion are not computed, unread_count and attachment_count, they were managed using counters, it will be replace using index compute capabilities