### PR TITLE
Feature/frontend/menu bar

### DIFF
--- a/src/frontend/web_application/src/components/Button/index.jsx
+++ b/src/frontend/web_application/src/components/Button/index.jsx
@@ -23,7 +23,7 @@ RawButton.defaultProps = {
   type: 'button',
 };
 
-const Button = ({ children, className, icon, display, color, shape, ...props }) => {
+const Button = ({ children, className, icon, display, color, shape, responsive, ...props }) => {
   const buttonProps = {
     ...props,
     className: classnames(
@@ -43,32 +43,44 @@ const Button = ({ children, className, icon, display, color, shape, ...props }) 
         'm-button--hollow': shape === 'hollow',
 
         'm-button--icon': icon,
+
+        'm-button--icon-only': responsive === 'icon-only',
+        'm-button--text-only': responsive === 'text-only',
       }
     ),
   };
 
-  if (icon) return <RawButton {...buttonProps}><Icon className="m-button__icon" type={icon} /><span className="m-button__text">{children}</span></RawButton>;
+  if (icon) {
+    return (
+      <RawButton {...buttonProps}><Icon className="m-button__icon" type={icon} />
+        {children && <span className="m-button__text">{children}</span>}
+      </RawButton>
+    );
+  }
 
   return <RawButton {...buttonProps}>{children}</RawButton>;
 };
 
 Button.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   shape: PropTypes.oneOf(['plain', 'hollow']),
   icon: PropTypes.string,
   display: PropTypes.oneOf(['inline', 'expanded']),
   color: PropTypes.oneOf(['success', 'alert', 'secondary', 'active', 'disabled']),
-  accesskey: PropTypes.string,
+  responsive: PropTypes.oneOf(['icon-only', 'text-only']),
+  accessKey: PropTypes.string,
 };
 
 Button.defaultProps = {
   className: undefined,
+  children: null,
   shape: null,
   icon: null,
   display: null,
   color: null,
-  accesskey: null,
+  responsive: null,
+  accessKey: null,
 };
 
 export default Button;

--- a/src/frontend/web_application/src/components/Button/index.jsx
+++ b/src/frontend/web_application/src/components/Button/index.jsx
@@ -67,7 +67,7 @@ Button.propTypes = {
   shape: PropTypes.oneOf(['plain', 'hollow']),
   icon: PropTypes.string,
   display: PropTypes.oneOf(['inline', 'expanded']),
-  color: PropTypes.oneOf(['success', 'alert', 'secondary', 'active', 'disabled']),
+  color: PropTypes.oneOf(['success', 'alert', 'secondary', 'active']),
   responsive: PropTypes.oneOf(['icon-only', 'text-only']),
   accessKey: PropTypes.string,
 };

