### PR TITLE
API always validates ingress & egress json docs against our json_models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - A python package caliopen_pi to group all logic related to privacy index compute
-- Add route `GET /v2/contacts/{contact_id}/identities` to search & retreive identities from a contact.
+- Add route `GET /v2/contacts/{contact_id}/identities` to search & retrieve identities from a contact.
 - New scene components related to Settings layout
 - New Importance Level range slider in tabs & alt navigation
 - In compose, add subject input field when recipient uses an email
 - Add user settings storage and API for management (GET and PATCH /settings)
+- Frontend can post draftID
+- Messages have 2 bodies : plain + HTML.
+    - Only one body is returned to frontend.
+    - HTML body is sanitized before output to frontend.
+- MailMessages's subject decoded to always output an UTF-8 string.
+- Index operations return after index has been fully updated
 
 ### Changed
 - Rename <Account...> layout and related scenes to <User...>
@@ -21,10 +27,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Handle 4xx errors when updating contact fails
 - Compose in multiple tabs messages, not only one
 - Refactore caliopen_main package for cleaner namespaces
+- Move tags API to V2. CRUD operations are now on routes /v2/tags
+- Discussions creation from ingress messages are build from messages' external references.
+- ingress & egress JSON payload are double validated by our API instead of only relying on swagger.
 
 ### Fixed
 - Bad wording for message update failures
 - Blink when composing a new message
+- Inconsistent date format string across stack
+- Bugs on patch operations (contact & messages)
+- Missing 'title' property on the user's Contact card
+- Elasticsearch inconsistent mapping
 
 ## [0.2.1] - 2017-07-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add user settings storage and API for management (GET and PATCH /settings)
 - Frontend can post draftID
 - Messages have 2 bodies : plain + HTML.
-    - Only one body is returned to frontend.
-    - HTML body is sanitized before output to frontend.
+- Only one body is returned to frontend for Message.
+- HTML body is sanitized before output to frontend.
 - MailMessages's subject decoded to always output an UTF-8 string.
 - Index operations return after index has been fully updated
 

--- a/src/backend/defs/rest-api/objects/NewSocialIdentity.yaml
+++ b/src/backend/defs/rest-api/objects/NewSocialIdentity.yaml
@@ -9,5 +9,6 @@ properties:
     type: string
 required:
 - name
+- type
 additionalProperties: false
 

--- a/src/backend/main/py.main/caliopen_main/common/objects/base.py
+++ b/src/backend/main/py.main/caliopen_main/common/objects/base.py
@@ -145,6 +145,15 @@ class ObjectJsonDictifiable(ObjectDictifiable):
 
     def unmarshall_json_dict(self, document, **options):
         """ TODO: handle conversion of basic json type into obj. types"""
+
+        # validate document against json_model before trying to unmarshal
+        valid_doc = self._json_model(document)
+        try:
+            valid_doc.validate()
+        except Exception as exc:
+            log.warn("document validation failed with error {}".format(exc))
+            raise exc
+
         self.unmarshall_dict(document, **options)
 
 

--- a/src/backend/main/py.main/caliopen_main/contact/parameters.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parameters.py
@@ -25,7 +25,7 @@ PHONE_TYPES = ['assistant', 'callback', 'car', 'company_main',
                'tty_tdd', 'work', 'work_fax', 'work_mobile', 'work_pager']
 # XXX : use configuration instead ?
 SOCIAL_TYPES = ['facebook', 'twitter', 'google', 'github', 'bitbucket',
-                'linkedin', 'ello', 'instagram', 'tumblr', 'skype']
+                'linkedin', 'ello', 'instagram', 'tumblr', 'skype', 'mastodon']
 
 KEY_CHOICES = ['rsa', 'gpg', 'ssh']
 
@@ -68,7 +68,7 @@ class Organization(NewOrganization):
 
     contact_id = UUIDType()
     deleted = BooleanType(default=False)
-    organization_id = UUIDType(required=True)
+    organization_id = UUIDType()
     user_id = UUIDType()
 
     class Options:
@@ -81,7 +81,7 @@ class NewPostalAddress(Model):
     """Input structure for a new postal address."""
 
     address_id = StringType()
