### PR TITLE
Fix error in Link PropTypes

### DIFF
--- a/src/frontend/web_application/src/components/Link/index.jsx
+++ b/src/frontend/web_application/src/components/Link/index.jsx
@@ -28,7 +28,7 @@ const Link = ({ children, href, noDecoration, className, button, expanded, activ
 
 Link.propTypes = {
   children: PropTypes.node.isRequired,
-  href: PropTypes.bool,
+  href: PropTypes.string,
   noDecoration: PropTypes.bool,
   className: PropTypes.string,
   button: PropTypes.bool,


### PR DESCRIPTION
Set `href` propType to `string` instead of `bool`