### PR TITLE
Revert "Upgrade stack to use Elasticsearch v5.4.1 (ie. current version)."

### DIFF
--- a/devtools/docker-compose.yml
+++ b/devtools/docker-compose.yml
@@ -55,12 +55,9 @@ services:
   #
   # Used to index mail content and ensure great research performances.
   elasticsearch:
-      image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+      image: elasticsearch:2
       ports:
           - "9200:9200"
-      environment:
-          - xpack.security.enabled=false
-          - xpack.monitoring.enabled=false
       volumes:
           - .data/elasticsearch/data:/usr/share/elasticsearch/data
 

--- a/src/backend/main/go.backends/index/elasticsearch/elasticsearch.go
+++ b/src/backend/main/go.backends/index/elasticsearch/elasticsearch.go
@@ -6,7 +6,7 @@ package index
 
 import (
 	log "github.com/Sirupsen/logrus"
-	elastic "gopkg.in/olivere/elastic.v5"
+	elastic "gopkg.in/olivere/elastic.v2"
 )
 
 type (
@@ -29,6 +29,7 @@ func (es *ElasticSearchBackend) initialize(config ElasticSearchConfig) (err erro
 	// Create elastic client
 	es.Client, err = elastic.NewClient(
 		elastic.SetURL(config.Urls...),
+		elastic.SetSniff(false),
 	)
 
 	if err != nil {

--- a/src/backend/main/go.backends/index/elasticsearch/messages.go
+++ b/src/backend/main/go.backends/index/elasticsearch/messages.go
@@ -5,7 +5,6 @@
 package index
 
 import (
-	"context"
 	"github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
 	log "github.com/Sirupsen/logrus"
 )
@@ -14,7 +13,7 @@ func (es *ElasticSearchBackend) UpdateMessage(msg *objects.Message, fields map[s
 
 	update, err := es.Client.Update().Index(msg.User_id.String()).Type("indexed_message").Id(msg.Message_id.String()).
 		Doc(fields).
-		Do(context.TODO())
+		Do()
 	if err != nil {
 		log.WithError(err).Warn("backend Index: updateMessage operation failed")
 		return err
@@ -32,8 +31,8 @@ func (es *ElasticSearchBackend) IndexMessage(msg *objects.Message) error {
 
 	resp, err := es.Client.Index().Index(msg.User_id.String()).Type("indexed_message").Id(msg.Message_id.String()).
 		BodyString(string(es_msg)).
-		Refresh("true").
-		Do(context.TODO())
+		Refresh(true).
+		Do()
 	if err != nil {
 		log.WithError(err).Warn("backend Index: IndexMessage operation failed")
 		return err
@@ -49,7 +48,7 @@ func (es *ElasticSearchBackend) SetMessageUnread(user_id, message_id string, sta
 	}{status}
 
 	update := es.Client.Update().Index(user_id).Type("indexed_message").Id(message_id)
-	_, err = update.Doc(payload).Refresh("true").Do(context.TODO())
+	_, err = update.Doc(payload).Refresh(true).Do()
 
 	return
 }

--- a/src/backend/vendor/vendor.json
+++ b/src/backend/vendor/vendor.json
@@ -423,12 +423,6 @@
 			"revisionTime": "2017-05-04T04:03:14Z"
 		},
 		{
-          "checksumSHA1": "+alGamFQmcGTgPK66CpSfF4lYbk=",
-          "path": "github.com/pkg/errors",
-          "revision": "c605e284fe17294bda444b34710735b29d1a9d90",
-          "revisionTime": "2017-05-05T04:36:39Z"
-        },
-      {
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
 			"path": "github.com/satori/go.uuid",
 			"revision": "5bf94b69c6b68ee1b541973bb8e1144db23a194b",
@@ -657,18 +651,24 @@
 			"revisionTime": "2016-08-17T06:38:38Z"
 		},
 		{
-          "checksumSHA1": "Ko5F2Kk9TIXHFjkriNT+CMPjIcI=",
-          "path": "gopkg.in/olivere/elastic.v5",
-          "revision": "f1fd7305d0b6270192b27010fe1193568b18e4b6",
-          "revisionTime": "2017-05-29T12:23:53Z"
-        },
-      {
-        "checksumSHA1": "pCApZfp2CeDnWbNVsyzNO62ZUXA=",
-        "path": "gopkg.in/olivere/elastic.v5/uritemplates",
-        "revision": "f1fd7305d0b6270192b27010fe1193568b18e4b6",
-        "revisionTime": "2017-05-29T12:23:53Z"
-      },
-      {
+			"checksumSHA1": "YaYXHmoUOYfWXu5TMM4k8ChZ8vY=",
+			"path": "gopkg.in/olivere/elastic.v2",
+			"revision": "54283cb278d855e562a3d20f6c5afdbe1decf25b",
+			"revisionTime": "2017-03-29T06:52:08Z"
+		},
+		{
+			"checksumSHA1": "TYefriikhzyFZ9ynNHgYUjeoHgw=",
+			"path": "gopkg.in/olivere/elastic.v2/backoff",
+			"revision": "54283cb278d855e562a3d20f6c5afdbe1decf25b",
+			"revisionTime": "2017-03-29T06:52:08Z"
+		},
+		{
+			"checksumSHA1": "O5dZe+m70S7vbkgePsMLrUc86DA=",
+			"path": "gopkg.in/olivere/elastic.v2/uritemplates",
+			"revision": "54283cb278d855e562a3d20f6c5afdbe1decf25b",
+			"revisionTime": "2017-03-29T06:52:08Z"
+		},
+		{
 			"checksumSHA1": "5cJY0lLgDCgPeui7ImDgvsBs3VM=",
 			"path": "gopkg.in/redis.v5",
 			"revision": "a16aeec10ff407b1e7be6dd35797ccf5426ef0f0",


### PR DESCRIPTION
Reverts CaliOpen/Caliopen#337

@iamdey and @myleneb have same problem using ES5: https://pastebin.com/tri1bqFG

I didn't find easily where is the problem and how to solve it, doing revert for further investigation /w blocking anyone
