### PR TITLE
Improvement/backend/discussion construction

### DIFF
--- a/src/backend/defs/go-objects/external_references.go
+++ b/src/backend/defs/go-objects/external_references.go
@@ -5,8 +5,7 @@
 package objects
 
 type ExternalReferences struct {
-	Discussion_id string   `cql:"discussion_id"            json:"discussion_id"`
-	Message_id    string   `cql:"message_id"               json:"message_id"`
-	Parent_id     string   `cql:"parent_id"                json:"parent_id"`
-	References    []string `cql:"references"               json:"references"` //References header (see RFC5322#3.6.4)
+	Ancestors_ids []string   `cql:"ancestors_ids"            json:"ancestors_ids"`
+	Message_id    string     `cql:"message_id"               json:"message_id"`
+	Parent_id     string     `cql:"parent_id"                json:"parent_id"`
 }

--- a/src/backend/defs/go-objects/external_references.go
+++ b/src/backend/defs/go-objects/external_references.go
@@ -5,7 +5,7 @@
 package objects
 
 type ExternalReferences struct {
-	Ancestors_ids []string   `cql:"ancestors_ids"            json:"ancestors_ids"`
-	Message_id    string     `cql:"message_id"               json:"message_id"`
-	Parent_id     string     `cql:"parent_id"                json:"parent_id"`
+	Ancestors_ids []string `cql:"ancestors_ids"            json:"ancestors_ids"`
+	Message_id    string   `cql:"message_id"               json:"message_id"`
+	Parent_id     string   `cql:"parent_id"                json:"parent_id"`
 }

--- a/src/backend/defs/rest-api/objects/ExternalReferences.yaml
+++ b/src/backend/defs/rest-api/objects/ExternalReferences.yaml
@@ -1,7 +1,7 @@
 ---
 type: object
 properties:
-  discussion_id:
+  ancestors_id:
     type: string
   message_id:
     type: string

--- a/src/backend/main/py.main/caliopen_main/discussion/core/__init__.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/core/__init__.py
@@ -2,11 +2,11 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from .discussion import MainView, Discussion, ReturnDiscussion
-from .discussion import DiscussionExternalLookup, DiscussionRecipientLookup
+from .discussion import DiscussionListLookup, DiscussionRecipientLookup
 from .discussion import DiscussionThreadLookup
 
 __all__ = [
     'Discussion', 'MainView', 'ReturnDiscussion',
-    'DiscussionExternalLookup', 'DiscussionRecipientLookup',
+    'DiscussionListLookup', 'DiscussionRecipientLookup',
     'DiscussionThreadLookup'
 ]

--- a/src/backend/main/py.main/caliopen_main/discussion/core/__init__.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/core/__init__.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from .discussion import MainView, Discussion, ReturnDiscussion
 from .discussion import DiscussionExternalLookup, DiscussionRecipientLookup
-from .discussion import DiscussionMessageLookup
+from .discussion import DiscussionThreadLookup
 
 __all__ = [
     'Discussion', 'MainView', 'ReturnDiscussion',
     'DiscussionExternalLookup', 'DiscussionRecipientLookup',
-    'DiscussionMessageLookup'
+    'DiscussionThreadLookup'
 ]

--- a/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
@@ -13,7 +13,7 @@ from caliopen_storage.parameters import ReturnCoreObject
 from ..store.discussion import \
     (DiscussionExternalLookup as ModelExternalLookup,
      DiscussionRecipientLookup as ModelRecipientLookup,
-     DiscussionMessageLookup as ModelMessageLookup,
+     DiscussionThreadLookup as ModelThreadLookup,
      Discussion as ModelDiscussion)
 from ..store.discussion_index import DiscussionIndexManager as DIM
 
@@ -47,11 +47,11 @@ class DiscussionRecipientLookup(BaseUserCore):
     _pkey_name = 'recipient_name'
 
 
