### PR TITLE
Make cassandra protocol_version configurable for python services

### DIFF
--- a/src/backend/configs/caliopen-docker.yaml
+++ b/src/backend/configs/caliopen-docker.yaml
@@ -18,6 +18,7 @@ cassandra:
     hosts:
         - 'cassandra.dev.caliopen.org'
     consistency_level: 1
+    protocol_version: 3
 
 lmtp:
     port: 4025

--- a/src/backend/configs/caliopen.yaml.template
+++ b/src/backend/configs/caliopen.yaml.template
@@ -9,6 +9,7 @@ cassandra:
     hosts:
         - 'cassandra.dev.caliopen.org'
     consistency_level: 1
+    protocol_version: 3
 
 lmtp:
     port: 4025

--- a/src/backend/main/py.storage/caliopen_storage/helpers/connection.py
+++ b/src/backend/main/py.storage/caliopen_storage/helpers/connection.py
@@ -12,9 +12,11 @@ def connect_storage():
         kwargs = {'connection_class': LibevConnection}
     except ImportError:
         kwargs = {}
-    setup_cassandra(Configuration('global').get('cassandra.hosts'),
-                    Configuration('global').get('cassandra.keyspace'),
-                    Configuration('global').get('cassandra.consistency_level'),
+    hosts = Configuration('global').get('cassandra.hosts')
+    keyspace = Configuration('global').get('cassandra.keyspace')
+    consistency = Configuration('global').get('cassandra.consistency_level')
+    protocol = Configuration('global').get('cassandra.protocol_version')
+    setup_cassandra(hosts, keyspace, consistency,
                     lazy_connect=True,
-                    protocol_version=4,
+                    protocol_version=protocol,
                     **kwargs)


### PR DESCRIPTION
Using scylladb we must use protocol_version = 3 to avoid some warning (and automatic downgrade of protocol by python driver).

This pull request permit to define the protocol_version in yaml configuration file