### PR TITLE
Fix/frontend/styles

### DIFF
--- a/src/frontend/web_application/src/components/ContactDetails/style.scss
+++ b/src/frontend/web_application/src/components/ContactDetails/style.scss
@@ -1,6 +1,7 @@
 @import '../../styles/common';
 
 .m-contact-details {
+  background-color: $co-color__fg__back--low;
 
   &__list {
     padding: 0 $co-margin;

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/PiGraph/style.scss
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/PiGraph/style.scss
@@ -3,6 +3,10 @@
 $gridColor: $co-color__fg__back--higher;
 
 .m-pi-graph {
+  display: block;
+  max-width: $co-pi-width;
+  margin-right: auto;
+  margin-left: auto;
   pointer-events: none;
 
   &__line {

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
@@ -40,7 +40,7 @@ $gridColor: $co-color__fg__back--higher;
   }
 
   &__item-name-label {
-    padding: $co-component__spacing;
+    padding-right: $co-component__spacing;
     text-transform: uppercase;
   }
 }

--- a/src/frontend/web_application/src/components/MultidimensionalPi/presenter.jsx
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/presenter.jsx
@@ -3,8 +3,6 @@ import classnames from 'classnames';
 import PiGraph from './components/PiGraph';
 import Ratings from './components/Ratings';
 
-import './style.scss';
-
 const PI_MAX = 100; // max value for PI levels
 
 const MultidimensionalPi = ({ pi, displayAveragePi, className }) => {

--- a/src/frontend/web_application/src/components/MultidimensionalPi/style.scss
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/style.scss
@@ -1,3 +1,0 @@
-@import '../../styles/common';
-
-.m-multidimensional-pi { max-width: $co-pi-width; }

--- a/src/frontend/web_application/src/components/NavList/style.scss
+++ b/src/frontend/web_application/src/components/NavList/style.scss
@@ -9,7 +9,6 @@
   @include flex-grid-row;
   list-style: none;
   margin: 0;
-  margin-bottom: $co-margin;
   padding: 0;
 
   &__item {

--- a/src/frontend/web_application/src/layouts/Page/components/Navigation/style.scss
+++ b/src/frontend/web_application/src/layouts/Page/components/Navigation/style.scss
@@ -8,6 +8,7 @@
     position: fixed;
     z-index: $l-z-index__navbar;
     width: 100%;
+    height: $co-component__height;
     padding-top: .75rem;
     transition: $co-animation__margin-transition;
     background-color: $co-color__bg__back;
@@ -17,7 +18,7 @@
       content: ' ';
       z-index: $l-z-index__navbar-shadow;
       width: 100%;
-      height: 10px;
+      height: $co-component__spacing;
       transition: $co-animation__box-transition;
       background-color: $co-color__fg__back;
     }

--- a/src/frontend/web_application/src/layouts/Page/components/Navigation/style.scss
+++ b/src/frontend/web_application/src/layouts/Page/components/Navigation/style.scss
@@ -2,7 +2,6 @@
 @import '../../../../styles/vendor/bootstrap_foundation-sites';
 
 .l-navigation {
-  min-height: $co-component__height;
 
   &__wrapper {
     @include flex-grid-row($size: expand);

--- a/src/frontend/web_application/src/layouts/Page/style.scss
+++ b/src/frontend/web_application/src/layouts/Page/style.scss
@@ -13,8 +13,11 @@ $co-font-path: '../../fonts';
   &__content {
     // XXX: need a better fix for call-to-action override on mobile
     margin-bottom: 160px;
-    padding-top: 45px;
+  }
 
-    background-color: $co-color__fg__back;
+  @include breakpoint(medium) {
+    &__content {
+      padding-top: 67px;
+    }
   }
 }

--- a/src/frontend/web_application/src/layouts/Page/style.scss
+++ b/src/frontend/web_application/src/layouts/Page/style.scss
@@ -9,6 +9,11 @@ $co-font-path: '../../fonts';
 
 @import '../../styles/common';
 
+$navigation__height: $co-component__height;
+$navigation__padding: .75rem;
+$navigation-after__height: $co-component__spacing;
+
+
 .l-body {
   &__content {
     // XXX: need a better fix for call-to-action override on mobile
@@ -17,7 +22,7 @@ $co-font-path: '../../fonts';
 
   @include breakpoint(medium) {
     &__content {
-      padding-top: 67px;
+      padding-top: ($navigation__height + $navigation__padding + $navigation-after__height);
     }
   }
 }

--- a/src/frontend/web_application/src/layouts/Settings/style.scss
+++ b/src/frontend/web_application/src/layouts/Settings/style.scss
@@ -4,7 +4,12 @@
 
 .l-settings {
   &__nav {
-    padding-top: map-get($co-form__spacing, 'small');
+    padding-bottom: map-get($co-form__spacing, 'small');
     background: $co-color__fg__back;
+  }
+
+  &__panel {
+    padding-top: $co-margin;
+
   }
 }

--- a/src/frontend/web_application/src/layouts/Settings/style.scss
+++ b/src/frontend/web_application/src/layouts/Settings/style.scss
@@ -4,12 +4,18 @@
 
 .l-settings {
   &__nav {
-    padding-bottom: map-get($co-form__spacing, 'small');
+    padding-top: $co-component__spacing;
+    padding-bottom: $co-component__spacing;
     background: $co-color__fg__back;
   }
 
   &__panel {
     padding-top: $co-margin;
+  }
 
+  @include breakpoint(medium) {
+    &__nav {
+      padding-top: 0;
+    }
   }
 }

--- a/src/frontend/web_application/src/scenes/Account/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Account/presenter.jsx
@@ -5,6 +5,7 @@ import Spinner from '../../components/Spinner';
 import Icon from '../../components/Icon';
 import ContactDetails from '../../components/ContactDetails';
 import ContactProfile from '../../components/ContactProfile';
+import MultidimensionalPi from '../../components/MultidimensionalPi';
 import TextBlock from '../../components/TextBlock';
 import { CheckboxFieldGroup } from '../../components/form';
 import AccountOpenPGPKeys from './components/AccountOpenPGPKeys';
@@ -39,7 +40,11 @@ class Account extends Component {
   loadUser() {
     this.setState({
       /* eslint-disable */
-      user: {"family_name": null, "user_id": "344489c3-fc63-4e41-b490-5f4dd317aa50", "name": "test@caliopen.local", "privacy_features": {}, "main_user_id": null, "privacy_index": 0, "date_insert": "2016-05-09T15:01:39.924000",
+      user: {"family_name": null, "user_id": "344489c3-fc63-4e41-b490-5f4dd317aa50", "name": "test@caliopen.local", "privacy_features": {}, "main_user_id": null, "privacy_index": [
+        { name: 'behavioral', level: 20 },
+        { name: 'contextual', level: 95 },
+        { name: 'technical', level: 55 },
+      ], "date_insert": "2016-05-09T15:01:39.924000",
         "contact": {
           "addresses": [], "privacy_features": {}, "phones": [], "contact_id": "19c3ce42-e3ba-46e7-984f-4c3e8de11c05", "date_insert": "2016-05-09T15:01:40.034000", "identities": [], "user_id": "344489c3-fc63-4e41-b490-5f4dd317aa50", "title": "John Doe", "additional_name": null, "date_update": null, "organizations": [], "ims": [], "given_name": "John", "name_prefix": null, "tags": [], "deleted": 0, "privacy_index": 0, "groups": [], "infos": {},
           "emails": [{"email_id": "93f03145-4398-4bd4-9bd5-00000100", "is_primary": 0, "date_update": null, "label": null, "address": "contact@john.doe", "date_insert": "2016-05-09T15:01:43.116000", "type": "other"}],
@@ -100,6 +105,8 @@ class Account extends Component {
                   onChange={onContactProfileChange}
                 />
               )}
+
+              <MultidimensionalPi className="s-account__pi" pi={this.state.user.privacy_index} />
 
               <TextBlock>
                 <Icon type="envelope" /> {this.state.user.name}

--- a/src/frontend/web_application/src/scenes/Account/style.scss
+++ b/src/frontend/web_application/src/scenes/Account/style.scss
@@ -3,17 +3,20 @@
 
 .s-account {
   @include flex-grid-row($size: expand);
-  background-color: $co-color__fg__back--low;
 
   &__col-datas-irl {
     @include flex-grid-column(12);
     padding: $co-margin;
     padding-top: 0;
-    background-color: $co-color__fg__back;
   }
 
   &__col-datas-online {
     @include flex-grid-column(12, 0);
+  }
+
+  &__pi {
+    margin-top: $co-margin;
+    margin-bottom: $co-margin;
   }
 
   &__contact-profile {

--- a/src/frontend/web_application/src/scenes/ContactBook/components/ContactFilters/style.scss
+++ b/src/frontend/web_application/src/scenes/ContactBook/components/ContactFilters/style.scss
@@ -2,10 +2,10 @@
 @import '../../../../styles/vendor/bootstrap_foundation-sites';
 
 .m-contacts-filters {
+  padding-bottom: map-get($co-form__spacing, 'small');
 
   &__select {
     @include flex-grid-row;
-    margin-bottom: map-get($co-form__spacing, 'small');
 
     label {
       @include flex-grid-column(shrink);

--- a/src/frontend/web_application/src/scenes/ContactBook/components/ContactFilters/style.scss
+++ b/src/frontend/web_application/src/scenes/ContactBook/components/ContactFilters/style.scss
@@ -2,10 +2,20 @@
 @import '../../../../styles/vendor/bootstrap_foundation-sites';
 
 .m-contacts-filters {
-  padding-bottom: map-get($co-form__spacing, 'small');
+  padding-top: $co-component__spacing;
+  padding-bottom: $co-component__spacing;
+
+  @include breakpoint(medium) {
+    padding-top: 0;
+  }
 
   &__select {
     @include flex-grid-row;
+    margin-top: $co-component__spacing;
+
+    @include breakpoint(medium) {
+      margin-top: 0;
+    }
 
     label {
       @include flex-grid-column(shrink);

--- a/src/frontend/web_application/src/scenes/DevicesRoute/index.jsx
+++ b/src/frontend/web_application/src/scenes/DevicesRoute/index.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { RouteWithSubRoutes } from '../../routes';
-import Settings from '../../layouts/Settings';
+import Devices from '../Devices';
 
 
-const SettingsRoute = ({ routes }) => (
-  <Settings>
+const DevicesRoute = ({ routes }) => (
+  <Devices>
     {routes.map((route, i) => (
       <RouteWithSubRoutes key={i} {...route} />
     ))}
-  </Settings>
+  </Devices>
 );
 
-SettingsRoute.propTypes = {
+DevicesRoute.propTypes = {
   routes: PropTypes.arrayOf({}).isRequired,
 };
 
-export default SettingsRoute;
+export default DevicesRoute;

--- a/src/frontend/web_application/src/scenes/SettingsRoute/index.jsx
+++ b/src/frontend/web_application/src/scenes/SettingsRoute/index.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { RouteWithSubRoutes } from '../../routes';
-import Devices from '../Devices';
+import Settings from '../../layouts/Settings';
 
 
-const DevicesRoute = ({ routes }) => (
-  <Devices>
+const SettingsRoute = ({ routes }) => (
+  <Settings>
     {routes.map((route, i) => (
       <RouteWithSubRoutes key={i} {...route} />
     ))}
-  </Devices>
+  </Settings>
 );
 
-DevicesRoute.propTypes = {
+SettingsRoute.propTypes = {
   routes: PropTypes.arrayOf({}).isRequired,
 };
 
-export default DevicesRoute;
+export default SettingsRoute;

--- a/src/frontend/web_application/src/styles/config/config.scss
+++ b/src/frontend/web_application/src/styles/config/config.scss
@@ -1,5 +1,5 @@
 $co-brand-width: 10rem;
-$co-pi-width: 20rem;
+$co-pi-width: 15rem;
 
 $co-margin: 1.5rem;
 $co-radius: .2rem;
@@ -37,7 +37,7 @@ $co-form__spacing: (
 $co-grid__gutter: 30px;
 $co-grid__gutter--small: 20px;
 
-$co-animation__clickable-transition: background-color 0.1s ease-out, color 0.1s ease-out !default;
+$co-animation__clickable-transition: background-color .1s ease-out, color .1s ease-out !default;
 $co-animation__box-transition: box-shadow .15s, border-color .15s ease-in-out !default;
 $co-animation__margin-transition: margin .15s, padding .15s ease !default;
 


### PR DESCRIPTION
This is a bunch of small fixes related to page layout, navigation layout, and Account:
- removes background on `l-body__content`
- fix top bars styles on `ContactBook` and `Settings` 
- raw display `MultidimensionalPI` on Account page (this will be improve on next PR about displaying PI on contact and message)
- inverts `SettingsRoute` and `DevicesRoute`