### PR TITLE
Feature/backend/context reply handling

### DIFF
--- a/src/backend/main/py.main/caliopen_main/objects/message.py
+++ b/src/backend/main/py.main/caliopen_main/objects/message.py
@@ -138,17 +138,21 @@ class Message(base.ObjectIndexable):
             log.warn(exc)
             return err.PatchError(message=exc.message)
 
-        # add missing params to be able check consistency
+        # add missing params to be able to check consistency
         self_dict = self.marshall_dict()
         if not hasattr(params, "message_id") and self.message_id is not None:
             draft_param.message_id = UUIDType().to_native(self.message_id)
+
         if not hasattr(params,
                        "discussion_id") and self.discussion_id is not None:
             draft_param.discussion_id = UUIDType().to_native(self.discussion_id)
+
         if not hasattr(params, "parent_id") and self.parent_id is not None:
             draft_param.parent_id = UUIDType().to_native(self.parent_id)
+
         if not hasattr(params, "subject"):
             draft_param.subject = self.subject
+
         if not hasattr(params,
                        "participants") and self.participants is not None:
             for participant in self_dict['participants']:

--- a/src/backend/main/py.storage/caliopen_storage/store/mixin.py
+++ b/src/backend/main/py.storage/caliopen_storage/store/mixin.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 
 
 class IndexedModelMixin(object):
-
     """Mixin to transform model into indexed documents."""
 
     def __process_udt(self, column, idx):
@@ -100,10 +99,9 @@ class IndexedModelMixin(object):
 
         idx.update(using=idx.client(), **out)
 
-
     @classmethod
     def search(cls, user, limit=None, offset=0,
-               min_pi=0, max_pi=0, **params):
+               min_pi=0, max_pi=0, sort=None, **params):
         """Search in index using a dict parameter."""
         search = cls._index_class.search(using=cls._index_class.client(),
                                          index=user.user_id)
@@ -117,6 +115,8 @@ class IndexedModelMixin(object):
         else:
             log.warn('Pagination not set for search query,'
                      ' using default storage one')
+        if sort:
+            search = search.sort(sort)
         log.debug('Search is {}'.format(search.to_dict()))
         resp = search.execute()
         log.debug('Search result {}'.format(resp))


### PR DESCRIPTION
This PR modifies how API handles new messages and replies within a discussion.  

From now on, when POSTing a reply with a `discussion_id` property, `subject` and `participants` properties are automatically computed by backend. Frontend should not send those properties anymore. If it does send those properties, they must be consistent.