-class DiscussionMessageLookup(BaseUserCore):
-    """Lookup discussion by external message_id."""
+class DiscussionThreadLookup(BaseUserCore):
+    """Lookup discussion by external thread's root message_id."""
 
-    _model_class = ModelMessageLookup
-    _pkey_name = 'external_message_id'
+    _model_class = ModelThreadLookup
+    _pkey_name = 'external_root_msg_id'
 
 
 def build_discussion(core, index):
@@ -125,7 +125,7 @@ class Discussion(BaseUserCore):
         kwargs = {'discussion_id': new_id,
                   'date_insert': datetime.utcnow(),
                   # 'privacy_index': message.privacy_index,
-                  'importance_level': message.importance_level,
+                  # 'importance_level': message.importance_level,
                   'excerpt': message.body_plain[:200],
                   }
         discussion = cls.create(user, **kwargs)

--- a/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
@@ -11,7 +11,7 @@ from caliopen_storage.core import BaseUserCore
 from caliopen_storage.parameters import ReturnCoreObject
 
 from ..store.discussion import \
-    (DiscussionExternalLookup as ModelExternalLookup,
+    (DiscussionListLookup as ModelListLookup,
      DiscussionRecipientLookup as ModelRecipientLookup,
      DiscussionThreadLookup as ModelThreadLookup,
      Discussion as ModelDiscussion)
@@ -33,11 +33,11 @@ def count_attachment(message):
     return cpt
 
 
-class DiscussionExternalLookup(BaseUserCore):
-    """Lookup discussion by external id (facebook, gmail, ...)."""
+class DiscussionListLookup(BaseUserCore):
+    """Lookup discussion by external list-id"""
 
-    _model_class = ModelExternalLookup
-    _pkey_name = 'external_id'
+    _model_class = ModelListLookup
+    _pkey_name = 'list_id'
 
 
 class DiscussionRecipientLookup(BaseUserCore):

--- a/src/backend/main/py.main/caliopen_main/discussion/store/discussion.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/store/discussion.py
@@ -19,23 +19,11 @@ class Discussion(BaseModel):
     excerpt = columns.Text()
 
 
-class DiscussionRecipientLookup(
-    BaseModel):  # TODO: rename to DiscussionParticipantLookup
-    """Lookup discussion by a recipient name."""
-
-    # XXX temporary, until a recipients able lookup can be design
-    user_id = columns.UUID(primary_key=True)
-    recipient_name = columns.Text(primary_key=True)
-    discussion_id = columns.UUID()
-
-
-class DiscussionExternalLookup(
-    BaseModel):  # TODO: renamo to DiscussionListLookup
-
-    """Lookup discussion by external_thread_id."""
+class DiscussionListLookup(BaseModel):
+    """Lookup discussion by external list-id."""
 
     user_id = columns.UUID(primary_key=True)
-    external_id = columns.Text(primary_key=True)
+    list_id = columns.Text(primary_key=True)
     discussion_id = columns.UUID()
 
 
@@ -45,4 +33,13 @@ class DiscussionThreadLookup(BaseModel):
     user_id = columns.UUID(primary_key=True)
     external_root_msg_id = columns.Text(primary_key=True)
     discussion_id = columns.UUID()
-    message_id = columns.UUID()
+
+
+class DiscussionRecipientLookup(
+    BaseModel):  # TODO: rename to DiscussionParticipantLookup
+    """Lookup discussion by a recipient name."""
+
+    # XXX temporary, until a recipients able lookup can be design
+    user_id = columns.UUID(primary_key=True)
+    recipient_name = columns.Text(primary_key=True)
+    discussion_id = columns.UUID()

--- a/src/backend/main/py.main/caliopen_main/discussion/store/discussion.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/store/discussion.py
@@ -19,8 +19,8 @@ class Discussion(BaseModel):
     excerpt = columns.Text()
 
 
-class DiscussionRecipientLookup(BaseModel):
-
+class DiscussionRecipientLookup(
+    BaseModel):  # TODO: rename to DiscussionParticipantLookup
     """Lookup discussion by a recipient name."""
 
     # XXX temporary, until a recipients able lookup can be design
@@ -29,7 +29,8 @@ class DiscussionRecipientLookup(BaseModel):
     discussion_id = columns.UUID()
 
 
-class DiscussionExternalLookup(BaseModel):
+class DiscussionExternalLookup(
+    BaseModel):  # TODO: renamo to DiscussionListLookup
 
     """Lookup discussion by external_thread_id."""
 
@@ -38,11 +39,10 @@ class DiscussionExternalLookup(BaseModel):
     discussion_id = columns.UUID()
 
 
-class DiscussionMessageLookup(BaseModel):
-
-    """Lookup discussion by external message_id."""
+class DiscussionThreadLookup(BaseModel):
+    """Lookup discussion by external thread's root message_id."""
 
     user_id = columns.UUID(primary_key=True)
-    external_message_id = columns.Text(primary_key=True)
+    external_root_msg_id = columns.Text(primary_key=True)
     discussion_id = columns.UUID()
     message_id = columns.UUID()

--- a/src/backend/main/py.main/caliopen_main/message/delivery.py
+++ b/src/backend/main/py.main/caliopen_main/message/delivery.py
@@ -8,7 +8,6 @@ import datetime
 from caliopen_storage.exception import NotFound
 from ..message.core import RawMessage
 from .qualifier import UserMessageQualifier
-from ..discussion.core import Discussion
 from ..objects.message import Message
 
 log = logging.getLogger(__name__)
@@ -31,11 +30,6 @@ class UserMessageDelivery(object):
 
         qualifier = UserMessageQualifier(self.user)
         message = qualifier.process_inbound(raw)
-        if not message.discussion_id:
-            discussion = Discussion.create_from_message(self.user, message)
-            log.debug('Created discussion {}'.format(discussion.discussion_id))
-            # xxx create lookup ?
-            message.discussion_id = discussion.discussion_id
 
         # store and index message
         obj = Message(self.user)

--- a/src/backend/main/py.main/caliopen_main/message/parameters/external_references.py
+++ b/src/backend/main/py.main/caliopen_main/message/parameters/external_references.py
@@ -3,10 +3,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from schematics.models import Model
 from schematics.types import StringType
+from schematics.types.compound import ListType
 
 
 class ExternalReferences(Model):
-    discussion_id = StringType()
+    ancestors_ids = ListType(StringType())
     message_id = StringType()
     parent_id = StringType()
 

--- a/src/backend/main/py.main/caliopen_main/message/parameters/message.py
+++ b/src/backend/main/py.main/caliopen_main/message/parameters/message.py
@@ -53,6 +53,7 @@ class NewInboundMessage(NewMessage):
     body_html = StringType()
     body_plain = StringType()
 
+
 class Message(NewMessage):
     """Existing message parameter."""
 

--- a/src/backend/main/py.main/caliopen_main/message/qualifier.py
+++ b/src/backend/main/py.main/caliopen_main/message/qualifier.py
@@ -8,8 +8,7 @@ from caliopen_storage.exception import NotFound
 from caliopen_storage.config import Configuration
 from caliopen_main.user.core import Contact
 from caliopen_main.discussion.core import (DiscussionThreadLookup,
-                                           DiscussionRecipientLookup,
-                                           DiscussionExternalLookup)
+                                           DiscussionListLookup)
 from caliopen_pi.features import InboundMailFeature
 # XXX use a message formatter registry not directly mail format
 from caliopen_main.parsers import MailMessage
