### PR TITLE
Remove all references to user Counter model

### DIFF
--- a/src/backend/main/py.main/caliopen_main/user/store/__init__.py
+++ b/src/backend/main/py.main/caliopen_main/user/store/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from .user import User, UserName, ReservedName, Counter, FilterRule
+from .user import User, UserName, ReservedName, FilterRule
 from .user import RemoteIdentity, IndexUser
 from .contact import Contact, IndexedContact, ContactLookup
 from .contact import Organization, PostalAddress
@@ -15,7 +15,7 @@ from .local_identity import LocalIdentity
 
 
 __all__ = [
-    'User', 'UserName', 'Counter', 'UserTag', 'FilterRule', 'ReservedName',
+    'User', 'UserName', 'UserTag', 'FilterRule', 'ReservedName',
     'RemoteIdentity', 'IndexUser',
     'Contact', 'ContactLookup', 'IndexedContact',
     'Organization', 'PostalAddress',

--- a/src/backend/main/py.main/caliopen_main/user/store/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/store/user.py
@@ -47,15 +47,6 @@ class User(BaseModel):
     local_identities = columns.List(columns.Text())
 
 
-class Counter(BaseModel):
-    """User counters model."""
-
-    user_id = columns.UUID(primary_key=True)
-    message_id = columns.Counter()
-    thread_id = columns.Counter()
-    rule_id = columns.Counter()
-
-
 class FilterRule(BaseModel):
     """User filter rules model."""
 

--- a/src/backend/main/py.main/caliopen_main/user/store/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/store/user.py
@@ -51,7 +51,7 @@ class FilterRule(BaseModel):
     """User filter rules model."""
 
     user_id = columns.UUID(primary_key=True)
-    rule_id = columns.Integer(primary_key=True)  # counter.rule_id
+    rule_id = columns.UUID(primary_key=True)
     date_insert = columns.DateTime()
     name = columns.Text()
     filter_expr = columns.Text()

--- a/src/backend/tools/py.CLI/caliopen_cli/commands/dump_model.py
+++ b/src/backend/tools/py.CLI/caliopen_cli/commands/dump_model.py
@@ -10,7 +10,7 @@ def dump_model(model, output_path, **kwargs):
         'contact': ['Contact', 'Organization', 'PostalAddress', 'Email', 'IM',
                     'Ohone', 'PublicKey', 'SocialIdentity'],
         'message': ['Message', 'Thread'],
-        'user':    ['User', 'Counter', 'UserTag', 'FilterRule'],
+        'user':    ['User', 'UserTag', 'FilterRule'],
     }
     for obj in _exports[model]:
         kls = core_registry.get(obj)


### PR DESCRIPTION
Cleanup completly no more used model user counters, as they are deprecated in cassandra and not supported at all by scylladb.