### PR TITLE
Compute inbound importance level, v0

### DIFF
--- a/devtools/run-tests.sh
+++ b/devtools/run-tests.sh
@@ -25,6 +25,7 @@ function do_backend_tests {
 
     export CALIOPEN_BASEDIR=${PROJECT_DIRECTORY}
     nosetests -sv src/backend/main/py.main/caliopen_main/tests
+    nosetests -sv src/backend/components/py.pi/caliopen_pi/tests
 }
 
 function do_frontend_tests {

--- a/src/backend/components/py.pi/caliopen_pi/features/importance_level.py
+++ b/src/backend/components/py.pi/caliopen_pi/features/importance_level.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""Compute Caliopen message importance level."""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import logging
+
+log = logging.getLogger(__name__)
+
+# Importance level is between MIN_VALUE and MAX_VALUE (inclusives)
+MIN_VALUE = -10
+MAX_VALUE = 10
+MAX_TAG_SCORE = 10  # Max importance level that can be set for a tag
+
+SPAM_RATIO = 0.5
+# Le PI contexte du message compte pour 1/8 des points positifs
+PI_CX_RATIO = 1.0 / 8.0
+# le PI comportement du message compte à lui seul pour 1/4 des points positifs
+PI_CO_RATIO = 1.0 / 4.0
+# Les éléments contextuels (tags associés, association du type de terminal
+# au protocole utilisé, horaire, langue...) comptent pour 1/8 des points
+# positifs.
+CONTEXT_RATIO = 1.0 / 8.0
+
+REPLY_VALUE = 2.0
+
+
+def get_importance_tags(tags):
+    """Get the max importance level from tags."""
+    max_value = 0
+    for tag in tags:
+        if getattr(tag, 'importance_level'):
+            if tag.importance_level > max_value:
+                max_value = tag.importance_level
+    return max_value
+
+
+def compute_inbound(user, message, participants):
+    """Compute importance level for an inbound message."""
+    positive = 0
+    negative = 0
+    scores = []
+    # Spam level
+    if message.privacy_features.get('is_spam'):
+        spam_score = message.privacy_features.get('spam_score', 0) / 100.0
+        negative -= spam_score * abs(MIN_VALUE * SPAM_RATIO)
+        scores.append(('spam_score', spam_score))
+    # PI message
+    if message.pi.context:
+        context_score = message.pi.context / 100.0
+        positive += context_score * PI_CX_RATIO
+        scores.append(('context_score', context_score))
+    if message.pi.comportment:
+        comportment_score = message.pi.comportment / 100.0
+        positive += comportment_score * PI_CO_RATIO
+        scores.append(('comportment_score', comportment_score))
+    # Tags
+    if message.tags:
+        tag_score = get_importance_tags(message.tags)
+        positive += tag_score / MAX_TAG_SCORE * CONTEXT_RATIO
+        scores.append(('tag_score', tag_score))
+
+    # It's a reply ?
+    if message.external_references:
+        # XXX find if we know related messages to increment level
+        positive += REPLY_VALUE
+        scores.append('reply_score', REPLY_VALUE)
+
+    log.info('Importance scores: {0}'.format(scores))
+    # Return the final value
+    if negative:
+        return max(MIN_VALUE, negative)
+    return min(MAX_VALUE, positive)

--- a/src/backend/components/py.pi/caliopen_pi/features/importance_level.py
+++ b/src/backend/components/py.pi/caliopen_pi/features/importance_level.py
@@ -69,5 +69,5 @@ def compute_inbound(user, message, features, participants):
     log.info('Importance scores: {0}'.format(scores))
     # Return the final value
     if negative:
-        return max(MIN_VALUE, negative)
-    return min(MAX_VALUE, positive)
+        return round(max(MIN_VALUE, negative))
+    return round(min(MAX_VALUE, positive))

--- a/src/backend/components/py.pi/caliopen_pi/features/importance_level.py
+++ b/src/backend/components/py.pi/caliopen_pi/features/importance_level.py
@@ -35,24 +35,24 @@ def get_importance_tags(tags):
     return max_value
 
 
-def compute_inbound(user, message, participants):
+def compute_inbound(user, message, features, participants):
     """Compute importance level for an inbound message."""
     positive = 0
     negative = 0
     scores = []
     # Spam level
-    if message.privacy_features.get('is_spam'):
-        spam_score = message.privacy_features.get('spam_score', 0) / 100.0
+    if features.get('is_spam'):
+        spam_score = features.get('spam_score', 0) / 100.0
         negative -= spam_score * abs(MIN_VALUE * SPAM_RATIO)
         scores.append(('spam_score', spam_score))
     # PI message
     if message.pi.context:
         context_score = message.pi.context / 100.0
-        positive += context_score * PI_CX_RATIO
+        positive += context_score * PI_CX_RATIO * MAX_VALUE
         scores.append(('context_score', context_score))
     if message.pi.comportment:
         comportment_score = message.pi.comportment / 100.0
-        positive += comportment_score * PI_CO_RATIO
+        positive += comportment_score * PI_CO_RATIO * MAX_VALUE
         scores.append(('comportment_score', comportment_score))
     # Tags
     if message.tags:
@@ -64,7 +64,7 @@ def compute_inbound(user, message, participants):
     if message.external_references:
         # XXX find if we know related messages to increment level
         positive += REPLY_VALUE
-        scores.append('reply_score', REPLY_VALUE)
+        scores.append(('reply_score', REPLY_VALUE))
 
     log.info('Importance scores: {0}'.format(scores))
     # Return the final value

--- a/src/backend/components/py.pi/caliopen_pi/features/mail.py
+++ b/src/backend/components/py.pi/caliopen_pi/features/mail.py
@@ -8,8 +8,9 @@ import pgpy
 
 from caliopen_main.pi.parameters import PIParameter
 from .spam import SpamScorer
-from .types import unmarshall_features
 from .ingress_path import get_ingress_features
+from .types import unmarshall_features
+from .importance_level import compute_inbound as compute_inbound_importance
 
 log = logging.getLogger(__name__)
 
@@ -188,10 +189,12 @@ class InboundMailFeature(object):
                             'comportment': sum(pi_co.values()),
                             'version': 0})
 
-    def process(self, message, participants):
+    def process(self, user, message, participants):
         """
         Process the message for privacy features and PI compute.
 
+        :param user: user the message belong to
+        :ptype user: caliopen_main.user.core.User
         :param message: a message parameter that will be updated with PI
         :ptype message: NewMessage
         :param participants: an array of participant with related Contact
@@ -199,4 +202,6 @@ class InboundMailFeature(object):
         """
         features = self._get_features()
         message.pi = self._compute_pi(participants, features)
+        il = compute_inbound_importance(user, message, features, participants)
         message.privacy_features = unmarshall_features(features)
+        message.importance_level = il

--- a/src/backend/components/py.pi/caliopen_pi/qualifier.py
+++ b/src/backend/components/py.pi/caliopen_pi/qualifier.py
@@ -124,7 +124,7 @@ class UserMessageQualifier(object):
         # Compute PI !!
         conf = Configuration('global').configuration
         extractor = InboundMailFeature(message, conf)
-        extractor.process(new_message, participants)
+        extractor.process(self.user, new_message, participants)
 
         # compute tags
         new_message.tags = self._get_tags(message)

--- a/src/backend/components/py.pi/caliopen_pi/tests/test_importance_level.py
+++ b/src/backend/components/py.pi/caliopen_pi/tests/test_importance_level.py
@@ -39,32 +39,32 @@ class TestInboundImportanceLevel(unittest.TestCase):
         features = {'is_spam': True, 'spam_score': 100.0}
         message = MockMessage(pi)
         score = compute_inbound(None, message, features, [])
-        self.assertEqual(score, -5.0)
+        self.assertEqual(score, -5)
 
     def test_half_spam(self):
         pi = MockPI(0, 0, 0)
         features = {'is_spam': True, 'spam_score': 50.0}
         message = MockMessage(pi)
         score = compute_inbound(None, message, features, [])
-        self.assertEqual(score, -2.5)
+        self.assertEqual(score, -3)
 
     def test_max_pi_context(self):
         pi = MockPI(0, 100, 0)
         features = {}
         message = MockMessage(pi)
         score = compute_inbound(None, message, features, [])
-        self.assertEqual(score, 1.25)
+        self.assertEqual(score, 1)
 
     def test_max_pi_comportment(self):
         pi = MockPI(0, 0, 100)
         features = {}
         message = MockMessage(pi)
         score = compute_inbound(None, message, features, [])
-        self.assertEqual(score, 2.5)
+        self.assertEqual(score, 3)
 
     def test_max_pi_context_comportment(self):
         pi = MockPI(0, 100, 100)
         features = {}
         message = MockMessage(pi)
         score = compute_inbound(None, message, features, [])
-        self.assertEqual(score, 3.75)
+        self.assertEqual(score, 4)

--- a/src/backend/components/py.pi/caliopen_pi/tests/test_importance_level.py
+++ b/src/backend/components/py.pi/caliopen_pi/tests/test_importance_level.py
@@ -1,0 +1,71 @@
+"""Test importance level compute."""
+
+import unittest
+import os
+
+from caliopen_storage.config import Configuration
+
+if 'CALIOPEN_BASEDIR' in os.environ:
+    conf_file = '{}/src/backend/configs/caliopen.yaml.template'. \
+                format(os.environ['CALIOPEN_BASEDIR'])
+else:
+    conf_file = '../../../../../configs/caliopen.yaml.template'
+
+Configuration.load(conf_file, 'global')
+
+from caliopen_pi.features.importance_level import compute_inbound
+
+
+class MockPI(object):
+
+    def __init__(self, technic, context, comportment):
+        self.technic = technic
+        self.context = context
+        self.comportment = comportment
+
+
+class MockMessage(object):
+
+    def __init__(self, pi, features, tags=None, refs=None):
+        self.pi = pi
+        self.privacy_features = features
+        self.tags = tags if tags else []
+        self.external_references = refs if refs else []
+
+
+class TestInboundImportanceLevel(unittest.TestCase):
+
+    def test_max_spam(self):
+        pi = MockPI(0, 0, 0)
+        features = {'is_spam': True, 'spam_score': 100.0}
+        message = MockMessage(pi, features)
+        score = compute_inbound(None, message, [])
+        self.assertEqual(score, -5.0)
+
+    def test_half_spam(self):
+        pi = MockPI(0, 0, 0)
+        features = {'is_spam': True, 'spam_score': 50.0}
+        message = MockMessage(pi, features)
+        score = compute_inbound(None, message, [])
+        self.assertEqual(score, -2.5)
+
+    def test_max_pi_context(self):
+        pi = MockPI(0, 100, 0)
+        features = {}
+        message = MockMessage(pi, features)
+        score = compute_inbound(None, message, [])
+        self.assertEqual(score, 1.25)
+
+    def test_max_pi_comportment(self):
+        pi = MockPI(0, 0, 100)
+        features = {}
+        message = MockMessage(pi, features)
+        score = compute_inbound(None, message, [])
+        self.assertEqual(score, 2.5)
+
+    def test_max_pi_context_comportment(self):
+        pi = MockPI(0, 100, 100)
+        features = {}
+        message = MockMessage(pi, features)
+        score = compute_inbound(None, message, [])
+        self.assertEqual(score, 3.75)

--- a/src/backend/components/py.pi/caliopen_pi/tests/test_importance_level.py
+++ b/src/backend/components/py.pi/caliopen_pi/tests/test_importance_level.py
@@ -26,9 +26,8 @@ class MockPI(object):
 
 class MockMessage(object):
 
-    def __init__(self, pi, features, tags=None, refs=None):
+    def __init__(self, pi, tags=None, refs=None):
         self.pi = pi
-        self.privacy_features = features
         self.tags = tags if tags else []
         self.external_references = refs if refs else []
 
@@ -38,34 +37,34 @@ class TestInboundImportanceLevel(unittest.TestCase):
     def test_max_spam(self):
         pi = MockPI(0, 0, 0)
         features = {'is_spam': True, 'spam_score': 100.0}
-        message = MockMessage(pi, features)
-        score = compute_inbound(None, message, [])
+        message = MockMessage(pi)
+        score = compute_inbound(None, message, features, [])
         self.assertEqual(score, -5.0)
 
     def test_half_spam(self):
         pi = MockPI(0, 0, 0)
         features = {'is_spam': True, 'spam_score': 50.0}
-        message = MockMessage(pi, features)
-        score = compute_inbound(None, message, [])
+        message = MockMessage(pi)
+        score = compute_inbound(None, message, features, [])
         self.assertEqual(score, -2.5)
 
     def test_max_pi_context(self):
         pi = MockPI(0, 100, 0)
         features = {}
-        message = MockMessage(pi, features)
-        score = compute_inbound(None, message, [])
+        message = MockMessage(pi)
+        score = compute_inbound(None, message, features, [])
         self.assertEqual(score, 1.25)
 
     def test_max_pi_comportment(self):
         pi = MockPI(0, 0, 100)
         features = {}
-        message = MockMessage(pi, features)
-        score = compute_inbound(None, message, [])
+        message = MockMessage(pi)
+        score = compute_inbound(None, message, features, [])
         self.assertEqual(score, 2.5)
 
     def test_max_pi_context_comportment(self):
         pi = MockPI(0, 100, 100)
         features = {}
-        message = MockMessage(pi, features)
-        score = compute_inbound(None, message, [])
+        message = MockMessage(pi)
+        score = compute_inbound(None, message, features, [])
         self.assertEqual(score, 3.75)

--- a/src/backend/components/py.pi/caliopen_pi/tests/test_spam.py
+++ b/src/backend/components/py.pi/caliopen_pi/tests/test_spam.py
@@ -1,4 +1,4 @@
-"""Test mail message format processing."""
+"""Test spam privacy feature extraction."""
 
 import unittest
 import os


### PR DESCRIPTION
First compute of importance level for an inbound message.

Only simple conditions are implemented regarding all those defined in https://pad.caliopen.org/p/importance