@@ -31,10 +30,8 @@ class UserMessageQualifier(object):
 
     _lookups = {
         'thread': DiscussionThreadLookup,
-        'list': DiscussionRecipientLookup,
-        'recipient': DiscussionRecipientLookup,
-        'external_thread': DiscussionExternalLookup,
-        'from': DiscussionRecipientLookup,
+        'list': DiscussionListLookup,
+        # 'recipient': DiscussionRecipientLookup,
     }
 
     def __init__(self, user):
@@ -57,6 +54,7 @@ class UserMessageQualifier(object):
             except NotFound:
                 log.debug('Lookup type %s with value %s failed' %
                           (prop[0], prop[1]))
+
         return None
 
     def create_lookups(self, sequence, message):
@@ -67,12 +65,9 @@ class UserMessageQualifier(object):
                 kls._pkey_name: prop[1],
                 'discussion_id': message.discussion_id
             }
-            if 'message_id' in kls._model_class._columns.keys():
-                params.update({'message_id': message.message_id})
             lookup = kls.create(self.user, **params)
             log.debug('Create lookup %r' % lookup)
-            if prop[0] == 'list':
-                return
+
 
     def get_participant(self, message, participant):
         """Try to find a related contact and return a Participant instance."""

--- a/src/backend/main/py.main/caliopen_main/message/store/external_references.py
+++ b/src/backend/main/py.main/caliopen_main/message/store/external_references.py
@@ -10,7 +10,7 @@ class ExternalReferences(BaseUserType):
 
     """External references nested in message."""
 
