### PR TITLE
Fix Dropdown prop `position` propType

### DIFF
--- a/src/frontend/web_application/src/components/Dropdown/index.jsx
+++ b/src/frontend/web_application/src/components/Dropdown/index.jsx
@@ -68,7 +68,7 @@ class Dropdown extends Component {
 Dropdown.propTypes = {
   id: PropTypes.string.isRequired,
   className: PropTypes.string,
-  position: PropTypes.oneOf(['bottom']),
+  position: PropTypes.oneOf(['bottom', 'left']),
   closeOnClick: PropTypes.bool,
   onToggle: PropTypes.func,
 };


### PR DESCRIPTION
this add `left` to oneOf[..] `position` propType for DropDown (on ReplyForm and MessageList, it opens on left) 