### PR TITLE
Missing caliopen pgp python components for apiv1

### DIFF
--- a/src/backend/Dockerfile.py-api
+++ b/src/backend/Dockerfile.py-api
@@ -37,6 +37,9 @@ RUN python setup.py develop
 
 ## Container specific installation part
 
+WORKDIR /srv/caliopen/src/backend/components/py.pgp
+RUN python setup.py develop
+
 # Install python API packages
 WORKDIR /srv/caliopen/src/backend/interfaces/REST/py.server
 RUN python setup.py develop


### PR DESCRIPTION
Fix #323 