### PR TITLE
fix/frontend/Message

### DIFF
--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -15,40 +15,6 @@ import './style.scss';
 
 const DropdownControl = withDropdownControl(Button);
 
-const MessageInfosContainer = ({ __, message, author, locale }) => {
-  const typeTranslations = {
-    email: __('message-list.message.protocol.email'),
-  };
-
-  return (
-    <div className="m-message__infos-container">
-      <TextBlock className="m-message__author">{author.address}</TextBlock>
-      {message.type &&
-        (<div className="m-message__type">
-          <span className="m-message__type-label">
-            {__('message-list.message.by', { type: typeTranslations[message.type] })}
-          </span>
-          {' '}
-          <Icon type={message.type} className="m-message__type-icon" spaced />
-        </div>
-      )}
-      <Moment className="m-message__date" format="LT" locale={locale}>
-        {message.date}
-      </Moment>
-    </div>
-  );
-};
-
-MessageInfosContainer.propTypes = {
-  author: PropTypes.shape({}).isRequired,
-  message: PropTypes.shape({}).isRequired,
-  locale: PropTypes.string,
-  __: PropTypes.func.isRequired,
-};
-MessageInfosContainer.defaultProps = {
-  locale: undefined,
-};
-
 class Message extends Component {
   static propTypes = {
     message: PropTypes.shape({}).isRequired,
@@ -117,6 +83,9 @@ class Message extends Component {
     );
 
     const dropdownId = uuidV1();
+    const typeTranslations = {
+      email: __('message-list.message.protocol.email'),
+    };
 
     return (
       <div className="m-message">
@@ -130,12 +99,20 @@ class Message extends Component {
           <div className={topBarClassName}>
             <MultidimensionalPi pi={message.pi} className="m-message__pi" mini />
 
-            <MessageInfosContainer
-              message={message}
-              author={author}
-              locale={locale}
-              __={__}
-            />
+            <TextBlock className="m-message__author">{author.address}</TextBlock>
+            {message.type &&
+              (<div className="m-message__type">
+                <span className="m-message__type-label">
+                  {__('message-list.message.by', { type: typeTranslations[message.type] })}
+                </span>
+                {' '}
+                <Icon type={message.type} className="m-message__type-icon" spaced />
+              </div>
+            )}
+
+            <Moment className="m-message__date" format="LT" locale={locale}>
+              {message.date}
+            </Moment>
 
             <DropdownControl toggle={dropdownId} className="m-message__actions-switcher">
               <Icon type="ellipsis-v" />

--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -31,8 +31,8 @@ class Message extends Component {
 
   state = {
     body: '',
-    exerpt: '',
-    isExerpt: false,
+    excerpt: '',
+    isExcerpt: false,
     isTooLong: false,
   };
 
@@ -54,15 +54,15 @@ class Message extends Component {
     if (body.length > 140) {
       this.setState({
         isTooLong: true,
-        isExerpt: true,
-        exerpt: body.substring(0, 140),
+        isExcerpt: true,
+        excerpt: body.substring(0, 140),
       });
     }
   }
 
   handleExpandClick = () => {
     this.setState(prevState => ({
-      isExerpt: !prevState.isExerpt,
+      isExcerpt: !prevState.isExcerpt,
     }));
   }
 
@@ -73,7 +73,7 @@ class Message extends Component {
 
     const bodyClassName = classnames(
       'm-message__body',
-      { 'm-message__body--exerpt': this.state.isExerpt },
+      { 'm-message__body--excerpt': this.state.isExcerpt },
       { 'm-message__body--html': !message.body_is_plain },
     );
 
@@ -143,14 +143,14 @@ class Message extends Component {
             <pre
               className={bodyClassName}
               dangerouslySetInnerHTML={
-                { __html: this.state.isExerpt ? this.state.exerpt : message.body }
+                { __html: this.state.isExcerpt ? this.state.excerpt : message.body }
               }
             />
           ) : (
             <div
               className={bodyClassName}
               dangerouslySetInnerHTML={
-                { __html: this.state.isExerpt ? this.state.exerpt : message.body }
+                { __html: this.state.isExcerpt ? this.state.excerpt : message.body }
               }
             />
             )
@@ -160,10 +160,10 @@ class Message extends Component {
             <div className="m-message__expand-button">
               <Button
                 onClick={this.handleExpandClick}
-                value={this.state.isExerpt}
+                value={this.state.isExcerpt}
                 display="expanded"
               >
-                {this.state.isExerpt ? __('message-list.message.action.expand') : __('message-list.message.action.collapse')}
+                {this.state.isExcerpt ? __('message-list.message.action.expand') : __('message-list.message.action.collapse')}
               </Button>
             </div>
           }

--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -17,14 +17,6 @@ const FOLD_HEIGHT = 80; // = .m-message__content--fold height
 
 const DropdownControl = withDropdownControl(Button);
 
-function generateStateFromProps(props) {
-  const { message } = props;
-
-  return {
-    isUnread: message.is_unread,
-  };
-}
-
 class Message extends Component {
   static propTypes = {
     message: PropTypes.shape({}).isRequired,
@@ -42,16 +34,11 @@ class Message extends Component {
   state = {
     bodyHeight: null,
     isTooLong: false,
-    isFold: false,
-    isUnread: false,
+    isFold: true, // set fold state as default to avoid content's height animation on load
   };
 
-  componentWillMount() {
-    this.setState(prevState => generateStateFromProps(this.props, prevState));
-  }
-
   componentDidMount() {
-    this.setContentHeight();
+    setTimeout(this.setContentHeight, 1);
   }
 
   componentDidUpdate() {
@@ -63,13 +50,15 @@ class Message extends Component {
   }
 
   setContentHeight = () => {
+    const { message } = this.props;
     const bodyHeight = this.divElement.clientHeight;
+    const isTooLong = bodyHeight > FOLD_HEIGHT;
 
     this.setState(prevState => ({
       ...prevState,
       bodyHeight,
-      isTooLong: bodyHeight > FOLD_HEIGHT && true,
-      isFold: bodyHeight > FOLD_HEIGHT && !prevState.isUnread && true,
+      isTooLong,
+      isFold: isTooLong && !message.is_unread,
     }));
   }
 
@@ -91,7 +80,6 @@ class Message extends Component {
       ),
       style: {
         height: this.state.isFold ? null : this.state.bodyHeight,
-        transitionTimingFunction: this.state.isFold ? 'ease-in-out' : 'ease-out', // to make 'expand'/'collapse' animation smoother
         transitionDuration: `${((this.state.bodyHeight / 100) * 0.05)}s`, // to make 'expand'/'collapse' animation smoother
       },
     };
@@ -127,12 +115,12 @@ class Message extends Component {
 
     const topBarClassName = classnames(
       'm-message__top-bar',
-      { 'm-message__top-bar--is-unread': this.state.isUnread },
+      { 'm-message__top-bar--is-unread': message.is_unread },
     );
 
     const subjectClassName = classnames(
       'm-message__subject',
-      { 'm-message__subject--is-unread': this.state.isUnread },
+      { 'm-message__subject--is-unread': message.is_unread },
     );
 
     return (
@@ -141,6 +129,7 @@ class Message extends Component {
           <ContactAvatarLetter
             contact={author}
             className="m-message__avatar"
+            contactDisplayFormat="address"
           />
         </div>
         <div className="m-message__container">

--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -6,6 +6,7 @@ import ContactAvatarLetter from '../../../ContactAvatarLetter';
 import Dropdown, { withDropdownControl } from '../../../../components/Dropdown';
 import Button from '../../../Button';
 import Icon from '../../../Icon';
+import TextBlock from '../../../TextBlock';
 import MultidimensionalPi from '../../../MultidimensionalPi';
 
 import MessageActionsContainer from '../MessageActionsContainer';
@@ -21,7 +22,7 @@ const MessageInfosContainer = ({ __, message, author, locale }) => {
 
   return (
     <div className="m-message__infos-container">
-      <div className="m-message__author">{author.address}</div>
+      <TextBlock className="m-message__author">{author.address}</TextBlock>
       {message.type &&
         (<div className="m-message__type">
           <span className="m-message__type-label">
@@ -62,17 +63,12 @@ class Message extends Component {
     locale: undefined,
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      body: '',
-      isExpanded: true,
-      isTooLong: false,
-      isActive: false,
-    };
-    this.handleActiveClick = this.handleActiveClick.bind(this);
-    this.handleExpandClick = this.handleExpandClick.bind(this);
-  }
+  state = {
+    body: '',
+    exerpt: '',
+    isExerpt: false,
+    isTooLong: false,
+  };
 
   componentDidMount() {
     this.setBodyHeight();
@@ -86,34 +82,21 @@ class Message extends Component {
     }
   }
 
-  setBodyHeight() {
+  setBodyHeight = () => {
     const message = this.props.message;
     const body = message.body;
     if (body.length > 140) {
       this.setState({
         isTooLong: true,
-        isExpanded: false,
-        body: body.substring(0, 140),
-      });
-    } else {
-      this.setState({
-        body,
+        isExerpt: true,
+        exerpt: body.substring(0, 140),
       });
     }
   }
 
-  handleActiveClick() {
+  handleExpandClick = () => {
     this.setState(prevState => ({
-      isActive: !prevState.isActive,
-    }));
-  }
-
-  handleExpandClick() {
-    const message = this.props.message;
-    const body = message.body;
-    this.setState(prevState => ({
-      isExpanded: !prevState.isExpanded,
-      body: prevState.isExpanded ? body.substring(0, 140) : body,
+      isExerpt: !prevState.isExerpt,
     }));
   }
 
@@ -121,13 +104,16 @@ class Message extends Component {
     const { message, locale, onDelete, __ } = this.props;
     const author = message.participants.find(participant => participant.type === 'From');
     const subject = message.subject;
+
+    const bodyClassName = classnames(
+      'm-message__body',
+      { 'm-message__body--exerpt': this.state.isExerpt },
+      { 'm-message__body--html': !message.body_is_plain },
+    );
+
     const topBarClassName = classnames(
       'm-message__top-bar',
-      { 'm-message__top-bar--active': this.state.isActive }
-    );
-    const bodyClassName = classnames(
-      'm-message__body__content',
-      { 'm-message__body__content--expanded': this.state.isExpanded }
+      { 'm-message__top-bar--new': message.is_unread },
     );
 
     const dropdownId = uuidV1();
@@ -140,7 +126,7 @@ class Message extends Component {
             className="m-message__avatar"
           />
         </div>
-        <div className="m-message__content">
+        <div className="m-message__container">
           <div className={topBarClassName}>
             <MultidimensionalPi pi={message.pi} className="m-message__pi" mini />
 
@@ -171,21 +157,36 @@ class Message extends Component {
 
           </div>
 
-          <div className="m-message__body">
-            {subject &&
-              <div className="m-message__body__subject">{subject}</div>
-            }
-            <div className={bodyClassName} dangerouslySetInnerHTML={{ __html: this.state.body }} />
-          </div>
+          {subject &&
+            <TextBlock className="m-message__subject">
+              <Icon type="comments-o" rightSpaced />{subject}
+            </TextBlock>
+          }
+          {message.body_is_plain ? (
+            <pre
+              className={bodyClassName}
+              dangerouslySetInnerHTML={
+                { __html: this.state.isExerpt ? this.state.exerpt : message.body }
+              }
+            />
+          ) : (
+            <div
+              className={bodyClassName}
+              dangerouslySetInnerHTML={
+                { __html: this.state.isExerpt ? this.state.exerpt : message.body }
+              }
+            />
+            )
+          }
 
           {this.state.isTooLong &&
             <div className="m-message__expand-button">
               <Button
                 onClick={this.handleExpandClick}
-                value={this.state.isExpanded}
-                title={this.state.isExpanded ? __('message-list.message.action.collapse') : __('message-list.message.action.expand')}
+                value={this.state.isExerpt}
+                display="expanded"
               >
-                {this.state.isExpanded ? __('message-list.message.action.collapse') : __('message-list.message.action.expand')}
+                {this.state.isExerpt ? __('message-list.message.action.expand') : __('message-list.message.action.collapse')}
               </Button>
             </div>
           }

--- a/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
@@ -1,5 +1,6 @@
 @import '../../../../styles/vendor/bootstrap_foundation-sites';
 @import '../../../../styles/object/o-avatar';
+@import '../../../../styles/object/o-reset-html-message';
 
 .m-message {
   @include flex-grid-row($size: expand);
@@ -23,9 +24,26 @@
 
   &__top-bar {
     @include flex-grid-row($size: expand);
-    justify-content: center;
+    align-items: center;
     border-bottom: 1px solid $co-color__fg__back--lower;
     background: $co-color__fg__back--higher;
+  }
+
+  &__type {  @include flex-grid-size(shrink); }
+  &__type-icon { color: $co-color__fg__text; }
+  &__type-label { display: none; }
+
+  &__pi { @include flex-grid-size(shrink); }
+
+  &__author {
+    @include flex-grid-column;
+    color: $co-color__fg__text--high;
+    font-weight: 600;
+  }
+
+  &__date {
+    @include flex-grid-column(shrink);
+    margin-left: auto;
   }
 
   &__actions-switcher {
@@ -60,16 +78,7 @@
       }
     }
 
-    &--html {
-      blockquote {
-        display: block;
-        margin-left: $co-component__spacing / 2;
-        padding: $co-component__spacing;
-        border-left: 2px solid $co-color__fg__back--high;
-        color: $co-color__fg__text--lower;
-        font-size: $co-font__size--small;
-      }
-    }
+    &--html { @include o-reset-html-message; }
   }
 
   &__expand-button {
@@ -78,29 +87,6 @@
     color: $co-color__fg__text--lower;
     line-height: $co-component__height;
     text-align: center;
-  }
-
-  &__infos-container {
-    @include flex-grid-row($size: expand);
-    flex: 1;
-    align-items: center;
-  }
-
-  &__type {  @include flex-grid-size(shrink); }
-  &__type-icon { color: $co-color__fg__text; }
-  &__type-label { display: none; }
-
-  &__pi { @include flex-grid-size(shrink); }
-
-  &__author {
-    @include flex-grid-column;
-    color: $co-color__fg__text--high;
-    font-weight: 600;
-  }
-
-  &__date {
-    @include flex-grid-column(shrink);
-    margin-left: auto;
   }
 
   @include breakpoint(medium) {

--- a/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
@@ -3,9 +3,23 @@
 
 .m-message {
   @include flex-grid-row($size: expand);
+  margin-bottom: $co-grid__gutter--small;
   font-size: $co-font__size--small;
 
-  &__content { @include flex-grid-size; }
+  &__avatar-col {
+    @include flex-grid-column(shrink);
+    display: none;
+    padding-top: $co-component__spacing;
+  }
+
+  &__avatar { @include m-avatar--size(medium); }
+
+  &__container {
+    @include flex-grid-column;
+    padding-right: 0;
+    padding-left: 0;
+    background: $co-color__fg__back;
+  }
 
   &__top-bar {
     @include flex-grid-row($size: expand);
@@ -21,56 +35,65 @@
 
   &__actions-menu { background: $co-color__fg__back--higher; }
 
-  &__body {
-    @include flex-grid-column(12);
-    padding-top: $co-component__spacing;
-    padding-bottom: $co-component__spacing;
-    background: $co-color__fg__back;
-    overflow: hidden;
 
-    &__content {
-      padding: $co-component__spacing 0;
-      color: $co-color__fg__text--low;
+  &__subject {
+    padding: $co-component__spacing;
+    border-bottom: 1px solid $co-color__fg__back--lower;
+    color: $co-color__fg__text--lower;
+  }
+
+  &__body {
+    padding: $co-component__spacing;
+    overflow: hidden;
+    color: $co-color__fg__text;
+
+    &--exerpt {
+      &,
+      > * {
+        display: inline-block;
+      }
 
       &::after {
         display: inline;
         content: ' [...]';
-      }
-
-      &--expanded {
-        &::after {  display: none; }
+        color: $co-color__fg__text--lower;
       }
     }
 
-    &__subject { color: $co-color__fg__text--lower; }
+    &--html {
+      blockquote {
+        display: block;
+        margin-left: $co-component__spacing / 2;
+        padding: $co-component__spacing;
+        border-left: 2px solid $co-color__fg__back--high;
+        color: $co-color__fg__text--lower;
+        font-size: $co-font__size--small;
+      }
+    }
   }
 
   &__expand-button {
-    @include flex-grid-size(12);
     border-top: 1px solid $co-color__fg__back--lower;
     background: $co-color__fg__back--high;
     color: $co-color__fg__text--lower;
+    line-height: $co-component__height;
     text-align: center;
-
   }
 
   &__infos-container {
     @include flex-grid-row($size: expand);
     flex: 1;
     align-items: center;
-    justify-content: center;
   }
 
   &__type {  @include flex-grid-size(shrink); }
-
   &__type-icon { color: $co-color__fg__text; }
+  &__type-label { display: none; }
 
-  &__pi {
-    @include flex-grid-size(shrink);
-  }
+  &__pi { @include flex-grid-size(shrink); }
 
   &__author {
-    @include flex-grid-column(shrink);
+    @include flex-grid-column;
     color: $co-color__fg__text--high;
     font-weight: 600;
   }
@@ -80,28 +103,14 @@
     margin-left: auto;
   }
 
-  @include breakpoint(small) {
-    margin-bottom: $co-grid__gutter--small;
-    &__avatar-col {  flex: none;  }
-    &__avatar { display: none; }
-    &__type-label { display: none; }
-  }
-
-  @include breakpoint(medium-small) {
-    &__avatar-col {
-      @include flex-grid-column(shrink);
-      padding-top: $co-component__spacing;
-    }
-
-    &__avatar {
-      @include m-avatar--size(small);
-      display: block;
-    }
-  }
-
   @include breakpoint(medium) {
     margin-bottom: $co-grid__gutter;
-    &__avatar {  @include m-avatar--size(medium); }
+
+    &__container {
+      padding-right: 0;
+      padding-left: 0;
+    }
+    &__avatar-col { display: flex; }
     &__type-label { display: inline; }
   }
 }

--- a/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
@@ -74,13 +74,14 @@ $message-content--fold__height: 80px; // = const FOLD_HEIGHT
     position: relative;
     transition-duration: .15s; // transition-duration is overrided by JS
     transition-property: height;
-    transition-timing-function: ease-out; // transition-timing-function is overrided by JS
+    transition-timing-function: ease-out;
     overflow: hidden;
     color: $co-color__fg__text;
     box-sizing: content-box;
 
     &--fold {
       height: $message-content--fold__height;
+      transition-timing-function: ease-in;
 
       &::before {
         display: block;

--- a/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
@@ -65,7 +65,7 @@
     overflow: hidden;
     color: $co-color__fg__text;
 
-    &--exerpt {
+    &--excerpt {
       &,
       > * {
         display: inline-block;

--- a/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/style.scss
@@ -2,6 +2,8 @@
 @import '../../../../styles/object/o-avatar';
 @import '../../../../styles/object/o-reset-html-message';
 
+$message-content--fold__height: 80px; // = const FOLD_HEIGHT
+
 .m-message {
   @include flex-grid-row($size: expand);
   margin-bottom: $co-grid__gutter--small;
@@ -26,7 +28,11 @@
     @include flex-grid-row($size: expand);
     align-items: center;
     border-bottom: 1px solid $co-color__fg__back--lower;
-    background: $co-color__fg__back--higher;
+    background: $co-color__fg__back--high;
+
+    &--is-unread {
+      background: $co-color__fg__back--higher;
+    }
   }
 
   &__type {  @include flex-grid-size(shrink); }
@@ -53,32 +59,45 @@
 
   &__actions-menu { background: $co-color__fg__back--higher; }
 
-
   &__subject {
     padding: $co-component__spacing;
     border-bottom: 1px solid $co-color__fg__back--lower;
     color: $co-color__fg__text--lower;
+
+    &--is-unread {
+      background: $co-color__fg__back--higher;
+      color: $co-color__fg__text;
+    }
+  }
+
+  &__content {
+    position: relative;
+    transition-duration: .15s; // transition-duration is overrided by JS
+    transition-property: height;
+    transition-timing-function: ease-out; // transition-timing-function is overrided by JS
+    overflow: hidden;
+    color: $co-color__fg__text;
+    box-sizing: content-box;
+
+    &--fold {
+      height: $message-content--fold__height;
+
+      &::before {
+        display: block;
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: $message-content--fold__height / 2;
+        background: linear-gradient(to bottom, transparent, $co-color__fg__back);
+      }
+    }
   }
 
   &__body {
     padding: $co-component__spacing;
-    overflow: hidden;
-    color: $co-color__fg__text;
-
-    &--excerpt {
-      &,
-      > * {
-        display: inline-block;
-      }
-
-      &::after {
-        display: inline;
-        content: ' [...]';
-        color: $co-color__fg__text--lower;
-      }
-    }
-
-    &--html { @include o-reset-html-message; }
+    &--rich-text { @include o-reset-html-message; }
   }
 
   &__expand-button {

--- a/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/components/Ratings/style.scss
@@ -1,8 +1,9 @@
 @import '../../../../styles/common';
 @import '../../../../styles/vendor/bootstrap_foundation-sites';
 
-$mini-pi-bar__height:  .35rem;
-$mini-pi-bar__margin: .25rem;
+$mini-pi-bar__height:  6px;
+$mini-pi-bar__margin: 1px;
+$mini-pi__height: 3 * ($mini-pi-bar__height + ($mini-pi-bar__margin * 2));
 
 .m-pi-ratings {
   max-width: map-get($co-pi-width, 'ratings');
@@ -14,7 +15,7 @@ $mini-pi-bar__margin: .25rem;
   &__item {
     @include flex-grid-row;
     align-items: center;
-    margin-top: $co-component__spacing;
+    padding-top: $co-component__spacing;
   }
 
   &__item-name {
@@ -44,19 +45,22 @@ $mini-pi-bar__margin: .25rem;
   }
 
   &--mini {
-    max-width: map-get($co-pi-width, 'mini-ratings');
+    width: $mini-pi__height;
+    max-width: $mini-pi__height;
+    padding: $co-component__spacing;
     cursor: help;
+    box-sizing: content-box;
 
     &__item {
       display: block;
-      width: map-get($co-pi-width, 'mini-ratings');;
+      width: 100%;
       max-width: 100%;
-      margin: $mini-pi-bar__margin 0;
+      padding: $mini-pi-bar__margin 0;
     }
 
     &__item-level {
       display: block;
-      width: map-get($co-pi-width, 'mini-ratings');
+      width: 100%;
       max-width: 100%;
     }
 

--- a/src/frontend/web_application/src/components/MultidimensionalPi/style.scss
+++ b/src/frontend/web_application/src/components/MultidimensionalPi/style.scss
@@ -13,10 +13,12 @@
 
   &__toggle-mini-pi {
     flex: auto;
+    padding: 0;
 
+    &,
     &:hover,
     &:active {
-      background: $co-color__fg__back--high;
+      background: inherit;
     }
   }
 
@@ -28,8 +30,8 @@
     box-shadow: $co-shadow;
 
     &::before {
-      @include o-triangle('top', .75rem, $co-color__fg__back--lower);
-      left: 1rem;
+      @include o-triangle('top', .5rem, $co-color__fg__back--lower);
+      left: .5rem;
     }
   }
 }

--- a/src/frontend/web_application/src/layouts/Page/style.scss
+++ b/src/frontend/web_application/src/layouts/Page/style.scss
@@ -17,7 +17,7 @@ $navigation-after__height: $co-component__spacing;
 .l-body {
   &__content {
     // XXX: need a better fix for call-to-action override on mobile
-    margin-bottom: 160px;
+    margin-bottom: 280px;
   }
 
   @include breakpoint(medium) {

--- a/src/frontend/web_application/src/styles/base/reset.scss
+++ b/src/frontend/web_application/src/styles/base/reset.scss
@@ -20,6 +20,20 @@ dd,
 dl,
 ul,
 li {
+  list-style: none;
   margin: 0;
   padding: 0;
+}
+
+pre {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+blockquote {
+  margin: 0;
 }

--- a/src/frontend/web_application/src/styles/config/config.scss
+++ b/src/frontend/web_application/src/styles/config/config.scss
@@ -2,7 +2,7 @@ $co-brand-width: 10rem;
 $co-pi-width: (
   graph: 15rem,
   ratings: 17rem,
-  mini-ratings: 2rem,
+  mini-ratings: 1rem,
 );
 
 $co-margin: 1.5rem;

--- a/src/frontend/web_application/src/styles/object/o-reset-html-message.scss
+++ b/src/frontend/web_application/src/styles/object/o-reset-html-message.scss
@@ -1,0 +1,15 @@
+@mixin o-reset-html-message {
+  * {
+    width: auto;
+    max-width: 100%;
+  }
+
+  blockquote {
+    display: block;
+    margin-left: $co-component__spacing / 2;
+    padding: $co-component__spacing;
+    border-left: 2px solid $co-color__fg__back--high;
+    color: $co-color__fg__text--lower;
+    font-size: $co-font__size--small;
+  }
+}

--- a/src/frontend/web_application/src/styles/object/o-reset-html-message.scss
+++ b/src/frontend/web_application/src/styles/object/o-reset-html-message.scss
@@ -4,6 +4,13 @@
     max-width: 100%;
   }
 
+  > * {
+    &:first-child {
+      margin-top: 0;
+      padding-top: 0;
+    }
+  }
+
   blockquote {
     display: block;
     margin-left: $co-component__spacing / 2;

--- a/src/frontend/web_application/test/functional/features/21-reply-to-messag-spec.js
+++ b/src/frontend/web_application/test/functional/features/21-reply-to-messag-spec.js
@@ -160,7 +160,7 @@ describe('Save a draft and send', () => {
       .then(() => {
         const draftBodyElement1 = element(by.css('.m-discussion-textarea__body'));
         expect(draftBodyElement1.getText()).toEqual('');
-        expect(element(by.cssContainingText('.m-message__body__content', text1)).isPresent()).toEqual(true);
+        expect(element(by.cssContainingText('.m-message__body', text1)).isPresent()).toEqual(true);
       })
       ;
   });


### PR DESCRIPTION
Fix issue https://github.com/CaliOpen/Caliopen/issues/455
- Display pre or html depends on body_is_plain
- override html messages inline styles with default styles
- fix `<Message>` styles (avatar col and top bar)