### PR TITLE
do not send 'message.type' on draft creation

### DIFF
--- a/src/frontend/web_application/src/store/middlewares/draft-messages-middleware.js
+++ b/src/frontend/web_application/src/store/middlewares/draft-messages-middleware.js
@@ -76,7 +76,6 @@ async function getNewDraft({ discussionId, store }) {
 
   return {
     discussion_id: discussionId,
-    type: 'email',
     body: '',
     participants: [],
     identities: getDefaultIdentities({ protocols: ['email'], identities: localIdentities }),


### PR DESCRIPTION
cf. #225