-    city = StringType(required=True)
+    city = StringType()
     country = StringType()
     is_primary = BooleanType(default=False)
     label = StringType()
@@ -98,7 +98,7 @@ class PostalAddress(NewPostalAddress):
 
     """Existing postal address."""
 
-    address_id = UUIDType(required=True)
+    address_id = UUIDType()
     contact_id = UUIDType()
     user_id = UUIDType()
 
@@ -149,7 +149,7 @@ class IM(NewIM):
     """Existing IM."""
 
     contact_id = UUIDType()
-    im_id = UUIDType(required=True)
+    im_id = UUIDType()
     user_id = UUIDType()
 
     class Options:
@@ -162,7 +162,7 @@ class NewPhone(Model):
     """Input structure for a new phone."""
 
     is_primary = BooleanType(default=False)
-    number = PhoneNumberType(required=True)
+    number = PhoneNumberType()
     type = StringType(choices=PHONE_TYPES, default='other')
     uri = StringType()
 
@@ -175,7 +175,7 @@ class Phone(NewPhone):
     """Existing phone."""
 
     contact_id = UUIDType()
-    phone_id = UUIDType(required=True)
+    phone_id = UUIDType()
     user_id = UUIDType()
 
     class Options:
@@ -189,7 +189,7 @@ class NewSocialIdentity(Model):
 
     infos = DictType(StringType, default=lambda: {})
     name = StringType(required=True)
-    type = StringType(choices=SOCIAL_TYPES)
+    type = StringType(choices=SOCIAL_TYPES, required=True)
 
     class Options:
         serialize_when_none = False
@@ -200,7 +200,7 @@ class SocialIdentity(NewSocialIdentity):
     """Existing social identity."""
 
     contact_id = UUIDType()
-    social_id = UUIDType(required=True)
+    social_id = UUIDType()
     user_id = UUIDType()
 
     class Options:
@@ -229,8 +229,7 @@ class PublicKey(NewPublicKey):
     """Existing public key."""
 
     contact_id = UUIDType()