-    discussion_id = columns.Text()
+    ancestors_ids = columns.List(columns.Text())
     message_id = columns.Text()
     parent_id = columns.Text()
 

--- a/src/backend/main/py.main/caliopen_main/message/store/external_references_index.py
+++ b/src/backend/main/py.main/caliopen_main/message/store/external_references_index.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-from elasticsearch_dsl import InnerObjectWrapper, Keyword
+from elasticsearch_dsl import InnerObjectWrapper, Keyword, Nested
 
 log = logging.getLogger(__name__)
 
@@ -12,6 +12,6 @@ class IndexedExternalReferences(InnerObjectWrapper):
 
     """Nest attachment indexed model."""
 
-    discussion_id = Keyword()
+    ancestors_ids = Keyword(multi=True)
     message_id = Keyword()
     parent_id = Keyword()

--- a/src/backend/main/py.main/caliopen_main/objects/external_references.py
+++ b/src/backend/main/py.main/caliopen_main/objects/external_references.py
@@ -14,7 +14,7 @@ class ExternalReferences(base.ObjectJsonDictifiable):
     """external references, nested within message object"""
 
     _attrs = {
-        'discussion_id': types.StringType,
+        'ancestors_ids': [types.StringType],
         'message_id': types.StringType,
         'parent_id': types.StringType
     }

--- a/src/backend/main/py.main/caliopen_main/user/helpers/normalize.py
+++ b/src/backend/main/py.main/caliopen_main/user/helpers/normalize.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Normalization functions for different values."""
 from __future__ import absolute_import, unicode_literals
-
+import logging
 from email.utils import parseaddr
 
+log = logging.getLogger(__name__)
 
 def clean_email_address(addr):
     """Clean an email address for user resolve."""
@@ -12,6 +13,9 @@ def clean_email_address(addr):
         raise Exception('Invalid email address %s' % addr)
     name, domain = email.lower().split('@', 2)
     if '+' in name:
-        name, ext = name.split('+', 2)
+        try:
+            name, ext = name.split('+', 2)
+        except Exception as exc:
+            log.info(exc)
     # unicode everywhere
     return (u'%s@%s' % (name, domain), email)

--- a/src/backend/main/py.main/caliopen_main/user/helpers/normalize.py
+++ b/src/backend/main/py.main/caliopen_main/user/helpers/normalize.py
@@ -10,7 +10,8 @@ def clean_email_address(addr):
     """Clean an email address for user resolve."""
     real_name, email = parseaddr(addr)
     if not email:
-        raise Exception('Invalid email address %s' % addr)
+        log.info('Invalid email address %s' % addr)
+        return ("", "")
     name, domain = email.lower().split('@', 2)
     if '+' in name:
         try:


### PR DESCRIPTION
Ingress messages will now trigger an effective discussion lookup process and storage.
For now, discussions are constructed from message's externals references and/or list-id header.