### PR TITLE
Refactor/frontend/pi

### DIFF
--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -15,9 +15,9 @@ import './style.scss';
 const DropdownControl = withDropdownControl(Button);
 
 const PI = [
-  { name: 'behavioral', level: 20 },
-  { name: 'contextual', level: 95 },
-  { name: 'technical', level: 55 },
+  { name: 'behavioral', level: 40 },
+  { name: 'contextual', level: 15 },
+  { name: 'technical', level: 90 },
 ];
 
 const MessageInfosContainer = ({ __, message, author, locale }) => {

--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -27,7 +27,6 @@ const MessageInfosContainer = ({ __, message, author, locale }) => {
 
   return (
     <div className="m-message__infos-container">
-      <MultidimensionalPi pi={PI} className="m-message__pi" mini />
       <div className="m-message__author">{author.address}</div>
       {message.type &&
         (<div className="m-message__type">
@@ -147,8 +146,9 @@ class Message extends Component {
           />
         </div>
         <div className="m-message__content">
-
           <div className={topBarClassName}>
+            <MultidimensionalPi pi={PI} className="m-message__pi" mini />
+
             <MessageInfosContainer
               message={message}
               author={author}

--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -6,11 +6,19 @@ import ContactAvatarLetter from '../../../ContactAvatarLetter';
 import Dropdown, { withDropdownControl } from '../../../../components/Dropdown';
 import Button from '../../../Button';
 import Icon from '../../../Icon';
+import MultidimensionalPi from '../../../MultidimensionalPi';
+
 import MessageActionsContainer from '../MessageActionsContainer';
 
 import './style.scss';
 
 const DropdownControl = withDropdownControl(Button);
+
+const PI = [
+  { name: 'behavioral', level: 20 },
+  { name: 'contextual', level: 95 },
+  { name: 'technical', level: 55 },
+];
 
 const MessageInfosContainer = ({ __, message, author, locale }) => {
   const typeTranslations = {
@@ -19,6 +27,7 @@ const MessageInfosContainer = ({ __, message, author, locale }) => {
 
   return (
     <div className="m-message__infos-container">
+      <MultidimensionalPi pi={PI} className="m-message__pi" mini />
       <div className="m-message__author">{author.address}</div>
       {message.type &&
         (<div className="m-message__type">

--- a/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
@@ -58,6 +58,7 @@
     @include flex-grid-row($size: expand);
     flex: 1;
     align-items: center;
+    justify-content: center;
   }
 
   &__type {  @include flex-grid-size(shrink); }
@@ -66,7 +67,6 @@
 
   &__pi {
     @include flex-grid-size(shrink);
-    padding-left: $co-component__spacing;
   }
 
   &__author {

--- a/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
@@ -64,6 +64,11 @@
 
   &__type-icon { color: $co-color__fg__text; }
 
+  &__pi {
+    @include flex-grid-size(shrink);
+    padding-left: $co-component__spacing;
+  }
+
   &__author {
     @include flex-grid-column(shrink);
     color: $co-color__fg__text--high;

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/index.jsx
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/index.jsx
@@ -41,7 +41,7 @@ const Ratings = ({ pi, piMax, averagePi, displayAveragePi, mini }) => {
   );
 
   return (
-    <div className={ratingsClassName}>
+    <div className={ratingsClassName} title={pi.map(p => ` ${p.name}: ${p.level}`)}>
       {displayAveragePi &&
         <Rating
           className="m-pi-ratings__item--average"

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/index.jsx
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/index.jsx
@@ -2,26 +2,19 @@ import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import './style.scss';
 
-function classFor(element, mini) {
-  const classNames = [`m-pi-ratings__${element}`];
-  if (mini) { classNames.push(`m-pi-ratings--mini__${element}`); }
-
-  return classNames;
-}
-
 const Rating = ({ name, level, piMax, className, mini }) => {
   const width = (level / piMax) * 100;
   const style = { width: `${width}%` };
 
   return (
-    <div className={classnames(classFor('item', mini), className)}>
-      <div className={classnames(classFor('item-name', mini))}>
-        <span className={classnames(classFor('item-name-label', mini))}>{name}</span>
+    <div className={classnames('m-pi-ratings__item', { 'm-pi-ratings--mini__item': mini }, className)}>
+      <div className={classnames('m-pi-ratings__item-name', { 'm-pi-ratings--mini__item-name': mini })}>
+        <span className={classnames('m-pi-ratings__item-name-label', { 'm-pi-ratings--mini__item-name-label': mini })}>{name}</span>
       </div>
-      <div className={classnames(classFor('item-level', mini))}>
-        <div className={classnames(classFor('item-level-bar', mini))} style={style} />
+      <div className={classnames('m-pi-ratings__item-level', { 'm-pi-ratings--mini__item-level': mini })}>
+        <div className={classnames('m-pi-ratings__item-level-bar', { 'm-pi-ratings--mini__item-level-bar': mini })} style={style} />
       </div>
-      <div className={classnames(classFor('item-level-label', mini))}>{level}</div>
+      <div className={classnames('m-pi-ratings__item-level-label', { 'm-pi-ratings--mini__item-level-label': mini })}>{level}</div>
     </div>
   );
 };

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/index.jsx
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/index.jsx
@@ -34,35 +34,45 @@ Rating.defaultProps = {
   className: '',
 };
 
-const Ratings = ({ pi, piMax, averagePi, displayAveragePi }) => (
-  <div className="m-pi-ratings">
-    {displayAveragePi &&
-      <Rating
-        className="m-pi-ratings__item--average"
-        name="Average PI"
-        level={Math.round(averagePi)}
-        piMax={piMax}
-      />
-    }
-    {pi.map(p =>
-      <Rating
-        name={p.name}
-        level={p.level <= piMax ? p.level : piMax}
-        key={p.name}
-        piMax={piMax}
-      />
-    )}
-  </div>
-);
+const Ratings = ({ pi, piMax, averagePi, displayAveragePi, mini }) => {
+  const ratingsClassName = classnames(
+    'm-pi-ratings',
+    { 'm-pi-ratings--mini': mini },
+  );
+
+  return (
+    <div className={ratingsClassName}>
+      {displayAveragePi &&
+        <Rating
+          className="m-pi-ratings__item--average"
+          name="Average PI"
+          level={Math.round(averagePi)}
+          piMax={piMax}
+        />
+      }
+      {pi.map(p =>
+        <Rating
+          name={p.name}
+          level={p.level <= piMax ? p.level : piMax}
+          key={p.name}
+          piMax={piMax}
+        />
+      )}
+    </div>
+  );
+};
 
 Ratings.defaultProps = {
   displayAveragePi: false,
+  mini: false,
+  averagePi: null,
 };
 Ratings.propTypes = {
   pi: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   piMax: PropTypes.number.isRequired,
   displayAveragePi: PropTypes.bool,
-  averagePi: PropTypes.number.isRequired,
+  mini: PropTypes.bool,
+  averagePi: PropTypes.number,
 };
 
 

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/index.jsx
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/index.jsx
@@ -2,29 +2,33 @@ import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import './style.scss';
 
-const Rating = ({ name, level, piMax, className }) => {
+function classFor(element, mini) {
+  const classNames = [`m-pi-ratings__${element}`];
+  if (mini) { classNames.push(`m-pi-ratings--mini__${element}`); }
+
+  return classNames;
+}
+
+const Rating = ({ name, level, piMax, className, mini }) => {
   const width = (level / piMax) * 100;
   const style = { width: `${width}%` };
-  const ratingClassName = classnames(
-    'm-pi-ratings__item',
-    className,
-  );
 
   return (
-    <div className={ratingClassName}>
-      <div className="m-pi-ratings__item-name">
-        <span className="m-pi-ratings__item-name-label">{name}</span>
+    <div className={classnames(classFor('item', mini), className)}>
+      <div className={classnames(classFor('item-name', mini))}>
+        <span className={classnames(classFor('item-name-label', mini))}>{name}</span>
       </div>
-      <div className="m-pi-ratings__item-level">
-        <div className="m-pi-ratings__item-level-bar" style={style} />
+      <div className={classnames(classFor('item-level', mini))}>
+        <div className={classnames(classFor('item-level-bar', mini))} style={style} />
       </div>
-      <div className="m-pi-ratings__item-level-label">{level}</div>
+      <div className={classnames(classFor('item-level-label', mini))}>{level}</div>
     </div>
   );
 };
 
 Rating.propTypes = {
   name: PropTypes.string.isRequired,
+  mini: PropTypes.bool,
   className: PropTypes.string,
   level: PropTypes.number.isRequired,
   piMax: PropTypes.number.isRequired,
@@ -32,6 +36,7 @@ Rating.propTypes = {
 
 Rating.defaultProps = {
   className: '',
+  mini: false,
 };
 
 const Ratings = ({ pi, piMax, averagePi, displayAveragePi, mini }) => {
@@ -48,6 +53,7 @@ const Ratings = ({ pi, piMax, averagePi, displayAveragePi, mini }) => {
           name="Average PI"
           level={Math.round(averagePi)}
           piMax={piMax}
+          mini={mini}
         />
       }
       {pi.map(p =>
@@ -56,6 +62,7 @@ const Ratings = ({ pi, piMax, averagePi, displayAveragePi, mini }) => {
           level={p.level <= piMax ? p.level : piMax}
           key={p.name}
           piMax={piMax}
+          mini={mini}
         />
       )}
     </div>

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
@@ -2,6 +2,9 @@
 @import '../../../../styles/vendor/bootstrap_foundation-sites';
 
 $gridColor: $co-color__fg__back--higher;
+$mini-pi__width: 2rem;
+$mini-pi-bar__height:  .35rem;
+$mini-pi-bar__margin: .25rem;
 
 .m-pi-ratings {
   max-width: $co-pi-width;
@@ -44,18 +47,24 @@ $gridColor: $co-color__fg__back--higher;
   }
 
   &--mini {
+    max-width: $mini-pi__width;
+    cursor: help;
+
+    .m-pi-ratings__item {
+      display: block;
+      margin: $mini-pi-bar__margin 0;
+    }
+
     .m-pi-ratings__item-level {
-      width: $co-component__height;
-      margin: 2px 0;
+      width: $mini-pi__width;
     }
 
     .m-pi-ratings__item-level-bar {
-      height: 4px;
-      line-height: 4px;
+      height: $mini-pi-bar__height;
     }
 
     .m-pi-ratings__item-level-label,
-    .m-pi-ratings__item-name-label {
+    .m-pi-ratings__item-name {
       display: none;
     }
   }

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
@@ -19,13 +19,13 @@ $mini-pi-bar__margin: .25rem;
   }
 
   &__item-name {
-    @include flex-grid-size(4);
+    @include flex-grid-size(5);
     text-align: right;
   }
 
   &__item-level-label {
     @include flex-grid-size(shrink);
-    padding: $co-component__spacing;
+    padding: $co-component__spacing 0 0 $co-component__spacing;
   }
 
   &__item-level {
@@ -35,10 +35,10 @@ $mini-pi-bar__margin: .25rem;
   }
 
   &__item-level-bar {
-    height: $co-component__height / 2;
+    height: $co-component__height / 3;
     transition: .5s width;
     background: $co-color__privacy;
-    line-height: $co-component__height / 2;
+    line-height: $co-component__height / 3;
   }
 
   &__item-name-label {
@@ -50,21 +50,21 @@ $mini-pi-bar__margin: .25rem;
     max-width: $mini-pi__width;
     cursor: help;
 
-    .m-pi-ratings__item {
+    &__item {
       display: block;
       margin: $mini-pi-bar__margin 0;
     }
 
-    .m-pi-ratings__item-level {
+    &__item-level {
       width: $mini-pi__width;
     }
 
-    .m-pi-ratings__item-level-bar {
+    &__item-level-bar {
       height: $mini-pi-bar__height;
     }
 
-    .m-pi-ratings__item-level-label,
-    .m-pi-ratings__item-name {
+    &__item-level-label,
+    &__item-name {
       display: none;
     }
   }

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
@@ -4,16 +4,15 @@
 $gridColor: $co-color__fg__back--higher;
 
 .m-pi-ratings {
+  max-width: $co-pi-width;
+  margin-right: auto;
+  margin-left: auto;
   font-size: $co-font__size--xsmall;
   font-weight: 600;
 
   &__item {
     @include flex-grid-row;
     align-items: center;
-
-    &--average {
-      margin-bottom: $co-margin;
-    }
   }
 
   &__item-name {
@@ -42,5 +41,22 @@ $gridColor: $co-color__fg__back--higher;
   &__item-name-label {
     padding-right: $co-component__spacing;
     text-transform: uppercase;
+  }
+
+  &--mini {
+    .m-pi-ratings__item-level {
+      width: $co-component__height;
+      margin: 2px 0;
+    }
+
+    .m-pi-ratings__item-level-bar {
+      height: 4px;
+      line-height: 4px;
+    }
+
+    .m-pi-ratings__item-level-label,
+    .m-pi-ratings__item-name-label {
+      display: none;
+    }
   }
 }

--- a/src/frontend/web_application/src/components/MultidimensionalPi/presenter.jsx
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/presenter.jsx
@@ -3,9 +3,11 @@ import classnames from 'classnames';
 import PiGraph from './components/PiGraph';
 import Ratings from './components/Ratings';
 
+export { Ratings };
+
 const PI_MAX = 100; // max value for PI levels
 
-const MultidimensionalPi = ({ pi, displayAveragePi, className }) => {
+const MultidimensionalPi = ({ pi, displayAveragePi, className, mini }) => {
   const gridWidth = PI_MAX * 2;
   const piLength = pi.length;
   const angle = 360 / piLength;
@@ -14,27 +16,41 @@ const MultidimensionalPi = ({ pi, displayAveragePi, className }) => {
 
   return (
     <div className={classnames('m-multidimensional-pi', className)}>
-      <PiGraph
-        gridWidth={gridWidth}
-        piMax={PI_MAX}
-        pi={pi}
-        angle={angle}
-      />
-      <Ratings
-        pi={pi}
-        piMax={PI_MAX}
-        averagePi={averagePi}
-        displayAveragePi={displayAveragePi}
-      />
+      {mini ? (
+        <Ratings
+          pi={pi}
+          piMax={PI_MAX}
+          mini
+        />
+      ) : (
+        <div>
+          <PiGraph
+            gridWidth={gridWidth}
+            piMax={PI_MAX}
+            pi={pi}
+            angle={angle}
+          />
+          <Ratings
+            pi={pi}
+            piMax={PI_MAX}
+            averagePi={averagePi}
+            displayAveragePi={displayAveragePi}
+          />
+        </div>
+      )
+    }
+
     </div>
   );
 };
 MultidimensionalPi.defaultProps = {
   displayAveragePi: false,
   className: null,
+  mini: false,
 };
 MultidimensionalPi.propTypes = {
   pi: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  mini: PropTypes.bool,
   className: PropTypes.string,
   displayAveragePi: PropTypes.bool,
 };

--- a/src/frontend/web_application/src/components/MultidimensionalPi/presenter.jsx
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/presenter.jsx
@@ -3,8 +3,6 @@ import classnames from 'classnames';
 import PiGraph from './components/PiGraph';
 import Ratings from './components/Ratings';
 
-export { Ratings };
-
 const PI_MAX = 100; // max value for PI levels
 
 const MultidimensionalPi = ({ pi, displayAveragePi, className, mini }) => {

--- a/src/frontend/web_application/src/components/MultidimensionalPi/presenter.jsx
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/presenter.jsx
@@ -1,9 +1,16 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
+import { v1 as uuidV1 } from 'uuid';
 import PiGraph from './components/PiGraph';
 import Ratings from './components/Ratings';
+import Button from '../Button';
+import Dropdown, { withDropdownControl } from '../Dropdown';
+
+import './style.scss';
 
 const PI_MAX = 100; // max value for PI levels
+const DropdownControl = withDropdownControl(Button);
+
 
 const MultidimensionalPi = ({ pi, displayAveragePi, className, mini }) => {
   const gridWidth = PI_MAX * 2;
@@ -11,15 +18,34 @@ const MultidimensionalPi = ({ pi, displayAveragePi, className, mini }) => {
   const angle = 360 / piLength;
   const piLevels = pi.map(p => p.level);
   const averagePi = (piLevels.reduce((a, b) => a + b, 0)) / piLength;
+  const id = uuidV1();
 
   return (
     <div className={classnames('m-multidimensional-pi', className)}>
       {mini ? (
-        <Ratings
-          pi={pi}
-          piMax={PI_MAX}
-          mini
-        />
+        <div className="m-multidimensional-pi__mini-pi">
+          <DropdownControl toggle={id} className="m-multidimensional-pi__toggle-mini-pi">
+            <Ratings
+              pi={pi}
+              piMax={PI_MAX}
+              mini
+            />
+          </DropdownControl>
+
+          <Dropdown
+            id={id}
+            className="m-multidimensional-pi__mini-graph"
+            position="bottom"
+            closeOnClick
+          >
+            <Ratings
+              pi={pi}
+              piMax={PI_MAX}
+              averagePi={averagePi}
+              displayAveragePi={displayAveragePi}
+            />
+          </Dropdown>
+        </div>
       ) : (
         <div>
           <PiGraph

--- a/src/frontend/web_application/src/components/MultidimensionalPi/style.scss
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/style.scss
@@ -1,0 +1,35 @@
+@import '../../styles/common';
+@import '../../styles/vendor/bootstrap_foundation-sites';
+@import '../../styles/object/o-triangle';
+
+
+.m-multidimensional-pi {
+  &__mini-pi {
+    display: flex;
+    position: relative;
+    align-items: stretch;
+    height: 100%;
+  }
+
+  &__toggle-mini-pi {
+    flex: auto;
+
+    &:hover,
+    &:active {
+      background: $co-color__fg__back--high;
+    }
+  }
+
+
+  &__mini-graph {
+    width: $co-pi-width;
+    padding: $co-component__spacing;
+    background: $co-color__fg__back--lower;
+    box-shadow: $co-shadow;
+
+    &::before {
+      @include o-triangle('top', .75rem, $co-color__fg__back--lower);
+      left: 1rem;
+    }
+  }
+}

--- a/src/frontend/web_application/stories/index.jsx
+++ b/src/frontend/web_application/stories/index.jsx
@@ -384,6 +384,7 @@ storiesOf('Pi', module)
         { name: 'technical', level: 55 },
       ]),
       displayAveragePi: boolean('display Average PI', false),
+      mini: boolean('mini', false),
     };
 
     return (<MultidimensionalPi {...props} />);


### PR DESCRIPTION
This adds a `mini` props to `<MultidimensionalPi>` and display `<MultidimensionalPi mini />` on messages.

By now: nothing on click or tap, more info is only displayed on hover, as a simple html `title="..."`+ css `cursor: help`. `Dropdown` could be used here for click/tap action, but maybe a kind of "tooltip" component would be better. @iamdey what's your opinion?