--- a/src/frontend/web_application/src/components/Button/index.jsx
+++ b/src/frontend/web_application/src/components/Button/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import Icon from '../Icon';
+
 import './style.scss';
 
 export const RawButton = ({ children, type, ...props }) => {
@@ -21,56 +23,52 @@ RawButton.defaultProps = {
   type: 'button',
 };
 
-const Button = ({
-  children, className, expanded, plain, hollow, inline,
-  active = false, alert, success, secondary, ...props
-}) => {
+const Button = ({ children, className, icon, display, color, shape, ...props }) => {
   const buttonProps = {
     ...props,
     className: classnames(
       className,
       'm-button',
       {
-        'm-button--alert': alert,
-        'm-button--alert-plain': alert && plain,
-        'm-button--success': success,
-        'm-button--secondary': secondary,
-        'm-button--secondary-plain': secondary && plain,
-        'm-button--expanded': expanded,
-        'm-button--plain': plain && !secondary && !alert,
-        'm-button--hollow': hollow,
-        'm-button--active': active,
-        'm-button--inline': inline,
+        'm-button--active': color === 'active',
+        'm-button--alert': color === 'alert',
+        'm-button--disabled': color === 'disabled',
+        'm-button--secondary': color === 'secondary',
+        'm-button--success': color === 'success',
+
+        'm-button--expanded': display === 'expanded',
+        'm-button--inline': display === 'inline',
+
+        'm-button--plain': shape === 'plain',
+        'm-button--hollow': shape === 'hollow',
+
+        'm-button--icon': icon,
       }
     ),
   };
+
+  if (icon) return <RawButton {...buttonProps}><Icon className="m-button__icon" type={icon} /><span className="m-button__text">{children}</span></RawButton>;
 
   return <RawButton {...buttonProps}>{children}</RawButton>;
 };
 
 Button.propTypes = {
   className: PropTypes.string,
-  plain: PropTypes.bool,
-  hollow: PropTypes.bool,
-  expanded: PropTypes.bool,
-  active: PropTypes.bool,
-  alert: PropTypes.bool,
-  inline: PropTypes.bool,
-  success: PropTypes.bool,
-  secondary: PropTypes.bool,
   children: PropTypes.node.isRequired,
+  shape: PropTypes.oneOf(['plain', 'hollow']),
+  icon: PropTypes.string,
+  display: PropTypes.oneOf(['inline', 'expanded']),
+  color: PropTypes.oneOf(['success', 'alert', 'secondary', 'active', 'disabled']),
+  accesskey: PropTypes.string,
 };
 
 Button.defaultProps = {
   className: undefined,
-  plain: false,
-  hollow: false,
-  expanded: false,
-  active: false,
-  alert: false,
-  inline: false,
-  success: false,
-  secondary: false,
+  shape: null,
+  icon: null,
+  display: null,
+  color: null,
+  accesskey: null,
 };
 
 export default Button;

--- a/src/frontend/web_application/src/components/Button/index.jsx
+++ b/src/frontend/web_application/src/components/Button/index.jsx
@@ -52,7 +52,8 @@ const Button = ({ children, className, icon, display, color, shape, responsive, 
 
   if (icon) {
     return (
-      <RawButton {...buttonProps}><Icon className="m-button__icon" type={icon} />
+      <RawButton {...buttonProps}>
+        <Icon className="m-button__icon" type={icon} />
         {children && <span className="m-button__text">{children}</span>}
       </RawButton>
     );

--- a/src/frontend/web_application/src/components/Button/style.scss
+++ b/src/frontend/web_application/src/components/Button/style.scss
@@ -54,30 +54,13 @@
   }
 
   @include breakpoint(small only) {
-    &--icon {
-      padding-top: $co-component__spacing;
-      padding-bottom: $co-component__spacing;
-      line-height: $co-font__line-height;
-      text-align: center;
-    }
 
     &__text {
-      display: block;
       max-width: 1.5 * $co-component__height;
-      margin-left: 0;
       overflow: hidden;
       text-overflow: ellipsis;
-      font-size: $co-font__size--xsmall;
+      font-size: $co-font__size--small;
       white-space: nowrap;
-    }
-
-    &--icon-only,
-    &--text-only {
-      &.m-button--icon {
-        padding-top: 0;
-        padding-bottom: 0;
-        line-height: $co-component__height;
-      }
     }
 
     &--icon-only {

--- a/src/frontend/web_application/src/components/Button/style.scss
+++ b/src/frontend/web_application/src/components/Button/style.scss
@@ -54,6 +54,25 @@
   }
 
   @include breakpoint(small only) {
+    &--icon-only,
+    &--text-only {
+      &.m-button--icon {
+        padding-top: 0;
+        padding-bottom: 0;
+        line-height: $co-component__height;
+      }
+      .m-button__text { display: none; }
+    }
+
+    &--icon-only {
+      .m-button__text { display: none; }
+    }
+
+    &--text-only {
+      .m-button__icon { display: none; }
+    }
+
+
     &--icon {
       padding-top: $co-component__spacing;
       padding-bottom: $co-component__spacing;

--- a/src/frontend/web_application/src/components/Button/style.scss
+++ b/src/frontend/web_application/src/components/Button/style.scss
@@ -54,25 +54,6 @@
   }
 
   @include breakpoint(small only) {
-    &--icon-only,
-    &--text-only {
-      &.m-button--icon {
-        padding-top: 0;
-        padding-bottom: 0;
-        line-height: $co-component__height;
-      }
-      .m-button__text { display: none; }
-    }
-
-    &--icon-only {
-      .m-button__text { display: none; }
-    }
-
-    &--text-only {
-      .m-button__icon { display: none; }
-    }
-
-
     &--icon {
       padding-top: $co-component__spacing;
       padding-bottom: $co-component__spacing;
@@ -88,6 +69,23 @@
       text-overflow: ellipsis;
       font-size: $co-font__size--xsmall;
       white-space: nowrap;
+    }
+
+    &--icon-only,
+    &--text-only {
+      &.m-button--icon {
+        padding-top: 0;
+        padding-bottom: 0;
+        line-height: $co-component__height;
+      }
+    }
+
+    &--icon-only {
+      .m-button__text { display: none; }
+    }
+
+    &--text-only {
+      .m-button__icon { display: none; }
     }
   }
 

--- a/src/frontend/web_application/src/components/Button/style.scss
+++ b/src/frontend/web_application/src/components/Button/style.scss
@@ -1,5 +1,6 @@
 @import '../../styles/common';
 @import '../../styles/object/o-clickable';
+@import '../../styles/vendor/bootstrap_foundation-sites';
 
 .m-button {
   @include o-clickable;
@@ -8,14 +9,67 @@
   &--expanded {
     @include o-clickable--expanded;
     width: 100%;
-    height: 100%;
   }
-  &--plain { @include o-clickable--plain; }
-  &--hollow { @include o-clickable--hollow; }
+
+  &__text { margin-left: $co-margin / 4; }
+
+  &--plain {
+    @include o-clickable--plain;
+    @each $name, $color in $caliopen-palette {
+      &.m-button--#{$name} {
+        $color-hover: scale-color($color, $lightness: -50%);
+        border-color: transparent;
+        background-color: $color;
+        color: $co-color__fg__text--low;
+
+        &:hover,
+        &:focus {
+          background-color: $color-hover;
+          color: $co-color__fg__text--high;
+        }
+      }
+    }
+  }
+
+  &--hollow {
+    @include o-clickable--hollow;
+    @each $name, $color in $caliopen-palette {
+      &.m-button--#{$name} {
+        $color-hover: scale-color($color, $lightness: -50%);
+
+        &:hover,
+        &:focus {
+          background-color: transparent;
+          color: $co-color__fg__text--high;
+        }
+      }
+    }
+
+  }
   &--inline { @include o-clickable--inline; }
 
   &--active {
     @include o-clickable--active-text;
     @include o-clickable--active-button;
   }
+
+  @include breakpoint(small only) {
+    &--icon {
+      padding-top: $co-component__spacing;
+      padding-bottom: $co-component__spacing;
+      line-height: $co-font__line-height;
+      text-align: center;
+    }
+
+    &__text {
+      display: block;
+      max-width: 1.5 * $co-component__height;
+      margin-left: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: $co-font__size--xsmall;
+      white-space: nowrap;
+    }
+  }
+
 }

--- a/src/frontend/web_application/src/components/Button/style.scss
+++ b/src/frontend/web_application/src/components/Button/style.scss
@@ -9,6 +9,7 @@
   &--expanded {
     @include o-clickable--expanded;
     width: 100%;
+    height: 100%;
   }
 
   &__text { margin-left: $co-margin / 4; }

--- a/src/frontend/web_application/src/components/ContactDetails/components/AddressDetails/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/components/AddressDetails/index.jsx
@@ -39,8 +39,7 @@ class AddressDetails extends Component {
     const { __ } = this.props;
 
     return (
-      <Button onClick={this.handleDelete} alert>
-        <Icon type="remove" />
+      <Button onClick={this.handleDelete} color="alert" icon="remove">
         <span className="show-for-sr">{__('contact.action.delete_contact_detail')}</span>
       </Button>
     );

--- a/src/frontend/web_application/src/components/ContactDetails/components/AddressForm/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/components/AddressForm/index.jsx
@@ -128,9 +128,7 @@ class AddressForm extends Component {
           </FormRow>
           <FormRow>
             <FormColumn size="shrink" className="m-address-form__action">
-              <Button type="submit" expanded plain>
-                <Icon type="plus" />
-                {' '}
+              <Button type="submit" display="expanded" shape="plain" icon="plus">
                 {__('contact.action.add_contact_detail')}
               </Button>
             </FormColumn>

--- a/src/frontend/web_application/src/components/ContactDetails/components/EmailDetails/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/components/EmailDetails/index.jsx
@@ -55,13 +55,14 @@ class EmailDetails extends Component {
 
   renderConnectIdentityToggleButton() {
     const { remoteIdentity, __ } = this.props;
+    const successButtonProp = (remoteIdentity && remoteIdentity.connected) && { color: 'success' };
 
     return (
       <Button
+        icon="plug"
         onClick={this.handleToggleConnectIdentityForm}
-        success={remoteIdentity && remoteIdentity.connected}
+        {...successButtonProp}
       >
-        <Icon type="plug" />
         {' '}
         <Icon type={this.state.connectIdentityEditMode ? 'caret-up' : 'caret-down'} />
         <span className="show-for-sr">{__('account.action.connect_identity')}</span>
@@ -73,7 +74,7 @@ class EmailDetails extends Component {
     const { __ } = this.props;
 
     return (
-      <Button onClick={this.handleDelete} alert>
+      <Button onClick={this.handleDelete} color="alert">
         <Icon type="remove" />
         <span className="show-for-sr">{__('contact.action.delete_contact_detail')}</span>
       </Button>

--- a/src/frontend/web_application/src/components/ContactDetails/components/EmailForm/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/components/EmailForm/index.jsx
@@ -116,9 +116,7 @@ class EmailForm extends Component {
           </FormRow>
           <FormRow>
             <FormColumn size="shrink" className="m-email-form__action">
-              <Button type="submit" expanded plain>
-                <Icon type="plus" />
-                {' '}
+              <Button type="submit" display="expanded" shape="plain" icon="plus">
                 {__('contact.action.add_contact_detail')}
               </Button>
             </FormColumn>

--- a/src/frontend/web_application/src/components/ContactDetails/components/ImDetails/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/components/ImDetails/index.jsx
@@ -36,8 +36,7 @@ class ImDetails extends Component {
     const { __ } = this.props;
 
     return (
-      <Button onClick={this.handleDelete} alert>
-        <Icon type="remove" />
+      <Button onClick={this.handleDelete} color="alert" icon="remove">
         <span className="show-for-sr">{__('contact.action.delete_contact_detail')}</span>
       </Button>
     );

--- a/src/frontend/web_application/src/components/ContactDetails/components/ImForm/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/components/ImForm/index.jsx
@@ -104,9 +104,7 @@ class EmailForm extends Component {
           </FormRow>
           <FormRow>
             <FormColumn size="shrink" className="m-im-form__action">
-              <Button type="submit" expanded plain>
-                <Icon type="plus" />
-                {' '}
+              <Button type="submit" display="expanded" shape="plain" icon="plus">
                 {__('contact.action.add_contact_detail')}
               </Button>
             </FormColumn>

--- a/src/frontend/web_application/src/components/ContactDetails/components/PhoneDetails/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/components/PhoneDetails/index.jsx
@@ -26,8 +26,7 @@ class PhoneDetails extends Component {
     const { __ } = this.props;
 
     return (
-      <Button onClick={this.handleDelete} alert>
-        <Icon type="remove" />
+      <Button onClick={this.handleDelete} color="alert" icon="remove">
         <span className="show-for-sr">{__('contact.action.delete_contact_detail')}</span>
       </Button>
     );

--- a/src/frontend/web_application/src/components/ContactDetails/components/RemoteIdentityEmail/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/components/RemoteIdentityEmail/index.jsx
@@ -178,7 +178,7 @@ class RemoteIdentityEmail extends Component {
         <Button
           disabled="$ctrl.remoteIdentity.cancel_fetch_required"
           onClick={this.handleDisconnect}
-          alert
+          color="alert"
         >
           {__('remote_identity.action.cancel')}
         </Button>
@@ -290,23 +290,23 @@ class RemoteIdentityEmail extends Component {
             <Button
               disabled={this.state.remoteIdentity.cancel_fetch_required}
               onClick={this.handleDisconnect}
-              alert
+              color="alert"
             >
               {__('remote_identity.action.disconnect')}
             </Button>
           )}
           {this.state.phase > 1 && (
-            <Button onClick={this.handleClickPrevious} hollow>
+            <Button onClick={this.handleClickPrevious} shape="hollow">
               {__('remote_identity.action.back')}
             </Button>
           )}
           {this.state.phase < MAX_PHASE && (
-            <Button plain onClick={this.handleClickNext}>
+            <Button shape="plain" onClick={this.handleClickNext}>
               {__('remote_identity.action.next')}
             </Button>
           )}
           {this.state.phase === MAX_PHASE && (
-            <Button onClick={this.handleClickFinish} plain secondary>
+            <Button onClick={this.handleClickFinish} shape="plain" color="secondary">
               {__('remote_identity.action.finish')}
             </Button>
           )}

--- a/src/frontend/web_application/src/components/ContactDetails/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/index.jsx
@@ -71,13 +71,15 @@ class ContactDetails extends Component {
 
   renderSubtitleActions() {
     const { __ } = this.props;
-    const activeButtonProp = this.state.editMode && { color: 'active' };
+    const activeButtonProp = this.state.editMode ? { color: 'active' } : {};
 
     return (
       <Button
         className="pull-right"
         {...activeButtonProp}
-        onClick={this.handleSwitchEditMode} icon="edit">
+        onClick={this.handleSwitchEditMode}
+        icon="edit"
+      >
         <span className="show-for-sr">{__('contact.action.edit_contact_details')}</span>
       </Button>
     );

--- a/src/frontend/web_application/src/components/ContactDetails/index.jsx
+++ b/src/frontend/web_application/src/components/ContactDetails/index.jsx
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Subtitle from '../Subtitle';
 import Button from '../Button';
-import Icon from '../Icon';
 import TextList, { ItemContent } from '../TextList';
 import AddressDetails from './components/AddressDetails';
 import EmailDetails from './components/EmailDetails';
@@ -72,13 +71,13 @@ class ContactDetails extends Component {
 
   renderSubtitleActions() {
     const { __ } = this.props;
+    const activeButtonProp = this.state.editMode && { color: 'active' };
+
     return (
       <Button
         className="pull-right"
-        active={this.state.editMode}
-        onClick={this.handleSwitchEditMode}
-      >
-        <Icon type="edit" />
+        {...activeButtonProp}
+        onClick={this.handleSwitchEditMode} icon="edit">
         <span className="show-for-sr">{__('contact.action.edit_contact_details')}</span>
       </Button>
     );

--- a/src/frontend/web_application/src/components/ContactProfile/components/ContactProfileForm/index.jsx
+++ b/src/frontend/web_application/src/components/ContactProfile/components/ContactProfileForm/index.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes, Component } from 'react';
 import { withTranslator } from '@gandi/react-translate';
-import Icon from '../../../Icon';
 import Button from '../../../Button';
 import { TextFieldGroup } from '../../../form';
 import './style.scss';
@@ -58,9 +57,7 @@ class ContactProfileForm extends Component {
         />
         <div className="m-contact-profile-form__save-button">
           <div className="m-contact-profile-form__save-button-wrapper">
-            <Button type="submit" expanded plain>
-              <Icon type="check" /> {__('contact_profile.action.save')}
-            </Button>
+            <Button type="submit" display="expanded" shape="plain" icon="check">{__('contact_profile.action.save')}</Button>
           </div>
         </div>
       </form>

--- a/src/frontend/web_application/src/components/ContactProfile/index.jsx
+++ b/src/frontend/web_application/src/components/ContactProfile/index.jsx
@@ -2,7 +2,6 @@ import React, { PropTypes, Component } from 'react';
 import classnames from 'classnames';
 import { withTranslator } from '@gandi/react-translate';
 import Button from '../Button';
-import Icon from '../Icon';
 import ContactAvatarLetter from '../ContactAvatarLetter';
 import ContactProfileForm from './components/ContactProfileForm';
 import './style.scss';
@@ -31,12 +30,16 @@ class ContactProfile extends Component {
 
   render() {
     const { contact, className, onChange, __ } = this.props;
+    const activeButtonProp = this.state.editMode && { color: 'active' };
 
     return (
       <div className={classnames('m-contact-profile', className)}>
         <div className="m-contact-profile__edit-button">
-          <Button active={this.state.editMode} onClick={this.toggleEditMode}>
-            <Icon type="edit" />
+          <Button
+            icon="edit"
+            {...activeButtonProp}
+            onClick={this.toggleEditMode}
+          >
             <span className="show-for-sr">
               {__('contact_profile.action.edit_contact')}
             </span>

--- a/src/frontend/web_application/src/components/ContactProfile/index.jsx
+++ b/src/frontend/web_application/src/components/ContactProfile/index.jsx
@@ -30,7 +30,7 @@ class ContactProfile extends Component {
 
   render() {
     const { contact, className, onChange, __ } = this.props;
-    const activeButtonProp = this.state.editMode && { color: 'active' };
+    const activeButtonProp = this.state.editMode ? { color: 'active' } : {};
 
     return (
       <div className={classnames('m-contact-profile', className)}>

--- a/src/frontend/web_application/src/components/Device/components/RevokeDevice/presenter.jsx
+++ b/src/frontend/web_application/src/components/Device/components/RevokeDevice/presenter.jsx
@@ -11,8 +11,8 @@ const RevokeDevice = ({ device, onRevokeDevice, __ }) => {
     <div className="m-device-revoke">
       <Button
         className="m-device-revoke__button"
-        plain
-        alert
+        shape="plain"
+        color="alert"
         onClick={handleRevoke}
       >{__('device.action.revoke')}</Button>
     </div>

--- a/src/frontend/web_application/src/components/MenuBar/index.jsx
+++ b/src/frontend/web_application/src/components/MenuBar/index.jsx
@@ -15,7 +15,7 @@ const MenuBar = ({ className, children }) => {
 
 MenuBar.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.bool,
+  children: PropTypes.node,
 };
 
 MenuBar.defaultProps = {

--- a/src/frontend/web_application/src/components/MenuBar/index.jsx
+++ b/src/frontend/web_application/src/components/MenuBar/index.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import './style.scss';
+
+const MenuBar = ({ className, children }) => {
+  const menuBarClassName = classnames(
+    'm-menu-bar',
+    className,
+  );
+
+  return <div className={menuBarClassName}>{children}</div>;
+};
+
+MenuBar.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.bool,
+};
+
+MenuBar.defaultProps = {
+  className: null,
+  children: null,
+};
+
+export default MenuBar;

--- a/src/frontend/web_application/src/components/MenuBar/style.scss
+++ b/src/frontend/web_application/src/components/MenuBar/style.scss
@@ -1,0 +1,11 @@
+@import '../../styles/vendor/bootstrap_foundation-sites';
+
+.m-menu-bar {
+  padding: $co-component__spacing;
+  border-bottom: 1px solid $co-color__bg__back;
+  background: $co-color__fg__back;
+
+  @include breakpoint(medium) {
+    padding-top: 0;
+  }
+}

--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -147,9 +147,7 @@ class Message extends Component {
               __={__}
             />
 
-            <DropdownControl toggle={dropdownId} className="m-message__actions-switcher">
-              <Icon type="ellipsis-v" />
-            </DropdownControl>
+            <DropdownControl toggle={dropdownId} className="m-message__actions-switcher" icon="ellipsis-v" />
 
             <Dropdown
               id={dropdownId}
@@ -177,6 +175,7 @@ class Message extends Component {
           {this.state.isTooLong &&
             <div className="m-message__expand-button">
               <Button
+                display="expanded"
                 onClick={this.handleExpandClick}
                 value={this.state.isExpanded}
                 title={this.state.isExpanded ? __('message-list.message.action.collapse') : __('message-list.message.action.expand')}

--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -147,7 +147,9 @@ class Message extends Component {
               __={__}
             />
 
-            <DropdownControl toggle={dropdownId} className="m-message__actions-switcher" icon="ellipsis-v" />
+            <DropdownControl toggle={dropdownId} className="m-message__actions-switcher">
+              <Icon type="ellipsis-v" />
+            </DropdownControl>
 
             <Dropdown
               id={dropdownId}
@@ -175,7 +177,6 @@ class Message extends Component {
           {this.state.isTooLong &&
             <div className="m-message__expand-button">
               <Button
-                display="expanded"
                 onClick={this.handleExpandClick}
                 value={this.state.isExpanded}
                 title={this.state.isExpanded ? __('message-list.message.action.collapse') : __('message-list.message.action.expand')}

--- a/src/frontend/web_application/src/components/MessageList/components/MessageActionsContainer/index.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/MessageActionsContainer/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Button from '../../../Button';
-import Icon from '../../../Icon';
 import './style.scss';
 
 const MessageActionsContainer = ({ __, className, ...props }) => {
@@ -13,22 +12,10 @@ const MessageActionsContainer = ({ __, className, ...props }) => {
 
   return (
     <div {...props} className={messageActionsContainerClassName}>
-      <Button className="m-message-actions-container__action">
-        <Icon type="reply" spaced />
-        <span>{__('message-list.message.action.reply')}</span>
-      </Button>
-      <Button className="m-message-actions-container__action">
-        <Icon type="share" spaced />
-        <span>{__('message-list.message.action.copy-to')}</span>
-      </Button>
-      <Button className="m-message-actions-container__action">
-        <Icon type="tags" spaced /><span>
-          {__('message-list.message.action.tags')}</span>
-      </Button>
-      <Button className="m-message-actions-container__action">
-        <Icon type="trash" spaced /><span>
-          {__('message-list.message.action.delete')}</span>
-      </Button>
+      <Button className="m-message-actions-container__action" icon="reply" responsive="icon-only">{__('message-list.message.action.reply')}</Button>
+      <Button className="m-message-actions-container__action" icon="share" responsive="icon-only">{__('message-list.message.action.copy-to')}</Button>
+      <Button className="m-message-actions-container__action" icon="tags" responsive="icon-only">{__('message-list.message.action.tags')}</Button>
+      <Button className="m-message-actions-container__action" icon="trash" responsive="icon-only">{__('message-list.message.action.delete')}</Button>
     </div>
   );
 };

--- a/src/frontend/web_application/src/components/MessageList/components/MessageActionsContainer/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/components/MessageActionsContainer/style.scss
@@ -4,7 +4,7 @@
   @include flex-grid-row;
 
   &__action {
-    @include flex-grid-column;
+    @include flex-grid-column(shrink);
     border-left: 1px solid $co-color__fg__back--lower;
   }
 }

--- a/src/frontend/web_application/src/components/MessageList/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/presenter.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../Button';
 import Icon from '../Icon';
+import MenuBar from '../MenuBar';
 import DayMessageList from './components/DayMessageList';
 import Message from './components/Message';
 import groupMessages from './services/groupMessages';
@@ -29,11 +30,11 @@ const renderDayGroups = (messages, onMessageView, __) => {
 
 const MessageList = ({ onMessageView, onReply, onForward, onDelete, messages, replyForm, __ }) => (
   <div className="m-message-list">
-    <div className="m-message-list__actions">
+    <MenuBar>
       <Button className="m-message-list__action" onClick={onReply}><Icon type="reply" spaced /><span>{__('message-list.action.reply')}</span></Button>
       <Button className="m-message-list__action" onClick={onForward}><Icon type="share" spaced /><span>{__('message-list.action.copy-to')}</span></Button>
       <Button className="m-message-list__action" onClick={onDelete}><Icon type="trash" spaced /><span>{__('message-list.action.delete')}</span></Button>
-    </div>
+    </MenuBar>
     <div className="m-message-list__list">
       {renderDayGroups(messages, onMessageView, __)}
     </div>

--- a/src/frontend/web_application/src/components/MessageList/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/presenter.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../Button';
-import Icon from '../Icon';
 import MenuBar from '../MenuBar';
 import DayMessageList from './components/DayMessageList';
 import Message from './components/Message';
@@ -31,9 +30,9 @@ const renderDayGroups = (messages, onMessageView, __) => {
 const MessageList = ({ onMessageView, onReply, onForward, onDelete, messages, replyForm, __ }) => (
   <div className="m-message-list">
     <MenuBar>
-      <Button className="m-message-list__action" onClick={onReply}><Icon type="reply" spaced /><span>{__('message-list.action.reply')}</span></Button>
-      <Button className="m-message-list__action" onClick={onForward}><Icon type="share" spaced /><span>{__('message-list.action.copy-to')}</span></Button>
-      <Button className="m-message-list__action" onClick={onDelete}><Icon type="trash" spaced /><span>{__('message-list.action.delete')}</span></Button>
+      <Button className="m-message-list__action" onClick={onReply} icon="reply">{__('message-list.action.reply')}</Button>
+      <Button className="m-message-list__action" onClick={onForward} icon="share">{__('message-list.action.copy-to')}</Button>
+      <Button className="m-message-list__action" onClick={onDelete} icon="trash">{__('message-list.action.delete')}</Button>
     </MenuBar>
     <div className="m-message-list__list">
       {renderDayGroups(messages, onMessageView, __)}

--- a/src/frontend/web_application/src/components/MessageList/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/presenter.jsx
@@ -30,9 +30,9 @@ const renderDayGroups = (messages, onMessageView, __) => {
 const MessageList = ({ onMessageView, onReply, onForward, onDelete, messages, replyForm, __ }) => (
   <div className="m-message-list">
     <MenuBar>
-      <Button className="m-message-list__action" onClick={onReply} icon="reply">{__('message-list.action.reply')}</Button>
-      <Button className="m-message-list__action" onClick={onForward} icon="share">{__('message-list.action.copy-to')}</Button>
-      <Button className="m-message-list__action" onClick={onDelete} icon="trash">{__('message-list.action.delete')}</Button>
+      <Button className="m-message-list__action" onClick={onReply} icon="reply" responsive="icon-only" >{__('message-list.action.reply')}</Button>
+      <Button className="m-message-list__action" onClick={onForward} icon="share" responsive="icon-only" >{__('message-list.action.copy-to')}</Button>
+      <Button className="m-message-list__action" onClick={onDelete} icon="trash" responsive="icon-only" >{__('message-list.action.delete')}</Button>
     </MenuBar>
     <div className="m-message-list__list">
       {renderDayGroups(messages, onMessageView, __)}

--- a/src/frontend/web_application/src/components/MessageList/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/style.scss
@@ -3,16 +3,6 @@
 .m-message-list {
   position: relative;
 
-  button { // ugly hack, to simulate "icon only" Button, waiting for Button refacto
-    span {
-      @include breakpoint(small) { display: none; }
-      @include breakpoint(medium) {
-        display: inline;
-        padding-left: $co-component__spacing;
-      }
-    }
-  }
-
   &__action { margin-right: $co-component__spacing; }
 
   &__reply {

--- a/src/frontend/web_application/src/components/MessageList/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/style.scss
@@ -13,16 +13,7 @@
     }
   }
 
-  &__actions {
-    padding: $co-component__spacing;
-    border-bottom: 1px solid $co-color__bg__back;
-    background: $co-color__fg__back;
-  }
-
-  &__action {
-    margin: $co-component__spacing;
-    background: $co-color__fg__back--higher; // need a modifier for Button
-  }
+  &__action { margin-right: $co-component__spacing; }
 
   &__reply {
     @include breakpoint(small) {
@@ -32,6 +23,7 @@
       left: 0;
       box-shadow: $co-shadow--higher;
     }
+
     @include breakpoint(medium) {
       position: static;
       box-shadow: none;

--- a/src/frontend/web_application/src/components/OpenPGPKey/presenter.jsx
+++ b/src/frontend/web_application/src/components/OpenPGPKey/presenter.jsx
@@ -106,8 +106,7 @@ class OpenPGPKey extends Component {
               <span className="show-for-sr">{__('openpgp.action.toggle-details')}</span>
             </Button>
             {editMode && (
-              <Button alert onClick={this.handleDeleteKey}>
-                <Icon type="remove" />
+              <Button color="alert" onClick={this.handleDeleteKey} icon="remove">
                 <span className="show-for-sr">{__('openpgp.action.remove-key')}</span>
               </Button>
             )}

--- a/src/frontend/web_application/src/components/OpenPGPKey/presenter.jsx
+++ b/src/frontend/web_application/src/components/OpenPGPKey/presenter.jsx
@@ -106,7 +106,8 @@ class OpenPGPKey extends Component {
               <span className="show-for-sr">{__('openpgp.action.toggle-details')}</span>
             </Button>
             {editMode && (
-              <Button color="alert" onClick={this.handleDeleteKey} icon="remove">
+              <Button color="alert" onClick={this.handleDeleteKey}>
+                <Icon type="remove" />
                 <span className="show-for-sr">{__('openpgp.action.remove-key')}</span>
               </Button>
             )}

--- a/src/frontend/web_application/src/components/ReplyForm/presenter.jsx
+++ b/src/frontend/web_application/src/components/ReplyForm/presenter.jsx
@@ -116,9 +116,7 @@ class ReplyForm extends Component {
               <div className="m-reply__date">{__('reply-form.now')}</div>
             </div>
 
-            <DropdownControl toggle={dropdownId} className="m-reply__top-actions-switcher">
-              <Icon type="ellipsis-v" />
-            </DropdownControl>
+            <DropdownControl toggle={dropdownId} className="m-reply__top-actions-switcher" icon="ellipsis-v" />
 
             <Dropdown
               id={dropdownId}
@@ -137,25 +135,22 @@ class ReplyForm extends Component {
           <BottomRow className="m-reply__bottom-bar">
             <div className="m-reply__bottom-actions">
               <div className="m-reply__bottom-action">
-                <Button plain onClick={this.handleSend}>
-                  <Icon type="send" spaced />
-                  <span>{__('messages.compose.action.send')}</span>
+                <Button shape="plain" onClick={this.handleSend} icon="send">
+                  {__('messages.compose.action.send')}
                 </Button>
               </div>
               <div className="m-reply__bottom-action">
-                <Button onClick={this.handleSave}>
-                  <Icon type="save" spaced />
-                  <span>{__('messages.compose.action.save')}</span>
+                <Button onClick={this.handleSave} icon="save">
+                  {__('messages.compose.action.save')}
                 </Button>
               </div>
               <div className="m-reply__bottom-action">
-                <Button onClick={this.handleSave}>
-                  <Icon type="share-alt" spaced />
-                  <span>{__('messages.compose.action.copy')}</span>
+                <Button onClick={this.handleSave} icon="share-alt">
+                  {__('messages.compose.action.copy')}
                 </Button>
               </div>
               <div className="m-reply__bottom-action m-reply__bottom-action--editor">
-                <Button><Icon type="editor" spaced /></Button>
+                <Button icon="editor" />
               </div>
             </div>
           </BottomRow>

--- a/src/frontend/web_application/src/components/SigninForm/presenter.jsx
+++ b/src/frontend/web_application/src/components/SigninForm/presenter.jsx
@@ -106,8 +106,8 @@ class SigninForm extends Component {
               <Button
                 type="submit"
                 onClick={this.handleSubmit}
-                expanded
-                plain
+                display="expanded"
+                shape="plain"
               >{__('signin.action.login')}</Button>
             </FormColumn>
           </FormRow>

--- a/src/frontend/web_application/src/components/SignupForm/presenter.jsx
+++ b/src/frontend/web_application/src/components/SignupForm/presenter.jsx
@@ -188,8 +188,8 @@ class SignupForm extends Component {
               <Button
                 type="submit"
                 onClick={this.handleSubmit}
-                expanded
-                plain
+                display="expanded"
+                shape="plain"
               >{__('signup.action.create')}</Button>
             </FormColumn>
           </FormRow>

--- a/src/frontend/web_application/src/components/TagsForm/components/TagItem/index.jsx
+++ b/src/frontend/web_application/src/components/TagsForm/components/TagItem/index.jsx
@@ -89,7 +89,7 @@ class TagItem extends Component {
         <Button
           className="m-tag__button"
           onClick={this.handleClickTag}
-          expanded
+          display="expanded"
         >
           <span className="m-tag__text">{tag.name}</span>
           <Icon className="m-tag__icon" type="edit" />

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ActionButton/index.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ActionButton/index.jsx
@@ -13,7 +13,7 @@ const ActionButton = ({ action, ...props }) => {
 
   return (
     <Tappable {...tappableProps}>
-      <Button {...props} plain />
+      <Button {...props} shape="plain" responsive="icon-only" />
     </Tappable>
   );
 };

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ComposeButton/presenter.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ComposeButton/presenter.jsx
@@ -2,12 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withTranslator } from '@gandi/react-translate';
 import ActionButton from '../ActionButton';
-import Icon from '../../../../../../components/Icon';
 
 const Presenter = ({ translator: { __ }, ...props }) => (
-  <ActionButton {...props}>
-    <Icon type="plus" /> {__('call-to-action.action.compose')}
-  </ActionButton>
+  <ActionButton {...props} icon="plus">{__('call-to-action.action.compose')}</ActionButton>
 );
 
 Presenter.propTypes = {

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ComposeContactButton/presenter.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ComposeContactButton/presenter.jsx
@@ -2,12 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withTranslator } from '@gandi/react-translate';
 import ActionButton from '../ActionButton';
-import Icon from '../../../../../../components/Icon';
 
 const Presenter = ({ translator: { __ }, ...props }) => (
-  <ActionButton {...props}>
-    <Icon type="comment-o" /> {__('call-to-action.action.compose_contact')}
-  </ActionButton>
+  <ActionButton {...props} icon="comment-o">{__('call-to-action.action.compose_contact')}</ActionButton>
 );
 
 Presenter.propTypes = {

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/CreateContactButton/presenter.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/CreateContactButton/presenter.jsx
@@ -2,12 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withTranslator } from '@gandi/react-translate';
 import ActionButton from '../ActionButton';
-import Icon from '../../../../../../components/Icon';
 
 const Presenter = ({ translator: { __ }, ...props }) => (
-  <ActionButton {...props}>
-    <Icon type="user" /> {__('call-to-action.action.create_contact')}
-  </ActionButton>
+  <ActionButton {...props} icon="user">{__('call-to-action.action.create_contact')}</ActionButton>
 );
 
 Presenter.propTypes = {

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ReplyButton/presenter.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ReplyButton/presenter.jsx
@@ -2,12 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withTranslator } from '@gandi/react-translate';
 import ActionButton from '../ActionButton';
-import Icon from '../../../../../../components/Icon';
 
 const Presenter = ({ translator: { __ }, ...props }) => (
-  <ActionButton {...props}>
-    <Icon type="reply" /> {__('call-to-action.action.reply')}
-  </ActionButton>
+  <ActionButton {...props} icon="reply">{__('call-to-action.action.reply')}</ActionButton>
 );
 
 Presenter.propTypes = {

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/style.scss
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/style.scss
@@ -22,7 +22,6 @@
   &__btn {
     margin-bottom: 1rem;
     box-shadow: $co-shadow;
-    text-align: right;
 
     &--principal {
       margin-bottom: 0;

--- a/src/frontend/web_application/src/layouts/Page/components/Header/components/UserMenu/presenter.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/Header/components/UserMenu/presenter.jsx
@@ -36,9 +36,9 @@ class Presenter extends Component {
         <DropdownControl
           toggle="co-user-menu"
           className="float-right"
-          expanded
+          display="expanded"
+          icon="user"
         >
-          <Icon type="user" />&nbsp;
           <span className="show-for-small-only">{user && user.name}</span>&nbsp;
           <Icon type={this.state.isDropdownOpen ? 'caret-up' : 'caret-down'} />
         </DropdownControl>

--- a/src/frontend/web_application/src/layouts/Page/components/Header/presenter.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/Header/presenter.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 import Button from '../../../../components/Button';
-import Icon from '../../../../components/Icon';
 import Brand from '../../../../components/Brand';
 import SearchField from './components/SearchField';
 import UserMenu from './components/UserMenu';
@@ -55,7 +54,8 @@ class Header extends Component {
             <Button
               aria-label={__('header.menu.toggle-search-form')}
               onClick={this.handleClickToggleSearchAsDropdown}
-            ><Icon type="search" /></Button>
+              icon="search"
+            />
           </div>
           <div className={searchClassName}>
             <div className="l-header__m-search-field"><SearchField /></div>

--- a/src/frontend/web_application/src/layouts/Page/components/Navigation/components/Navbar/components/ItemButton/style.scss
+++ b/src/frontend/web_application/src/layouts/Page/components/Navigation/components/Navbar/components/ItemButton/style.scss
@@ -5,6 +5,9 @@
   color: $co-color__primary--low;
   line-height: $co-component__height;
 
-  &:hover   { color: $co-color__primary--high; }
+  &:hover   {
+    background: none;
+    color: $co-color__primary--high;
+  }
   &:active  { color: $co-color__primary--lower; }
 }

--- a/src/frontend/web_application/src/layouts/Page/components/Navigation/components/Navbar/components/Tab/presenter.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/Navigation/components/Navbar/components/Tab/presenter.jsx
@@ -41,7 +41,7 @@ class Tab extends Component {
             {tab.label}
           </ItemLink>
         )}
-        actionChildren={<ItemButton onClick={this.handleRemove}><Icon type="remove" /></ItemButton>}
+        actionChildren={<ItemButton onClick={this.handleRemove} icon="remove" />}
         last={last}
       />
     );

--- a/src/frontend/web_application/src/layouts/Settings/presenter.jsx
+++ b/src/frontend/web_application/src/layouts/Settings/presenter.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import NavList, { ItemContent } from '../../components/NavList';
+import MenuBar from '../../components/MenuBar';
 import Link from '../../components/Link';
 
 import './style.scss';
@@ -16,13 +17,15 @@ const Settings = ({ __, children }) => {
 
   return (
     <div className="l-settings">
-      <NavList className="l-settings__nav">
-        {navLinks.map(link => (
-          <ItemContent active={link.active} large key={link.title}>
-            <Link noDecoration {...link}>{link.title}</Link>
-          </ItemContent>
-        ))}
-      </NavList>
+      <MenuBar>
+        <NavList>
+          {navLinks.map(link => (
+            <ItemContent active={link.active} large key={link.title}>
+              <Link noDecoration {...link}>{link.title}</Link>
+            </ItemContent>
+          ))}
+        </NavList>
+      </MenuBar>
       <div className="l-settings__panel">{children}</div>
     </div>
   );

--- a/src/frontend/web_application/src/layouts/Settings/style.scss
+++ b/src/frontend/web_application/src/layouts/Settings/style.scss
@@ -3,19 +3,8 @@
 @import '../../styles/vendor/bootstrap_foundation-sites';
 
 .l-settings {
-  &__nav {
-    padding-top: $co-component__spacing;
-    padding-bottom: $co-component__spacing;
-    background: $co-color__fg__back;
-  }
 
   &__panel {
     padding-top: $co-margin;
-  }
-
-  @include breakpoint(medium) {
-    &__nav {
-      padding-top: 0;
-    }
   }
 }

--- a/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/components/AccountOpenPGPKeyForm/index.jsx
+++ b/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/components/AccountOpenPGPKeyForm/index.jsx
@@ -154,6 +154,8 @@ class AccountOpenPGPKeyForm extends Component {
     // XXX: note on importForm, errors comes from props and form items from this.state since form is
     // not real time saved in redux store
     const { __, isLoading, className, importForm, children } = this.props;
+    const generateHollowProp = this.state.formType === FORM_TYPE_GENERATE && { display: 'hollow' };
+    const rawHollowProp = this.state.formType === FORM_TYPE_RAW && { display: 'hollow' };
 
     return (
       <div className={classnames('m-account-openpgp-form', className)}>
@@ -164,14 +166,14 @@ class AccountOpenPGPKeyForm extends Component {
             <Button
               onClick={this.handleSwitchFormType}
               name={FORM_TYPE_GENERATE}
-              shape={this.state.formType === FORM_TYPE_GENERATE && 'hollow'}
+              {...generateHollowProp}
             >
               {__('account.openpgp.action.switch-generate-key')}
             </Button>
             <Button
               onClick={this.handleSwitchFormType}
               name={FORM_TYPE_RAW}
-              shape={this.state.formType === FORM_TYPE_RAW && 'hollow'}
+              {...rawHollowProp}
             >
               {__('account.openpgp.action.switch-import-raw-key')}
             </Button>

--- a/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/components/AccountOpenPGPKeyForm/index.jsx
+++ b/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/components/AccountOpenPGPKeyForm/index.jsx
@@ -154,8 +154,8 @@ class AccountOpenPGPKeyForm extends Component {
     // XXX: note on importForm, errors comes from props and form items from this.state since form is
     // not real time saved in redux store
     const { __, isLoading, className, importForm, children } = this.props;
-    const generateHollowProp = this.state.formType === FORM_TYPE_GENERATE && { display: 'hollow' };
-    const rawHollowProp = this.state.formType === FORM_TYPE_RAW && { display: 'hollow' };
+    const generateHollowProp = this.state.formType === FORM_TYPE_GENERATE ? { display: 'hollow' } : {};
+    const rawHollowProp = this.state.formType === FORM_TYPE_RAW ? { display: 'hollow' } : {};
 
     return (
       <div className={classnames('m-account-openpgp-form', className)}>

--- a/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/components/AccountOpenPGPKeyForm/index.jsx
+++ b/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/components/AccountOpenPGPKeyForm/index.jsx
@@ -164,14 +164,14 @@ class AccountOpenPGPKeyForm extends Component {
             <Button
               onClick={this.handleSwitchFormType}
               name={FORM_TYPE_GENERATE}
-              hollow={this.state.formType === FORM_TYPE_GENERATE}
+              shape={this.state.formType === FORM_TYPE_GENERATE && 'hollow'}
             >
               {__('account.openpgp.action.switch-generate-key')}
             </Button>
             <Button
               onClick={this.handleSwitchFormType}
               name={FORM_TYPE_RAW}
-              hollow={this.state.formType === FORM_TYPE_RAW}
+              shape={this.state.formType === FORM_TYPE_RAW && 'hollow'}
             >
               {__('account.openpgp.action.switch-import-raw-key')}
             </Button>
@@ -219,7 +219,7 @@ class AccountOpenPGPKeyForm extends Component {
               </div>
             )}
             <div className="m-account-openpgp-form__field-group">
-              <Button type="submit" plain>
+              <Button type="submit" shape="plain">
                 <Spinner isLoading={isLoading} />
                 {' '}
                 {__('account.openpgp.action.create')}
@@ -262,7 +262,7 @@ class AccountOpenPGPKeyForm extends Component {
             <Button
               className="m-account-openpgp-form__field-group"
               type="submit"
-              plain
+              shape="plain"
             >
               <Spinner isLoading={isLoading} />
               {__('account.openpgp.action.add')}

--- a/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/presenter.jsx
@@ -77,7 +77,7 @@ class AccountOpenPGPKeys extends Component {
       onGenerateKey,
     } = this.props;
 
-    const activeButtonProp = this.state.editMode && { color: 'active' };
+    const activeButtonProp = this.state.editMode ? { color: 'active' } : {};
 
     return (
       <div className="m-account-openpgp">

--- a/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Account/components/AccountOpenPGPKeys/presenter.jsx
@@ -77,6 +77,8 @@ class AccountOpenPGPKeys extends Component {
       onGenerateKey,
     } = this.props;
 
+    const activeButtonProp = this.state.editMode && { color: 'active' };
+
     return (
       <div className="m-account-openpgp">
         <Subtitle
@@ -84,7 +86,7 @@ class AccountOpenPGPKeys extends Component {
           actions={(
             <Button
               className="pull-right"
-              active={this.state.editMode}
+              {...activeButtonProp}
               onClick={this.handleClickEditMode}
             >
               <Icon type="edit" />

--- a/src/frontend/web_application/src/scenes/ContactBook/components/ContactFilters/index.jsx
+++ b/src/frontend/web_application/src/scenes/ContactBook/components/ContactFilters/index.jsx
@@ -6,7 +6,7 @@ import { SORT_VIEW_FAMILY_NAME, SORT_VIEW_GIVEN_NAME } from '../../../ContactBoo
 import './style.scss';
 
 const ContactFilters = ({ onSortDirChange, onSortViewChange, sortView, sortDir, __ }) => (
-  <FormGrid className="m-contacts-filters">
+  <FormGrid>
     <FormRow>
       <FormColumn size="shrink">
         <SelectFieldGroup

--- a/src/frontend/web_application/src/scenes/ContactBook/components/ContactFilters/style.scss
+++ b/src/frontend/web_application/src/scenes/ContactBook/components/ContactFilters/style.scss
@@ -2,12 +2,6 @@
 @import '../../../../styles/vendor/bootstrap_foundation-sites';
 
 .m-contacts-filters {
-  padding-top: $co-component__spacing;
-  padding-bottom: $co-component__spacing;
-
-  @include breakpoint(medium) {
-    padding-top: 0;
-  }
 
   &__select {
     @include flex-grid-row;

--- a/src/frontend/web_application/src/scenes/ContactBook/components/TagList/index.jsx
+++ b/src/frontend/web_application/src/scenes/ContactBook/components/TagList/index.jsx
@@ -32,11 +32,11 @@ const TagItem = ({ title, link, onTagClick, nbContacts, active, className }) => 
   return (
     <ItemContent className="m-tag-list__item">
       <Button
-        expanded
+        dispay="expanded"
         onClick={onTagClick}
         value={link}
         className={tagClassName}
-        active={active}
+        color={active}
       >
         {title} ({nbContacts})
       </Button>

--- a/src/frontend/web_application/src/scenes/ContactBook/components/TagList/style.scss
+++ b/src/frontend/web_application/src/scenes/ContactBook/components/TagList/style.scss
@@ -5,6 +5,7 @@
   &__tag {
     color: $co-color__fg__text--lower;
     font-weight: 400;
+    line-height: $co-font__line-height;
 
     &--active {
       color: $co-color__fg__text--higher;

--- a/src/frontend/web_application/src/scenes/ContactBook/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/ContactBook/presenter.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ContactList from './components/ContactList';
 import ContactFilters from './components/ContactFilters';
+import MenuBar from '../../components/MenuBar';
 import TagList from './components/TagList';
 import Spinner from '../../components/Spinner';
 import Button from '../../components/Button';
@@ -101,7 +102,7 @@ class ContactBook extends Component {
 
     return (
       <div className="l-contact-book">
-        <div className="l-contact-book__filters">
+        <MenuBar>
           <ContactFilters
             onSortDirChange={handleSortDirChange}
             onSortViewChange={handleSortViewChange}
@@ -109,7 +110,7 @@ class ContactBook extends Component {
             sortView={this.state.sortView}
             __={__}
           />
-        </div>
+        </MenuBar>
         <div className="l-contact-book__contacts">
           <div className="l-contact-book__tags">
             <TagList

--- a/src/frontend/web_application/src/scenes/ContactBook/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/ContactBook/presenter.jsx
@@ -135,7 +135,7 @@ class ContactBook extends Component {
             />
             {hasMore && (
               <div className="l-contact-book-list__load-more">
-                <Button hollow onClick={this.loadMore}>{__('general.action.load_more')}</Button>
+                <Button shape="hollow" onClick={this.loadMore}>{__('general.action.load_more')}</Button>
               </div>
             )}
           </div>

--- a/src/frontend/web_application/src/scenes/ContactBook/style.scss
+++ b/src/frontend/web_application/src/scenes/ContactBook/style.scss
@@ -4,15 +4,8 @@
 .l-contact-book {
   background: $co-color__bg__back;
 
-
-  &__filters {
-    @include flex-grid-row($size: expand);
-    background-color: $co-color__fg__back;
-  }
-
   &__contacts {
     @include flex-grid-row($size: expand);
-
   }
 
   &__tags {

--- a/src/frontend/web_application/src/scenes/DiscussionList/components/DiscussionItemActionsContainer/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/DiscussionList/components/DiscussionItemActionsContainer/presenter.jsx
@@ -59,13 +59,13 @@ class DiscussionItemActionsContainer extends Component {
       <div
         className={classnames('m-discussion-item-actions-container__actions', { 'm-discussion-item-actions-container--active__actions': this.state.isActive })}
       >
-        <Button plain className="m-discussion-item-actions-container__action">{__('Delete')}</Button>
-        <Button plain className="m-discussion-item-actions-container__action">{__('Reply')}</Button>
-        <Button plain className="m-discussion-item-actions-container__action">{__('Forward')}</Button>
+        <Button shape="plain" className="m-discussion-item-actions-container__action">{__('Delete')}</Button>
+        <Button shape="plain" className="m-discussion-item-actions-container__action">{__('Reply')}</Button>
+        <Button shape="plain" className="m-discussion-item-actions-container__action">{__('Forward')}</Button>
         <DropdownControl
           toggle={this.dropdownId}
           className="m-discussion-item-actions-container__action float-right"
-          plain
+          shape="plain"
         >
           {__('discussion-item-actions.action.more')}
         </DropdownControl>
@@ -78,19 +78,19 @@ class DiscussionItemActionsContainer extends Component {
             <VerticalMenuItem>
               <Button
                 className="m-discussion-item-actions-container__menu-button"
-                expanded
+                display="expanded"
               >{__('Archive')}</Button>
             </VerticalMenuItem>
             <VerticalMenuItem>
               <Button
                 className="m-discussion-item-actions-container__menu-button"
-                expanded
+                display="expanded"
               >{__('Enable tracking')}</Button>
             </VerticalMenuItem>
             <VerticalMenuItem>
               <Button
                 className="m-discussion-item-actions-container__menu-button"
-                expanded
+                display="expanded"
                 onClick={this.handleClickTags}
               >{__('Manage tags')}</Button>
             </VerticalMenuItem>

--- a/src/frontend/web_application/src/scenes/DiscussionList/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/DiscussionList/presenter.jsx
@@ -55,7 +55,7 @@ class DiscussionList extends Component {
         )}
         {hasMore && (
           <div className="s-discussion-list__load-more">
-            <Button hollow onClick={this.loadMore}>{__('general.action.load_more')}</Button>
+            <Button shape="hollow" onClick={this.loadMore}>{__('general.action.load_more')}</Button>
           </div>
         )}
       </div>

--- a/src/frontend/web_application/src/styles/object/o-clickable.scss
+++ b/src/frontend/web_application/src/styles/object/o-clickable.scss
@@ -57,7 +57,7 @@
 
 @mixin o-clickable--expanded {
   display: block;
-  height: inherit;
+  line-height: inherit;
 }
 
 @mixin o-clickable--hollow {

--- a/src/frontend/web_application/src/styles/object/o-clickable.scss
+++ b/src/frontend/web_application/src/styles/object/o-clickable.scss
@@ -57,7 +57,7 @@
 
 @mixin o-clickable--expanded {
   display: block;
-  // line-height: inherit;
+  height: inherit;
 }
 
 @mixin o-clickable--hollow {

--- a/src/frontend/web_application/src/styles/object/o-clickable.scss
+++ b/src/frontend/web_application/src/styles/object/o-clickable.scss
@@ -57,7 +57,7 @@
 
 @mixin o-clickable--expanded {
   display: block;
-  line-height: inherit;
+  // line-height: inherit;
 }
 
 @mixin o-clickable--hollow {

--- a/src/frontend/web_application/stories/index.jsx
+++ b/src/frontend/web_application/stories/index.jsx
@@ -110,16 +110,13 @@ storiesOf('Badge', module)
 storiesOf('Buttons & Links', module)
   .addDecorator(hostDecorator)
   .addWithInfo('Button', () => {
+    const iconType = Object.assign({ '': '' }, typeAssoc);
     const props = {
-      plain: boolean('plain', false),
-      expanded: boolean('expanded', false),
-      hollow: boolean('hollow', false),
-      active: boolean('active', false),
-      alert: boolean('alert', false),
-      success: boolean('success', false),
-      secondary: boolean('secondary', false),
-      inline: boolean('inline', false),
+      icon: select('icon', iconType, ''),
       children: text('children', 'Click Me'),
+      shape: select('shape', { '': '', plain: 'plain', hollow: 'hollow' }, ''),
+      display: select('display', { '': '', expanded: 'expanded', inline: 'inline' }, ''),
+      color: select('color', { '': '', active: 'active', alert: 'alert', success: 'success', secondary: 'secondary', disabled: 'disabled' }, ''),
     };
 
     return (<Button {...props} onClick={action('clicked')} />);


### PR DESCRIPTION
This create a component MenuBar to keep consistency for top menu bars on different pages (Setting, MessageList, ContactBook)

This also refactors `<Button>` with new props:
- shape: PropTypes.oneOf(['plain', 'hollow']),
- icon: PropTypes.string,
- display: PropTypes.oneOf(['inline', 'expanded']),
- color: PropTypes.oneOf(['success', 'alert', 'secondary', 'active']),
- responsive: PropTypes.oneOf(['icon-only', 'text-only'])
- accessKey: PropTypes.string