-    date_insert = DateTimeType(required=True,
-                               serialized_format=helpers.RFC3339Milli,
+    date_insert = DateTimeType(serialized_format=helpers.RFC3339Milli,
                                tzd=u'utc')
     date_update = DateTimeType(serialized_format=helpers.RFC3339Milli,
                                tzd=u'utc')
@@ -272,7 +271,7 @@ class Contact(NewContact):
 
     addresses = ListType(ModelType(PostalAddress), default=lambda: [])
     avatar = StringType(default='avatar.png')
-    contact_id = UUIDType(required=True)
+    contact_id = UUIDType()
     date_insert = DateTimeType(serialized_format=helpers.RFC3339Milli,
                                tzd=u'utc')
     date_update = DateTimeType(serialized_format=helpers.RFC3339Milli,
@@ -287,7 +286,7 @@ class Contact(NewContact):
     pi = ModelType(PIParameter)
     # XXX not such default here
     title = StringType()
-    user_id = UUIDType(required=True)
+    user_id = UUIDType()
 
     class Options:
         serialize_when_none = False
@@ -297,7 +296,7 @@ class ShortContact(Model):
 
     """Input structure for contact in short form."""
 
-    contact_id = UUIDType(required=True)
+    contact_id = UUIDType()
     family_name = StringType()
     given_name = StringType()
     tags = ListType(ModelType(ResourceTag), default=lambda: [])

--- a/src/backend/main/py.main/caliopen_main/message/objects/message.py
+++ b/src/backend/main/py.main/caliopen_main/message/objects/message.py
@@ -111,7 +111,7 @@ class Message(ObjectIndexable):
             raise exc
 
         message = Message()
-        message.unmarshall_json_dict(draft_param)
+        message.unmarshall_json_dict(draft_param.to_primitive())
         message.user_id = UUID(user_id)
         message.is_draft = True
         message.type = "email"  # TODO: type handling inferred from participants

--- a/src/backend/main/py.main/caliopen_main/message/parameters/draft.py
+++ b/src/backend/main/py.main/caliopen_main/message/parameters/draft.py
@@ -97,7 +97,7 @@ class Draft(NewMessage):
         except NotFound:
             raise NotFound
         if str(local_identity.user_id) != user_id:
-            raise err.ForbiddenAction
+            raise err.ForbiddenAction(message="Action forbidden for this user")
 
         # add 'from' participant with local identity's identifier
         user = User.get(user_id)

--- a/src/backend/main/py.main/caliopen_main/message/parameters/message.py
+++ b/src/backend/main/py.main/caliopen_main/message/parameters/message.py
@@ -37,8 +37,7 @@ class NewMessage(Model):
     is_unread = BooleanType()
     message_id = UUIDType()
     parent_id = StringType()
-    participants = ListType(ModelType(Participant), default=lambda: [],
-                            required=True)
+    participants = ListType(ModelType(Participant), default=lambda: [])
     privacy_features = DictType(StringType, default=lambda: {})
     pi = ModelType(PIParameter)
     raw_msg_id = UUIDType()
@@ -60,10 +59,9 @@ class Message(NewMessage):
 
     body = StringType()
     user_id = UUIDType()
-    message_id = UUIDType(required=True)
-    raw_msg_id = UUIDType(required=True)
-    date_insert = DateTimeType(required=True,
-                               serialized_format=helpers.RFC3339Milli,
+    message_id = UUIDType()
+    raw_msg_id = UUIDType()
+    date_insert = DateTimeType(serialized_format=helpers.RFC3339Milli,
                                tzd=u'utc')
     date_delete = DateTimeType(serialized_format=helpers.RFC3339Milli,
                                tzd=u'utc')

--- a/src/backend/main/py.main/caliopen_main/user/parameters/device.py
+++ b/src/backend/main/py.main/caliopen_main/user/parameters/device.py
@@ -41,14 +41,13 @@ class NewDevice(Model):
 class Device(NewDevice):
     """Parameter for an existing device."""
 
-    device_id = UUIDType(required=True)
-    user_id = UUIDType(required=True)
-    date_insert = DateTimeType(required=True,
-                               serialized_format=helpers.RFC3339Milli,
+    device_id = UUIDType()
+    user_id = UUIDType()
+    date_insert = DateTimeType(serialized_format=helpers.RFC3339Milli,
                                tzd=u'utc')
     last_seen = DateTimeType(serialized_format=helpers.RFC3339Milli,
                              tzd=u'utc')
-    status = StringType(required=True)
+    status = StringType()
 
     privacy_features = DictType(StringType, default=lambda: {})
     pi = ModelType(PIParameter)

--- a/src/backend/main/py.main/caliopen_main/user/parameters/identity.py
+++ b/src/backend/main/py.main/caliopen_main/user/parameters/identity.py
@@ -21,7 +21,7 @@ class LocalIdentity(Model):
     identifier = StringType(required=True)
     status = StringType()
     type = StringType()
-    user_id = UUIDType(required=True)
+    user_id = UUIDType()
 
 
 class NewRemoteIdentity(Model):
@@ -33,6 +33,6 @@ class NewRemoteIdentity(Model):
 
 
 class RemoteIdentity(NewRemoteIdentity):
-    user_id = UUIDType(required=True)
+    user_id = UUIDType()
     last_check = DateTimeType(serialized_format=helpers.RFC3339Milli,
                               tzd=u'utc')

--- a/src/backend/main/py.main/caliopen_main/user/parameters/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/parameters/user.py
@@ -43,7 +43,7 @@ class User(NewUser):
     password = StringType()     # not outpout by default, not required
     privacy_features = DictType(StringType, default=lambda: {}, )
     pi = ModelType(PIParameter)
-    user_id = UUIDType(required=True)
+    user_id = UUIDType()
 
     class Options:
         roles = {'default': blacklist('password')}


### PR DESCRIPTION
+ we do not rely anymore exclusively on swagger to validate in&out json docs, but make always use of objects' Schematics json_model.
+ consequently, "required" property of our json_models has been partially removed to permit the validation of partial docs.
+ fix issue #447 