### PR TITLE
fix broker hostname for docker environment in CLI

### DIFF
--- a/devtools/docker-compose.yml
+++ b/devtools/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       links:
           - cassandra:cassandra.dev.caliopen.org
           - elasticsearch:es.dev.caliopen.org
+          - broker:broker.dev.caliopen.org
       environment:
           CQLENG_ALLOW_SCHEMA_MANAGEMENT: 1
 
@@ -74,11 +75,11 @@ services:
   # Broker
   broker:
       build: ../src/backend/protocols/go.smtp
-      links: 
+      links:
           - cassandra:cassandra.dev.caliopen.org
           - elasticsearch:es.dev.caliopen.org
           - nats:nats.dev.caliopen.org
-          
+
       ports:
         - "2525:2525"
   # NATS

--- a/src/backend/configs/caliopen-docker.yaml
+++ b/src/backend/configs/caliopen-docker.yaml
@@ -1,5 +1,5 @@
 # Caliopen configuration file to run REST API server in a docker container
-# 
+#
 # Storage services must be accessible using FQDN:
 #  - cassandra.dev.caliopen.org
 #  - es.dev.caliopen.org
@@ -22,6 +22,10 @@ cassandra:
 lmtp:
     port: 4025
     bind_address: 0.0.0.0
+
+broker:
+    port: 2525
+    host: broker.dev.caliopen.org
 
 system:
     default_tags:

--- a/src/backend/configs/caliopen.yaml.template
+++ b/src/backend/configs/caliopen.yaml.template
@@ -14,6 +14,10 @@ lmtp:
     port: 4025
     bind_address: 0.0.0.0
 
+broker:
+    port: 2525
+    host: localhost
+
 system:
     default_tags:
         -

--- a/src/backend/tools/py.CLI/caliopen_cli/commands/import_email.py
+++ b/src/backend/tools/py.CLI/caliopen_cli/commands/import_email.py
@@ -16,6 +16,7 @@ from email import message_from_file
 from mailbox import mbox, Maildir
 
 from caliopen_storage.exception import NotFound
+from caliopen_storage.config import Configuration
 
 log = logging.getLogger(__name__)
 
@@ -78,10 +79,11 @@ def import_email(email, import_path, format, **kwargs):
                         contact.emails = [e_mail]
                     contact.privacy_index = random.randint(0, 100)
                     Contact.create(user, contact)
+    conf = Configuration('global').configuration
     for i, msg in enumerate(msgs, 1):
         # injection is made here to test smtp delivery speed
         log.info('Injecting mail {}/{}'.format(i, total_msgs))
-        smtp = smtplib.SMTP(host="localhost", port=2525)
+        smtp = smtplib.SMTP(host=conf['broker']['host'], port=conf['broker']['port'])
         try:
             smtp.sendmail("maibox_importer@py.caliopen.cli", rcpts,
                           msg.mail.as_string())


### PR DESCRIPTION
fix #243 

PS: totally blind fix since, Dockerfile cannot add the fix to its workspace