### PR TITLE
Fix/backend/input doc validation

### DIFF
--- a/src/backend/interfaces/REST/py.server/caliopen_api/message/message.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/message/message.py
@@ -103,7 +103,8 @@ class Message(Api):
 
         message = ObjectMessage(self.user.user_id, message_id=message_id)
         try:
-            message.patch_draft(patch, db=True, index=True)
+            message.patch_draft(patch, db=True, index=True,
+                                with_validation=True)
         except Exception as exc:
             raise MergePatchError(exc)
 

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/contact.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/contact.py
@@ -51,8 +51,16 @@ class Contact(Api):
                          'offset': self.get_offset()}
         log.debug('Filter parameters {}'.format(filter_params))
         results = CoreContact._model_class.search(self.user, **filter_params)
-        data = [ReturnContact.build(CoreContact.get(self.user, x.contact_id)).
-                serialize() for x in results]
+        data = []
+        for item in results:
+            try:
+                c = ReturnContact.build(
+                    CoreContact.get(self.user, item.contact_id)). \
+                    serialize()
+                data.append(c)
+            except Exception as exc:
+                log.error("unable to serialize contact : {}".format(exc))
+
         return {'contacts': data, 'total': results.hits.total}
 
     @view(renderer='json', permission='authenticated')

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/contact.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/contact.py
@@ -97,7 +97,8 @@ class Contact(Api):
 
         contact = ContactObject(self.user.user_id, contact_id=contact_id)
         try:
-            contact.apply_patch(patch, db=True, index=True)
+            contact.apply_patch(patch, db=True, index=True,
+                                with_validation=True)
         except Exception as exc:
             raise MergePatchError(error=exc)
 

--- a/src/backend/main/py.main/caliopen_main/message/store/message_index.py
+++ b/src/backend/main/py.main/caliopen_main/message/store/message_index.py
@@ -51,7 +51,7 @@ class IndexedMessage(BaseIndexDocument):
     def create_mapping(cls, user_id):
         """Create elasticsearch mapping object for an user."""
         m = Mapping(cls.doc_type)
-        m.meta('_all', enabled=False)
+        m.meta('_all', enabled=True)
         m.field('attachments', Nested(doc_class=IndexedMessageAttachment,
                                       include_in_all=True))
         m.field('body_html', 'text')


### PR DESCRIPTION
This PR will : 
- adapt our python API to new schematics validation interface (schematics 2.0 since may 2017).
- Improve egress & ingress documents validation when calling PATCH verb on routes messages & contacts.