### PR TITLE
Feature/backend/importance level filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - Connect settings and apply
+- The brand new Timeline
+- Load more in the discussions
 
 ## [0.3.0] 2017-08-31
 

--- a/devtools/api-mock/messages/data.json
+++ b/devtools/api-mock/messages/data.json
@@ -1,6 +1,7 @@
 [{
 	"attachments": [],
 	"body": "<p>It's okay, Bender. I like cooking too. You, minion. Lift my arm. AFTER H=\r\nIM! I don't know what you did, Fry, but once again, you screwed up! Now all\r\nthe planets are gonna start cracking wise abo",
+	"excerpt": "It's okay, Bender. I like cooking too. You, minion. Lift my arm. AFTER HIM! I don't ...",
 	"date": "2017-03-21T10:55:00.153000+00:00",
 	"date_insert": "2017-03-21T10:55:00.153000+00:00",
 	"discussion_id": "cd53e13a-267d-4d9c-97ee-d0fc59c64200",
@@ -49,6 +50,7 @@
 }, {
 	"attachments": [],
 	"body": "Fry! Stay back! He's too powerful! Can I use the gun? I barely knew Philip, but as a clergyman I have no problem telling his most intimate friends all about him. What are you hacking off? Is it my torso?! 'It is!' My precious torso!",
+	"excerpt": "Fry! Stay back! He's too powerful! Can I use the gun? I barely knew Philip, but as a ...",
 	"date": "2017-03-21T12:55:00.153000+00:00",
 	"date_insert": "2017-03-21T12:55:00.153000+00:00",
 	"discussion_id": "cd53e13a-267d-4d9c-97ee-d0fc59c64200",
@@ -97,6 +99,7 @@
 {
 	"attachments": [],
 	"body": "Shut up and take my money! Leela, are you alright? You got wanged on the he=\r\nad. Bender, you risked your life To save me! Spare me your space age techno=\r\nbabble, Attila the Hun! Now that the, uh, ga",
+	"excerpt": "Shut up and take my money! Leela, are you alright? You got wanged on the head. Bender, ...",
 	"date": "2017-03-21T10:55:00.153000+00:00",
 	"date_insert": "2017-03-21T10:55:00.153000+00:00",
 	"discussion_id": "46d30c27-6cd8-407b-8536-fda4196c20ca",
@@ -119,6 +122,12 @@
 		"contact_ids": ["0ba2e346-e4f8-4c45-9adc-eeb1d42f07e0"],
 		"label": "zoidberg",
 		"protocol": "email",
+		"type": "To"
+	},{
+		"address": "fry@planet-express.tld",
+		"contact_ids": ["92d3907a-eeui-4537-b229-85f1c9d197bb"],
+		"label": "Fry",
+		"protocol": "email",
 		"type": "From"
 	}],
 	"privacy_features": {},
@@ -139,6 +148,7 @@
 {
 	"attachments": [],
 	"body": "first message to remove individually",
+	"excerpt": "first message to remove individually",
 	"date": "2017-03-21T10:55:00.153000+00:00",
 	"date_insert": "2017-03-21T10:55:00.153000+00:00",
 	"discussion_id": "3330c27-6cd8-407b-8536-fda4196c20ca",
@@ -172,6 +182,7 @@
 {
 	"attachments": [],
 	"body": "last message to remove individually",
+	"excerpt": "last message to remove individually",
 	"date": "2017-03-21T10:55:00.153000+00:00",
 	"date_insert": "2017-03-21T10:55:00.153000+00:00",
 	"discussion_id": "3330c27-6cd8-407b-8536-fda4196c20ca",
@@ -205,6 +216,7 @@
 {
 	"attachments": [],
 	"body": "a message of a collection to remove ",
+	"excerpt": "a message of a collection to remove ",
 	"date": "2017-03-21T10:55:00.153000+00:00",
 	"date_insert": "2017-03-21T10:55:00.153000+00:00",
 	"discussion_id": "44440c27-6cd8-407b-8536-fda4196c20ca",
@@ -238,6 +250,7 @@
 {
 	"attachments": [],
 	"body": "an other message of a collection to remove",
+	"excerpt": "an other message of a collection to remove",
 	"date": "2017-03-21T10:55:00.153000+00:00",
 	"date_insert": "2017-03-21T10:55:00.153000+00:00",
 	"discussion_id": "44440c27-6cd8-407b-8536-fda4196c20ca",

--- a/devtools/api-mock/messages/index.js
+++ b/devtools/api-mock/messages/index.js
@@ -14,6 +14,13 @@ const actions = {
 const selectors = {
   all: () => state => state.messages,
   last: () => state => [...state.messages].pop(),
+  byQuery: ({ offset = 0, limit = 20, discussion_id }) => createSelector(
+    [discussion_id ? selectors.byDiscussionId({ discussion_id }) :  selectors.all()],
+    messages => {
+      const end = new Number(offset) + new Number(limit);
+      return messages.slice(offset, end);
+    }
+  ),
   byDiscussionId: ({ discussion_id }) => createSelector(
     selectors.all(),
     messages => messages.filter(message => message.discussion_id === discussion_id)
@@ -47,6 +54,7 @@ const reducer = {
     {
       discussion_id: discussionId,
       ...body,
+      excerpt: body.body.slice(0, 30) + '...',
       message_id: uuidv1(),
       is_draft: true,
       is_unread: false,
@@ -111,7 +119,7 @@ const reducer = {
 const routes = {
   'GET /v2/messages/': {
     action: actions.get,
-    selector: selectors.byDiscussionId,
+    selector: selectors.byQuery,
     status: 200,
     middlewares: [createCollectionMiddleware('messages')],
   },

--- a/doc/api/Search-API-readme.md
+++ b/doc/api/Search-API-readme.md
@@ -5,6 +5,9 @@
 #####REQUEST:
 For now, search API is triggered by a simple `GET` with few query params :
 
+- ##### Mandatory header : `X-Caliopen-IL`
+    - the header is always required, *but* only taken into account if `doctype=message`.
+    - default values : -10;10
 - ##### Mandatory param : `term`
     - Example : `http://localhost:31415/api/v2/search?term=caliopdev`
     - This is the simplier request. It will trigger a fulltext search across all document types on all fields for the word « **caliopdev** ».

--- a/src/backend/defs/go-objects/search.go
+++ b/src/backend/defs/go-objects/search.go
@@ -15,6 +15,7 @@ type IndexSearch struct {
 	Terms   map[string][]string `json:"terms"`
 	User_id UUID                `json:"user_id"`
 	DocType string              `json:"doc_type"`
+	ILrange [2]int8             `json:"il_range"`
 }
 
 type IndexResult struct {
@@ -42,17 +43,14 @@ type IndexHit struct {
 
 func (is *IndexSearch) FilterQuery(service *elastic.SearchService) *elastic.SearchService {
 
-	if len(is.Terms) == 0 {
-		return service
-	}
-
 	q := elastic.NewBoolQuery()
 	for name, values := range is.Terms {
 		for _, value := range values {
 			q = q.Filter(elastic.NewTermQuery(name, value))
 		}
 	}
-
+	rq := elastic.NewRangeQuery("importance_level").Gte(is.ILrange[0]).Lte(is.ILrange[1])
+	q = q.Filter(rq)
 	service = service.Query(q)
 
 	return service

--- a/src/backend/defs/rest-api/paths/contacts.yaml
+++ b/src/backend/defs/rest-api/paths/contacts.yaml
@@ -13,6 +13,12 @@ contacts:
       description: The PI range requested in form of `1;100`
       type: string
       default: 1;100
+    - name: X-Caliopen-IL
+      in: header
+      required: true
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     - name: limit
       in: query
       required: false

--- a/src/backend/defs/rest-api/paths/discussions.yaml
+++ b/src/backend/defs/rest-api/paths/discussions.yaml
@@ -14,6 +14,12 @@ discussions:
       description: The PI range requested in form of `0;100`
       type: string
       default: 0;100
+    - name: X-Caliopen-IL
+      in: header
+      required: true
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     - name: limit
       in: query
       required: false
@@ -62,6 +68,18 @@ discussions_{discussion_id}:
       in: path
       required: true
       type: string
+    - name: X-Caliopen-PI
+      in: header
+      required: false
+      description: The PI range requested in form of `0;100`
+      type: string
+      default: 0;100
+    - name: X-Caliopen-IL
+      in: header
+      required: false
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     produces:
     - application/json
     responses:

--- a/src/backend/defs/rest-api/paths/messagesV2.yaml
+++ b/src/backend/defs/rest-api/paths/messagesV2.yaml
@@ -14,6 +14,12 @@ messages:
       description: The PI range requested in form of `0;100`
       type: string
       default: 0;100
+    - name: X-Caliopen-IL
+      in: header
+      required: true
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     - name: discussion_id
       in: query
       description: filter messages belonging to a specific discussion

--- a/src/backend/defs/rest-api/paths/search.yaml
+++ b/src/backend/defs/rest-api/paths/search.yaml
@@ -9,6 +9,12 @@ search:
     security:
     - basicAuth: []
     parameters:
+    - name: X-Caliopen-IL
+      in: header
+      required: true
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     - name: term
       in: query
       description: the search string

--- a/src/backend/doc/api/swagger.json
+++ b/src/backend/doc/api/swagger.json
@@ -7900,6 +7900,14 @@
         ],
         "parameters": [
           {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": true,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
+          },
+          {
             "name": "term",
             "in": "query",
             "description": "the search string",

--- a/src/backend/doc/api/swagger.json
+++ b/src/backend/doc/api/swagger.json
@@ -1311,6 +1311,14 @@
             "default": "1;100"
           },
           {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": true,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,
@@ -3347,6 +3355,14 @@
             "default": "0;100"
           },
           {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": true,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,
@@ -3528,6 +3544,22 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "X-Caliopen-PI",
+            "in": "header",
+            "required": false,
+            "description": "The PI range requested in form of `0;100`",
+            "type": "string",
+            "default": "0;100"
+          },
+          {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": false,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
           }
         ],
         "produces": [
@@ -3936,6 +3968,14 @@
             "description": "The PI range requested in form of `0;100`",
             "type": "string",
             "default": "0;100"
+          },
+          {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": true,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
           },
           {
             "name": "discussion_id",

--- a/src/backend/interfaces/REST/go.server/operations/helpers.go
+++ b/src/backend/interfaces/REST/go.server/operations/helpers.go
@@ -1,0 +1,42 @@
+package operations
+
+import (
+	"gopkg.in/gin-gonic/gin.v1"
+	"strconv"
+	"strings"
+)
+
+// fall back to default values if can't extract valid numbers.
+func GetImportanceLevel(ctx *gin.Context) (il [2]int8) {
+	il = [2]int8{-10, 10} // default values
+	var from, to int
+	var err error
+	if il_header, ok := ctx.Request.Header["X-Caliopen-Il"]; !ok {
+		return il
+	} else {
+		il_range_str := strings.Split(il_header[0], ";") // get only first value found
+		if len(il_range_str) != 2 {
+			return il
+		}
+		from, err = strconv.Atoi(il_range_str[0])
+		if err != nil {
+			from = -10
+		}
+		to, err = strconv.Atoi(il_range_str[1])
+		if err != nil {
+			to = 10
+		}
+		if from < -10 || from > 10 {
+			from = -10
+		}
+		if to < -10 || to > 10 {
+			to = 10
+		}
+		if from > to {
+			from = to
+		}
+		il[0] = int8(from)
+		il[1] = int8(to)
+		return
+	}
+}

--- a/src/backend/interfaces/REST/go.server/operations/messages/messages.go
+++ b/src/backend/interfaces/REST/go.server/operations/messages/messages.go
@@ -31,7 +31,7 @@ func GetMessagesList(ctx *gin.Context) {
 	//extract importance level
 	il_header := ctx.Request.Header["X-Caliopen-Il"][0] // get only first value found
 	il_range_str := strings.Split(il_header, ";")
-	il_range := [2]int8{0, 0}
+	il_range := [2]int8{-10, 10} // default values
 	if from, e := strconv.Atoi(il_range_str[0]); e == nil {
 		il_range[0] = int8(from)
 	}

--- a/src/backend/interfaces/REST/go.server/operations/messages/messages.go
+++ b/src/backend/interfaces/REST/go.server/operations/messages/messages.go
@@ -8,13 +8,13 @@ import (
 	"bytes"
 	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/middlewares"
+	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.main"
 	swgErr "github.com/go-openapi/errors"
 	"github.com/satori/go.uuid"
 	"gopkg.in/gin-gonic/gin.v1"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 // GET …/messages
@@ -26,17 +26,6 @@ func GetMessagesList(ctx *gin.Context) {
 		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
 		ctx.Abort()
 		return
-	}
-
-	//extract importance level
-	il_header := ctx.Request.Header["X-Caliopen-Il"][0] // get only first value found
-	il_range_str := strings.Split(il_header, ";")
-	il_range := [2]int8{-10, 10} // default values
-	if from, e := strconv.Atoi(il_range_str[0]); e == nil {
-		il_range[0] = int8(from)
-	}
-	if to, e := strconv.Atoi(il_range_str[1]); e == nil {
-		il_range[1] = int8(to)
 	}
 
 	var limit, offset int
@@ -61,7 +50,7 @@ func GetMessagesList(ctx *gin.Context) {
 		Terms:   map[string][]string(query_values),
 		Limit:   limit,
 		Offset:  offset,
-		ILrange: il_range,
+		ILrange: operations.GetImportanceLevel(ctx),
 	}
 	list, totalFound, err := caliopen.Facilities.RESTfacility.GetMessagesList(filter)
 	if err != nil {

--- a/src/backend/interfaces/REST/go.server/operations/search.go
+++ b/src/backend/interfaces/REST/go.server/operations/search.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/gin-gonic/gin.v1"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 func SimpleSearch(ctx *gin.Context) {
@@ -21,17 +20,6 @@ func SimpleSearch(ctx *gin.Context) {
 		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
 		ctx.Abort()
 		return
-	}
-
-	//extract importance level
-	il_header := ctx.Request.Header["X-Caliopen-Il"][0] // get only first value found
-	il_range_str := strings.Split(il_header, ";")
-	il_range := [2]int8{-10, 10} // default values
-	if from, e := strconv.Atoi(il_range_str[0]); e == nil {
-		il_range[0] = int8(from)
-	}
-	if to, e := strconv.Atoi(il_range_str[1]); e == nil {
-		il_range[1] = int8(to)
 	}
 
 	user_uuid, _ := uuid.FromString(ctx.MustGet("user_id").(string))
@@ -83,7 +71,7 @@ func SimpleSearch(ctx *gin.Context) {
 		User_id: user_UUID,
 		Limit:   limit,
 		Offset:  offset,
-		ILrange: il_range,
+		ILrange: GetImportanceLevel(ctx),
 	}
 
 	if field, ok := query["field"]; ok {

--- a/src/backend/interfaces/REST/py.server/caliopen_api/message/discussion.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/message/discussion.py
@@ -55,4 +55,4 @@ class Discussion(Api):
         # return resp
         discussion_id = self.request.swagger_data['discussion_id']
         raise HTTPMovedPermanently(
-            location="/V2/messages?discussion_id=" + discussion_id)
+            location="/v2/messages?discussion_id=" + discussion_id)

--- a/src/backend/interfaces/REST/py.server/caliopen_api/message/discussion.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/message/discussion.py
@@ -2,14 +2,9 @@ import logging
 
 from cornice.resource import resource, view
 
-from caliopen_main.discussion.core.discussion import (MainView,
-                                                      Discussion as UserDiscussion,
-                                                      build_discussion)
+from caliopen_main.discussion.core.discussion import MainView
 from ..base import Api
-from caliopen_main.discussion.store.discussion_index import \
-    DiscussionIndexManager as DIM
-from caliopen_storage.exception import NotFound
-from ..base.exception import ResourceNotFound
+from pyramid.httpexceptions import HTTPBadRequest, HTTPMovedPermanently
 
 log = logging.getLogger(__name__)
 
@@ -24,8 +19,15 @@ class Discussion(Api):
     @view(renderer='json', permission='authenticated')
     def collection_get(self):
         pi_range = self.request.authenticated_userid.pi_range
+        try:
+            il_range = self.request.authenticated_userid._get_il_range()
+        except Exception as exc:
+            log.warn(exc)
+            raise HTTPBadRequest
+
         view = MainView()
         result = view.get(self.user, pi_range[0], pi_range[1],
+                          il_range[0], il_range[1],
                           limit=self.get_limit(),
                           offset=self.get_offset())
 
@@ -34,19 +36,23 @@ class Discussion(Api):
 
     @view(renderer='json', permission='authenticated')
     def get(self):
+        # LEGACY CODE. ROUTE MOVED TO API V2
+        # discussion_id = self.request.swagger_data['discussion_id']
+        # try:
+        #     discussion = UserDiscussion.get(self.user, discussion_id)
+        # except NotFound:
+        #     raise ResourceNotFound('No such discussion %r' % discussion_id)
+        #
+        # dim = DIM(self.user.id)
+        #
+        # indexed_discussion = dim.get_by_id(discussion_id)
+        # if indexed_discussion:
+        #     resp = build_discussion(discussion, indexed_discussion)
+        # else:
+        #     raise ResourceNotFound(
+        #         'Discussion {} not found in index'.format(discussion_id))
+        #
+        # return resp
         discussion_id = self.request.swagger_data['discussion_id']
-        try:
-            discussion = UserDiscussion.get(self.user, discussion_id)
-        except NotFound:
-            raise ResourceNotFound('No such discussion %r' % discussion_id)
-
-        dim = DIM(self.user.id)
-
-        indexed_discussion = dim.get_by_id(discussion_id)
-        if indexed_discussion:
-            resp = build_discussion(discussion, indexed_discussion)
-        else:
-            raise ResourceNotFound(
-                'Discussion {} not found in index'.format(discussion_id))
-
-        return resp
+        raise HTTPMovedPermanently(
+            location="/V2/messages?discussion_id=" + discussion_id)

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/authentication.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/authentication.py
@@ -8,7 +8,6 @@ from zope.interface import implements, implementer
 from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
 from pyramid.security import Everyone, NO_PERMISSION_REQUIRED
 
-
 from caliopen_main.user.core import User
 from ..base.exception import AuthenticationError
 
@@ -16,7 +15,6 @@ log = logging.getLogger(__name__)
 
 
 class AuthenticatedUser(object):
-
     """Represent an authenticated user."""
 
     def __init__(self, request):
@@ -63,6 +61,21 @@ class AuthenticatedUser(object):
             log.error('Invalid range for PI {}: {}'.format(pi_range, exc))
         return (-1, -1)
 
+    def _get_il_range(self):
+        il_range = self.request.headers.get('X-Caliopen-IL', None)
+        if not il_range:
+            log.warn('No X-Caliopen-IL header')
+            raise ValueError
+        min_il, max_il = il_range.split(';', 1)
+        try:
+            return (int(min_il), int(max_il))
+        except ValueError:
+            log.error('Invalid value for IL {}'.format(il_range))
+            raise ValueError
+        except Exception as exc:
+            log.error('Invalid range for IL {}: {}'.format(il_range, exc))
+            raise exc
+
     def _load_user(self):
         if self._user:
             return
@@ -80,7 +93,6 @@ class AuthenticatedUser(object):
 
 
 class AuthenticationPolicy(object):
-
     """Global authentication policy."""
 
     implements(IAuthenticationPolicy)
@@ -118,7 +130,6 @@ class AuthenticationPolicy(object):
 
 @implementer(IAuthorizationPolicy)
 class AuthorizationPolicy(object):
-
     """Basic authorization policy."""
 
     def permits(self, context, principals, permission):

--- a/src/backend/main/go.backends/index/elasticsearch/broad_search.go
+++ b/src/backend/main/go.backends/index/elasticsearch/broad_search.go
@@ -23,21 +23,30 @@ func (es *ElasticSearchBackend) Search(search IndexSearch) (result *IndexResult,
 	for field, value := range search.Terms {
 		q = q.Must(elastic.NewCommonTermsQuery(field, value).CutoffFrequency(0.01)) //words that have a document frequency greater than 1% will be treated as common terms.
 	}
-	rq := elastic.NewRangeQuery("importance_level").Gte(search.ILrange[0]).Lte(search.ILrange[1])
-	q = q.Filter(rq)
 
 	// make aggregation to file docs by type:
 	// get only the 5 most relevant doc for each type if search.DocType is empty
 	// otherwise get docs according to limit & offset params.
 	var s *elastic.SearchService
-	if search.DocType == "" {
+	switch search.DocType {
+	case "":
 		// no doctype provided. Trigger search on all document types within index and build an aggregation
 		h := elastic.NewHighlight().Fields(elastic.NewHighlighterField("*").RequireFieldMatch(false))
 		top_hits := elastic.NewTopHitsAggregation().Size(5).FetchSource(true).Highlight(h)
 		by_type := elastic.NewTermsAggregation().Field("_type").SubAggregation(sub_agg_key, top_hits)
-		s = es.Client.Search().Index(search.User_id.String()).Query(q).FetchSource(false).Aggregation(agg_key, by_type)
-	} else {
-		// The search focuses on a specified document type, no aggregation needed.
+		//TODO/WIP
+		/*iq := elastic.NewIndicesQuery(elastic.NewRangeQuery("importance_level").Gte(search.ILrange[0]).Lte(search.ILrange[1]), MessageIndexType)
+		msg_hits := elastic.NewFilterAggregation().Filter(iq)
+		*/
+		s = es.Client.Search().Index(search.User_id.String()).Query(q).FetchSource(false).Aggregation(agg_key, by_type).Highlight(h)
+	case MessageIndexType:
+		// The search focuses on message document type, no aggregation needed, but importance level apply
+		h := elastic.NewHighlight().Fields(elastic.NewHighlighterField("*").RequireFieldMatch(false))
+		rq := elastic.NewRangeQuery("importance_level").Gte(search.ILrange[0]).Lte(search.ILrange[1])
+		q = q.Filter(rq)
+		s = es.Client.Search().Index(search.User_id.String()).Query(q).FetchSource(true).Highlight(h)
+	case ContactIndexType:
+		// The search focuses on message document type, no aggregation needed and importance level not taken into account
 		h := elastic.NewHighlight().Fields(elastic.NewHighlighterField("*").RequireFieldMatch(false))
 		s = es.Client.Search().Index(search.User_id.String()).Query(q).FetchSource(true).Highlight(h)
 	}
@@ -110,7 +119,6 @@ func (es *ElasticSearchBackend) Search(search IndexSearch) (result *IndexResult,
 
 	} else {
 		// elastic returns buckets aggregation as a raw []byte, need to unmarshal
-
 		by_types, _ := response.Aggregations[agg_key] // by_types is a *json.RawMessage
 		var agg map[string]interface{}
 		err = json.Unmarshal(*by_types, &agg)

--- a/src/backend/main/go.backends/index/elasticsearch/broad_search.go
+++ b/src/backend/main/go.backends/index/elasticsearch/broad_search.go
@@ -23,6 +23,8 @@ func (es *ElasticSearchBackend) Search(search IndexSearch) (result *IndexResult,
 	for field, value := range search.Terms {
 		q = q.Must(elastic.NewCommonTermsQuery(field, value).CutoffFrequency(0.01)) //words that have a document frequency greater than 1% will be treated as common terms.
 	}
+	rq := elastic.NewRangeQuery("importance_level").Gte(search.ILrange[0]).Lte(search.ILrange[1])
+	q = q.Filter(rq)
 
 	// make aggregation to file docs by type:
 	// get only the 5 most relevant doc for each type if search.DocType is empty

--- a/src/backend/main/go.backends/index/elasticsearch/messages.go
+++ b/src/backend/main/go.backends/index/elasticsearch/messages.go
@@ -68,6 +68,7 @@ func (es *ElasticSearchBackend) FilterMessages(filter objects.IndexSearch) (mess
 	if filter.Limit > 0 {
 		search = search.Size(filter.Limit)
 	}
+
 	result, err := search.Do(context.TODO())
 
 	if err != nil {

--- a/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
@@ -102,12 +102,13 @@ class MainView(object):
             if core:
                 yield build_discussion(core, discussion)
 
-    def get(self, user, min_pi, max_pi, limit, offset):
+    def get(self, user, min_pi, max_pi, min_il, max_il, limit, offset):
         """Build the main view results."""
         # XXX use of correct pagination and correct datasource (index)
         dim = DIM(user.user_id)
         discussions, total = dim.list_discussions(limit=limit, offset=offset,
-                                                  min_pi=min_pi, max_pi=max_pi)
+                                                  min_pi=min_pi, max_pi=max_pi,
+                                                  min_il=min_il, max_il=max_il)
         responses = self.build_responses(user, discussions)
         return {'discussions': list(responses), 'total': total}
 

--- a/src/frontend/web_application/src/components/BlockList/style.scss
+++ b/src/frontend/web_application/src/components/BlockList/style.scss
@@ -5,8 +5,6 @@
   margin: 0;
   padding: 0;
 
-  border-top: 1px solid $co-color__bg__back;
-
   &__item {
     border-bottom: 1px solid $co-color__bg__back;
   }

--- a/src/frontend/web_application/src/components/InfiniteScroll/index.jsx
+++ b/src/frontend/web_application/src/components/InfiniteScroll/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component, Children } from 'react';
 import PropTypes from 'prop-types';
 import throttle from 'lodash.throttle';
 
@@ -30,7 +30,7 @@ class InfiniteScroll extends Component {
   }
 
   render() {
-    return (<div>{this.props.children}</div>);
+    return Children.only(this.props.children);
   }
 }
 

--- a/src/frontend/web_application/src/components/MessageList/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/presenter.jsx
@@ -29,7 +29,7 @@ const renderDayGroups = (messages, onMessageView, onMessageDelete, __) => {
 };
 
 const MessageList = ({
-  onMessageView, onMessageDelete, onReply, onForward, onDelete, messages, replyForm, __,
+  loadMore, onMessageView, onMessageDelete, onReply, onForward, onDelete, messages, replyForm, __,
 }) => (
   <div className="m-message-list">
     <MenuBar>
@@ -37,6 +37,9 @@ const MessageList = ({
       <Button className="m-message-list__action" onClick={onForward} icon="share" responsive="icon-only" >{__('message-list.action.copy-to')}</Button>
       <Button className="m-message-list__action" onClick={onDelete} icon="trash" responsive="icon-only" >{__('message-list.action.delete')}</Button>
     </MenuBar>
+    <div className="m-message-list__load-more">
+      {loadMore}
+    </div>
     <div className="m-message-list__list">
       {renderDayGroups(messages, onMessageView, onMessageDelete, __)}
     </div>
@@ -47,6 +50,7 @@ const MessageList = ({
 );
 
 MessageList.propTypes = {
+  loadMore: PropTypes.node,
   onMessageView: PropTypes.func,
   onMessageDelete: PropTypes.func.isRequired,
   onReply: PropTypes.func.isRequired,
@@ -58,6 +62,7 @@ MessageList.propTypes = {
 };
 
 MessageList.defaultProps = {
+  loadMore: null,
   onMessageView: null,
 };
 

--- a/src/frontend/web_application/src/components/MessageList/style.scss
+++ b/src/frontend/web_application/src/components/MessageList/style.scss
@@ -5,6 +5,11 @@
 
   &__action { margin-right: $co-component__spacing; }
 
+  &__load-more {
+    padding-top: $co-margin;
+    text-align: center;
+  }
+
   &__reply {
     @include breakpoint(small) {
       position: fixed;

--- a/src/frontend/web_application/src/routes.jsx
+++ b/src/frontend/web_application/src/routes.jsx
@@ -4,6 +4,7 @@ import { Route, Switch } from 'react-router-dom';
 import { withTranslator } from '@gandi/react-translate';
 import Contact from './scenes/Contact';
 import Auth from './scenes/Auth';
+import Timeline from './scenes/Timeline';
 import DiscussionList from './scenes/DiscussionList';
 import AppRoute from './scenes/AppRoute';
 import NewDraft from './scenes/NewDraft';
@@ -34,6 +35,12 @@ export const getRouteConfig = ({ __ }) => [
     routes: [
       {
         path: '/',
+        exact: true,
+        component: Timeline,
+        app: 'discussion',
+      },
+      {
+        path: '/discussions',
         exact: true,
         component: DiscussionList,
         app: 'discussion',

--- a/src/frontend/web_application/src/scenes/MessageList/index.js
+++ b/src/frontend/web_application/src/scenes/MessageList/index.js
@@ -3,36 +3,59 @@ import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
 import { matchPath } from 'react-router-dom';
-import { requestMessages, postActions, deleteMessage, invalidateDiscussion } from '../../store/modules/message';
-import { requestDiscussion } from '../../store/modules/discussion';
+import { requestMessages, postActions, deleteMessage, invalidate, loadMore, hasMore as getHasMore } from '../../store/modules/message';
 import { removeTab } from '../../store/modules/tab';
 import Presenter from './presenter';
 
+const getDiscussionIdFromProps = props => props.match.params.discussionId;
+
 const messageByIdSelector = state => state.message.messagesById;
-const messagesDidInvalidateSelector = state => state.message.didDiscussionInvalidate;
-const discussionIdSelector = (state, ownProps) => ownProps.match.params.discussionId;
+const discussionIdSelector = (state, ownProps) => getDiscussionIdFromProps(ownProps);
 const currentTabSelector = createSelector(
   [state => state.tab.tabs, state => state.router.location && state.router.location.pathname],
   (tabs, pathname) => tabs.find(tab => matchPath(pathname, { path: tab.pathname, exact: true }))
 );
-
-const mapStateToProps = createSelector(
-  [messageByIdSelector, messagesDidInvalidateSelector, discussionIdSelector, currentTabSelector],
-  (messagesById, messagesDidInvalidate, discussionId, currentTab) => ({
-    discussionId,
-    messages: Object.keys(messagesById)
-      .map(messageId => messagesById[messageId])
-      .filter(message => message.discussion_id === discussionId && message.is_draft !== true),
-    currentTab,
-    messagesDidInvalidate: messagesDidInvalidate[discussionId] || false,
+const messageCollectionStateSelector = createSelector(
+  [state => state.message.messagesCollections, discussionIdSelector],
+  (collections, discussionId) => ({
+    messageIds: (
+      collections.discussion &&
+      collections.discussion[discussionId] &&
+      collections.discussion[discussionId].messages) || [],
+    didInvalidate: (
+      collections.discussion &&
+      collections.discussion[discussionId] &&
+      collections.discussion[discussionId].didInvalidate) || false,
+    hasMore: (
+      collections.discussion &&
+      collections.discussion[discussionId] &&
+      getHasMore(collections.discussion[discussionId])) || false,
+    isFetching: (
+      collections.discussion &&
+      collections.discussion[discussionId] &&
+      collections.discussion[discussionId].isFetching) || false,
   })
 );
 
-const mapDispatchToProps = dispatch => bindActionCreators({
-  requestDiscussion,
-  requestMessages,
+const mapStateToProps = createSelector(
+  [messageByIdSelector, discussionIdSelector, currentTabSelector, messageCollectionStateSelector],
+  (messagesById, discussionId, currentTab, { didInvalidate, messageIds, hasMore, isFetching }) => ({
+    discussionId,
+    didInvalidate,
+    isFetching,
+    hasMore,
+    messages: messageIds
+      .map(messageId => messagesById[messageId])
+      .filter(message => message.is_draft !== true),
+    currentTab,
+  })
+);
+
+const mapDispatchToProps = (dispatch, ownProps) => bindActionCreators({
+  requestMessages: requestMessages.bind(null, 'discussion', getDiscussionIdFromProps(ownProps)),
+  loadMore: loadMore.bind(null, 'discussion', getDiscussionIdFromProps(ownProps)),
   deleteMessage,
-  invalidateDiscussion,
+  invalidate: invalidate.bind(null, 'discussion', getDiscussionIdFromProps(ownProps)),
   setMessageRead: ({ message, isRead = true }) => {
     const action = isRead ? 'set_read' : 'set_unread';
 

--- a/src/frontend/web_application/src/scenes/MessageList/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/MessageList/presenter.jsx
@@ -1,19 +1,26 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import throttle from 'lodash.throttle';
 import MessageListBase from '../../components/MessageList';
+import Button from '../../components/Button';
 import ReplyForm from './components/DraftForm';
+
+const LOAD_MORE_THROTTLE = 1000;
 
 class MessageList extends Component {
   static propTypes = {
+    __: PropTypes.func.isRequired,
     requestMessages: PropTypes.func.isRequired,
-    requestDiscussion: PropTypes.func.isRequired,
-    invalidateDiscussion: PropTypes.func.isRequired,
+    invalidate: PropTypes.func.isRequired,
     discussionId: PropTypes.string.isRequired,
     messages: PropTypes.arrayOf(PropTypes.shape({})),
-    messagesDidInvalidate: PropTypes.bool.isRequired,
+    didInvalidate: PropTypes.bool.isRequired,
+    isFetching: PropTypes.bool.isRequired,
     setMessageRead: PropTypes.func.isRequired,
     deleteMessage: PropTypes.func.isRequired,
     removeTab: PropTypes.func.isRequired,
+    loadMore: PropTypes.func.isRequired,
+    hasMore: PropTypes.bool.isRequired,
     currentTab: PropTypes.shape({}),
   };
 
@@ -25,13 +32,23 @@ class MessageList extends Component {
 
   componentDidMount() {
     const { discussionId } = this.props;
-    this.props.requestMessages({ discussionId });
-    this.props.requestDiscussion({ discussionId });
+    this.props.requestMessages({ discussion_id: discussionId });
+
+    this.throttledLoadMore = throttle(
+      () => this.props.loadMore(),
+      LOAD_MORE_THROTTLE,
+      { trailing: false }
+    );
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.messagesDidInvalidate) {
-      this.props.requestMessages({ discussionId: nextProps.discussionId });
+    if (nextProps.didInvalidate && !nextProps.isFetching) {
+      this.props.requestMessages({ discussion_id: nextProps.discussionId });
+    }
+
+    if (!nextProps.didInvalidate && !nextProps.isFetching && nextProps.messages.length === 0) {
+      const { currentTab, removeTab } = nextProps;
+      removeTab(currentTab);
     }
   }
 
@@ -40,29 +57,28 @@ class MessageList extends Component {
   };
 
   handleDeleteMessage = ({ message }) => {
-    const {
-      deleteMessage, invalidateDiscussion, requestMessages, removeTab, discussionId, currentTab,
-    } = this.props;
-    deleteMessage({ message })
-      .then(() => invalidateDiscussion({ discussionId }))
-      .then(() => requestMessages({ discussionId }))
-      .then(
-        ({ payload: { data } }) => data.messages.length === 0 && removeTab(currentTab)
-      );
+    const { deleteMessage } = this.props;
+    deleteMessage({ message });
   };
 
   handleDelete = () => {
-    const {
-      messages, deleteMessage, invalidateDiscussion, requestMessages, removeTab, discussionId,
-      currentTab,
-    } = this.props;
-    Promise.all(messages.map(message => deleteMessage({ message })))
-      .then(() => invalidateDiscussion({ discussionId }))
-      .then(() => requestMessages({ discussionId }))
-      .then(
-        ({ payload: { data } }) => data.messages.length === 0 && removeTab(currentTab)
-      );
+    const { messages, deleteMessage } = this.props;
+    Promise.all(messages.map(message => deleteMessage({ message })));
   };
+
+  loadMore = () => {
+    if (this.props.hasMore) {
+      this.throttledLoadMore();
+    }
+  }
+
+  renderLoadMore() {
+    const { __, hasMore } = this.props;
+
+    return hasMore && (
+      <Button shape="hollow" onClick={this.loadMore}>{__('general.action.load_more')}</Button>
+    );
+  }
 
   render() {
     const { messages, discussionId } = this.props;
@@ -76,6 +92,7 @@ class MessageList extends Component {
         onForward={() => {}}
         onDelete={this.handleDelete}
         onMessageDelete={this.handleDeleteMessage}
+        loadMore={this.renderLoadMore()}
       />
     );
   }

--- a/src/frontend/web_application/src/scenes/Timeline/components/AuthorAvatar/index.js
+++ b/src/frontend/web_application/src/scenes/Timeline/components/AuthorAvatar/index.js
@@ -1,0 +1,3 @@
+import Presenter from './presenter';
+
+export default Presenter;

--- a/src/frontend/web_application/src/scenes/Timeline/components/AuthorAvatar/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Timeline/components/AuthorAvatar/presenter.jsx
@@ -1,0 +1,26 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import ParticipantIconLetter from '../../../../components/ParticipantIconLetter';
+import './style.scss';
+
+const getAuthor = message => message.participants.find(participant => participant.type === 'From');
+
+class AuthorAvatar extends PureComponent {
+  static propTypes = {
+    message: PropTypes.shape({}).isRequired,
+  };
+  static defaultProps = {
+  };
+
+  render() {
+    const participant = getAuthor(this.props.message);
+
+    return (
+      <div className="s-author-avatar">
+        <ParticipantIconLetter className="s-author-avatar__letter" participant={participant} />
+      </div>
+    );
+  }
+}
+
+export default AuthorAvatar;

--- a/src/frontend/web_application/src/scenes/Timeline/components/AuthorAvatar/style.scss
+++ b/src/frontend/web_application/src/scenes/Timeline/components/AuthorAvatar/style.scss
@@ -1,0 +1,27 @@
+@import '../../../../styles/common';
+
+$s-author-avatar__size: 40px;
+$s-author-avatar__padding: 0;
+
+.s-author-avatar {
+  display: inline-block;
+  vertical-align: middle;
+
+  width: $s-author-avatar__size;
+  height: $s-author-avatar__size;
+
+  border-radius: 50%;
+  background-color: $co-color__primary--low;
+  overflow: hidden;
+
+  &__letter {
+    &::before {
+      display: block;
+      float: left;
+      width: $s-author-avatar__size;
+      height: $s-author-avatar__size;
+      line-height: $s-author-avatar__size;
+      text-align: center;
+    }
+  }
+}

--- a/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/index.js
+++ b/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/index.js
@@ -1,0 +1,4 @@
+import { withTranslator } from '@gandi/react-translate';
+import Presenter from './presenter';
+
+export default withTranslator()(Presenter);

--- a/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/presenter.jsx
@@ -1,0 +1,80 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import Link from '../../../../components/Link';
+// FIXME
+import DiscussionItemContainer from '../../../DiscussionList/components/DiscussionItemContainer';
+import AuthorAvatar from '../AuthorAvatar';
+import Icon from '../../../../components/Icon';
+import TextBlock from '../../../../components/TextBlock';
+import Badge from '../../../../components/Badge';
+
+import './style.scss';
+
+class MessageItem extends PureComponent {
+  static propTypes = {
+    message: PropTypes.shape({}).isRequired,
+    formatDate: PropTypes.func.isRequired,
+    __: PropTypes.func.isRequired,
+  };
+  static defaultProps = {
+  };
+
+  renderAuthor() {
+    const { message: { participants } } = this.props;
+    const author = participants.find(participant => participant.type === 'From');
+
+    return `${author.label} (${author.address})`;
+  }
+
+  renderTags() {
+    const { message } = this.props;
+
+    return message.tags && message.tags.map(tag => (
+      <span key={tag.name}>
+        {' '}
+        <Badge className="s-message-item__tag">{tag.name}</Badge>
+      </span>
+    ));
+  }
+
+  render() {
+    const { message, formatDate, __ } = this.props;
+
+    return (
+      <DiscussionItemContainer discussion={{}} __={__}>
+        <Link
+          to={`/discussions/${message.discussion_id}`}
+          className={classnames('s-message-item', { 's-message-item--unread': message.is_unread, 's-message-item--draft': message.is_draft })}
+          noDecoration
+        >
+          <div className="s-message-item__col-avatars">
+            <AuthorAvatar message={message} />
+          </div>
+          <div className="s-message-item__col-title">
+            <TextBlock>
+              {this.renderAuthor()}
+              {this.renderTags()}
+            </TextBlock>
+            <TextBlock>{message.excerpt}</TextBlock>
+          </div>
+          <div className="s-message-item__col-file">
+            { message.attachments && <Icon type="paperclip" /> }
+          </div>
+          <div className="s-message-item__col-dates">
+            <time
+              title={formatDate(message.date_insert, 'LLL')}
+              dateTime={formatDate(message.date_insert, '')}
+            >
+              <TextBlock inline>{formatDate(message.date_insert, 'll')}</TextBlock>
+              {' '}
+              <TextBlock inline>{formatDate(message.date_insert, 'LT')}</TextBlock>
+            </time>
+          </div>
+        </Link>
+      </DiscussionItemContainer>
+    );
+  }
+}
+
+export default MessageItem;

--- a/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/style.scss
+++ b/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/style.scss
@@ -1,0 +1,56 @@
+@import '../../../../styles/common';
+@import '../../../../styles/vendor/bootstrap_foundation-sites';
+
+.s-message-item {
+  @include flex-grid-row($size: expand);
+  align-items: center;
+  height: 2 * $co-component__height;
+
+  &:hover {
+    color: $co-color__fg__text--high;
+  }
+
+  &:active {
+    color: $co-color__fg__text--low;
+  }
+
+  &--draft,
+  &--unread {
+    position: relative;
+    background-color: $co-color__fg__back--higher;
+    color: $co-color__fg__text--higher;
+
+    &::before {
+      display: block;
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 3px;
+      background: $co-color__primary;
+    }
+  }
+
+  &__col-avatars {
+    @include flex-grid-column(shrink);
+  }
+
+  &__col-title {
+    @include flex-grid-column;
+    min-width: 0; // https://github.com/zurb/foundation-sites/pull/8511
+  }
+
+  &__col-file {
+    @include flex-grid-column(1);
+  }
+
+  &__col-dates {
+    @include flex-grid-column(2);
+    display: none;
+    font-weight: 600;
+  }
+
+  @include breakpoint(medium) {
+    &__col-dates { display: block; }
+  }
+}

--- a/src/frontend/web_application/src/scenes/Timeline/index.js
+++ b/src/frontend/web_application/src/scenes/Timeline/index.js
@@ -1,0 +1,27 @@
+import { createSelector } from 'reselect';
+import { bindActionCreators, compose } from 'redux';
+import { connect } from 'react-redux';
+import { withTranslator } from '@gandi/react-translate';
+import Presenter from './presenter';
+import { requestMessages, loadMore, hasMore } from '../../store/modules/message';
+
+const timelineSelector = state => state.message.messagesCollections.timeline && state.message.messagesCollections.timeline['0'];
+const messagesSelector = state => state.message.messagesById;
+const mapStateToProps = createSelector(
+  [timelineSelector, messagesSelector],
+  (timeline, messagesById) => ({
+    messages: timeline && timeline.messages.map(id => messagesById[id])
+      .sort((a, b) => new Date(b.date_insert) - new Date(a.date_insert)),
+    hasMore: timeline && hasMore(timeline),
+    isFetching: timeline && timeline.isFetching,
+  })
+);
+const mapDispatchToProps = dispatch => bindActionCreators({
+  requestMessages: requestMessages.bind(null, 'timeline', '0'),
+  loadMore: loadMore.bind(null, 'timeline', '0'),
+}, dispatch);
+
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  withTranslator()
+)(Presenter);

--- a/src/frontend/web_application/src/scenes/Timeline/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Timeline/presenter.jsx
@@ -1,0 +1,74 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import throttle from 'lodash.throttle';
+import Spinner from '../../components/Spinner';
+import Button from '../../components/Button';
+import BlockList from '../../components/BlockList';
+import InfiniteScroll from '../../components/InfiniteScroll';
+import MenuBar from '../../components/MenuBar';
+import MessageItem from './components/MessageItem';
+import './style.scss';
+
+const LOAD_MORE_THROTTLE = 1000;
+
+class Timeline extends Component {
+  static propTypes = {
+    user: PropTypes.shape({}),
+    requestMessages: PropTypes.func.isRequired,
+    loadMore: PropTypes.func.isRequired,
+    messages: PropTypes.arrayOf(PropTypes.shape({})),
+    isFetching: PropTypes.bool,
+    hasMore: PropTypes.bool,
+    __: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    user: null,
+    messages: [],
+    isFetching: false,
+    hasMore: false,
+  };
+  state = {};
+
+  componentDidMount() {
+    this.props.requestMessages();
+
+    this.throttledLoadMore = throttle(
+      () => this.props.loadMore(),
+      LOAD_MORE_THROTTLE,
+      { trailing: false }
+    );
+  }
+
+  loadMore = () => {
+    if (this.props.hasMore) {
+      this.throttledLoadMore();
+    }
+  }
+
+  render() {
+    const { user, messages, isFetching, hasMore, __ } = this.props;
+
+    return (
+      <div className="s-timeline">
+        <MenuBar className="s-timeline__menu-bar">
+          <Spinner isLoading={isFetching} className="s-timeline__spinner" />
+        </MenuBar>
+        <InfiniteScroll onReachBottom={this.loadMore}>
+          <BlockList className="s-timeline__list">
+            {messages.map(item => (
+              <MessageItem key={item.message_id} user={user} message={item} />
+            ))}
+          </BlockList>
+        </InfiniteScroll>
+        {hasMore && (
+          <div className="s-timeline__load-more">
+            <Button shape="hollow" onClick={this.loadMore}>{__('general.action.load_more')}</Button>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default Timeline;

--- a/src/frontend/web_application/src/scenes/Timeline/style.scss
+++ b/src/frontend/web_application/src/scenes/Timeline/style.scss
@@ -1,0 +1,19 @@
+@import '../../styles/common';
+
+.s-timeline {
+  background-color: $co-color__fg__back;
+
+  &__menu-bar {
+    height: $co-component__height;
+  }
+
+  &__spinner {
+    float: right;
+  }
+
+  &__load-more {
+    padding-top: $co-margin;
+    padding-bottom: $co-margin;
+    text-align: center;
+  }
+}

--- a/src/frontend/web_application/src/store/middlewares/draft-messages-middleware.js
+++ b/src/frontend/web_application/src/store/middlewares/draft-messages-middleware.js
@@ -144,15 +144,16 @@ async function requestDraftHandler({ store, action }) {
   }
 
   const { internalId, discussionId } = action.payload;
-  await store.dispatch(requestMessages({ discussionId }));
+  await store.dispatch(requestMessages('discussion', discussionId, { discussion_id: discussionId }));
 
   const {
-    message: { messagesById },
+    message: {
+      messagesById,
+      messagesCollections: { discussion: { [discussionId]: { messages: messageIds } } },
+    },
   } = store.getState();
 
-  const messages = Object.keys(messagesById)
-    .map(messageId => messagesById[messageId])
-    .filter(item => item.discussion_id === discussionId);
+  const messages = messageIds.map(id => messagesById[id]);
 
   const message = messages.find(item => item.is_draft)
     || await getNewDraft({ discussionId, store, messageToAnswer: messages[0] });

--- a/src/frontend/web_application/src/store/modules/message.spec.js
+++ b/src/frontend/web_application/src/store/modules/message.spec.js
@@ -13,6 +13,66 @@ describe('ducks module message', () => {
       });
     });
 
+    it('reduces REQUEST_MESSAGES', () => {
+      const initialState = {
+        ...reducer(undefined, { type: '@@INIT' }),
+      };
+      const action = module.requestMessages('timeline', '0');
+      expect(reducer(initialState, action)).toEqual({
+        ...initialState,
+        messagesCollections: {
+          timeline: {
+            0: {
+              isFetching: true,
+              didInvalidate: false,
+              messages: [],
+              total: 0,
+              request: { },
+            },
+          },
+        },
+      });
+    });
+
+    it('reduces INVALIDATE_MESSAGES', () => {
+      const initialState = {
+        ...reducer(undefined, { type: '@@INIT' }),
+        messagesById: {
+          a0: { body: 'already here', discussion_id: 'a', message_id: 'a0' },
+        },
+        messagesCollections: {
+          timeline: {
+            0: {
+              isFetching: false,
+              didInvalidate: false,
+              messages: ['a0'],
+              total: 1,
+              request: {
+                foo: 'bar',
+              },
+            },
+          },
+        },
+      };
+      const action = module.invalidate('timeline', '0');
+      expect(reducer(initialState, action)).toEqual({
+        ...initialState,
+        messagesCollections: {
+          timeline: {
+            0: {
+              isFetching: false,
+              didInvalidate: true,
+              messages: ['a0'],
+              total: 1,
+              request: {
+                foo: 'bar',
+              },
+            },
+          },
+        },
+      });
+    });
+
     describe('reduces REQUEST_MESSAGES_SUCCESS', () => {
       it('reduces without invalidateDiscussion', () => {
         const initialState = {
@@ -20,17 +80,30 @@ describe('ducks module message', () => {
           messagesById: {
             a0: { body: 'already here', discussion_id: 'a', message_id: 'a0' },
           },
+          messagesCollections: {
+            timeline: {
+              0: {
+                isFetching: false,
+                didInvalidate: false,
+                messages: ['a0'],
+                total: 1,
+                request: {
+                  foo: 'bar',
+                },
+              },
+            },
+          },
         };
         const message = { body: 'foo', message_id: 'a1', discussion_id: 'a' };
         const action = {
           type: module.REQUEST_MESSAGES_SUCCESS,
           payload: {
             data: {
-              total: 1,
+              total: 2,
               messages: [message],
             },
           },
-          meta: { previousAction: { type: module.REQUEST_MESSAGES, payload: { discussionId: 'a', request: { } } } },
+          meta: { previousAction: { type: module.REQUEST_MESSAGES, payload: { type: 'timeline', key: '0', discussionId: 'a', request: { foo: 'bar' } } } },
         };
         expect(reducer(initialState, action)).toEqual({
           ...initialState,
@@ -38,16 +111,40 @@ describe('ducks module message', () => {
             ...initialState.messagesById,
             a1: message,
           },
-          total: 1,
+          messagesCollections: {
+            timeline: {
+              0: {
+                isFetching: false,
+                didInvalidate: false,
+                messages: ['a0', 'a1'],
+                total: 2,
+                request: {
+                  foo: 'bar',
+                },
+              },
+            },
+          },
         });
       });
 
       it('reduces with invalidateDiscussion', () => {
         const initialState = {
           ...reducer(undefined, { type: '@@INIT' }),
-          didDiscussionInvalidate: { a: true },
           messagesById: {
             a0: { body: 'I am invalid', discussion_id: 'a', message_id: 'a0' },
+          },
+          messagesCollections: {
+            timeline: {
+              0: {
+                isFetching: false,
+                didInvalidate: true,
+                messages: ['a0'],
+                total: 1,
+                request: {
+                  foo: 'bar',
+                },
+              },
+            },
           },
         };
         const message = { body: 'foo', message_id: 'a1', discussion_id: 'a' };
@@ -59,17 +156,72 @@ describe('ducks module message', () => {
               messages: [message],
             },
           },
-          meta: { previousAction: { type: module.REQUEST_MESSAGES, payload: { discussionId: 'a', request: { } } } },
+          meta: { previousAction: { type: module.REQUEST_MESSAGES, payload: { type: 'timeline', key: '0', discussionId: 'a', request: { foo: 'bar' } } } },
         };
         expect(reducer(initialState, action)).toEqual({
           ...initialState,
-          didDiscussionInvalidate: {},
           messagesById: {
+            ...initialState.messagesById,
             a1: message,
           },
-          total: 1,
+          messagesCollections: {
+            timeline: {
+              0: {
+                isFetching: false,
+                didInvalidate: false,
+                messages: ['a1'],
+                total: 1,
+                request: {
+                  foo: 'bar',
+                },
+              },
+            },
+          },
         });
       });
+    });
+
+    describe('REQUEST_MESSAGE_SUCCESS', () => {
+      it('reduces', () => {
+        const initialState = {
+          ...reducer(undefined, { type: '@@INIT' }),
+          messagesById: {
+            a0: { body: 'I am invalid', discussion_id: 'a', message_id: 'a0' },
+          },
+        };
+        const message = { body: 'foo', message_id: 'a1', discussion_id: 'a' };
+        const action = {
+          type: module.REQUEST_MESSAGE_SUCCESS,
+          payload: {
+            data: message,
+          },
+        };
+        expect(reducer(initialState, action)).toEqual({
+          ...initialState,
+          messagesById: {
+            ...initialState.messagesById,
+            a1: message,
+          },
+        });
+      });
+    });
+  });
+
+  describe('hasMore', () => {
+    it('return true', () => {
+      expect(module.hasMore({ messages: ['a1'], total: 2 })).toEqual(true);
+    });
+    it('return false', () => {
+      expect(module.hasMore({ messages: ['a1'], total: 1 })).toEqual(false);
+    });
+  });
+
+  describe('getNextOffset', () => {
+    it('return 0', () => {
+      expect(module.getNextOffset({ messages: [] })).toEqual(0);
+    });
+    it('return n', () => {
+      expect(module.getNextOffset({ messages: ['a1', 'a3'] })).toEqual(2);
     });
   });
 });

--- a/src/frontend/web_application/test/functional/features/10_discussion-spec.js
+++ b/src/frontend/web_application/test/functional/features/10_discussion-spec.js
@@ -14,13 +14,13 @@ describe('Discussions', () => {
         expect(appSwitcher.element(by.cssContainingText('.m-navbar-item__content', 'Discussions')).isPresent())
         .toBe(true);
       })
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 5 * 1000))
       .then(() => {
-        expect(element.all(by.css('.s-discussion-list__thread')).first().getText())
-          .toContain('test@caliopen.local, john@caliopen.local, zoidberg@planet-express.tld');
-        expect(element.all(by.css('.s-discussion-list__thread')).count()).toEqual(4);
+        expect(element.all(by.cssContainingText('.s-timeline .s-message-item', 'Jaune john (john@caliopen.local)')).first().getText())
+          .toContain('12:55');
+        expect(element.all(by.css('.s-message-item')).count()).toEqual(7);
         expect(
-          element(by.cssContainingText('.s-discussion-list__load-more', 'Load more')).isPresent()
+          element(by.cssContainingText('.s-timeline__load-more', 'Load more')).isPresent()
         ).toBe(false);
       });
   });
@@ -28,14 +28,14 @@ describe('Discussions', () => {
   describe('thread', () => {
     it('render and listed contacts describe the thread', () => {
       browser.get('/');
-      browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 5 * 1000);
+      browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 5 * 1000);
       element(by.cssContainingText(
-        '.s-discussion-list__thread',
-        'test@caliopen.local, john@caliopen.local, zoidberg@planet-express.tld'
+        '.s-message-item',
+        'zoidberg (zoidberg@planet-express.tld)'
       )).click();
       // TODO tabs
       // expect(element(by.css('.m-tab.m-navbar__item--is-active .m-tab__link')).getText())
-      //   .toContain('test@caliopen.local, zoidberg@caliopen.local');
+      //   .toContain('zoidberg, john');
     });
   });
 });

--- a/src/frontend/web_application/test/functional/features/20-message-list-spec.js
+++ b/src/frontend/web_application/test/functional/features/20-message-list-spec.js
@@ -9,10 +9,10 @@ describe('Message list', () => {
 
   it('list', () => {
     browser.get('/')
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 5 * 1000))
       .then(() => element(by.cssContainingText(
-        '.s-discussion-list__thread',
-        'test@caliopen.local, john@caliopen.local, zoidberg@planet-express.tld'
+        '.s-timeline .s-message-item',
+        'zoidberg (zoidberg@planet-express.tld)'
       )).click())
       .then(() => browser.wait(EC.presenceOf($('.m-message-list')), 5 * 1000))
       .then(() => expect(element.all(by.css('.m-message')).count()).toEqual(2));

--- a/src/frontend/web_application/test/functional/features/21-reply-to-messag-spec.js
+++ b/src/frontend/web_application/test/functional/features/21-reply-to-messag-spec.js
@@ -26,14 +26,14 @@ describe('Save a draft and send', () => {
 
   it('Automatically saves a draft', () => {
     const discussion1Selector = by.cssContainingText(
-      '.s-discussion-list__thread',
-      'test@caliopen.local, john@caliopen.local, zoidberg@planet-express.tld'
+      '.s-timeline .s-message-item',
+      'zoidberg (zoidberg@planet-express.tld)'
     );
     const text1 = 'Automatically saves a draft, then refresh.';
     const text2 = ' Automatically updates a draft, then refresh.';
 
     browser.get('/')
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 5 * 1000))
       .then(() => element(discussion1Selector).click())
       .then(() => browser.wait(EC.presenceOf($('.m-message-list')), 5 * 1000))
       .then(() => {
@@ -67,16 +67,16 @@ describe('Save a draft and send', () => {
 
   it('Automatically saves a draft while browsing', () => {
     const discussion1Selector = by.cssContainingText(
-      '.s-discussion-list__thread',
-      'test@caliopen.local, john@caliopen.local, zoidberg@planet-express.tld'
+      '.s-timeline .s-message-item',
+      'zoidberg (zoidberg@planet-express.tld)'
     );
     const discussion2Selector = by.cssContainingText(
-      '.s-discussion-list__thread',
-      'john@caliopen.local, fry@planet-express.tld'
+      '.s-timeline .s-message-item',
+      'Fry (fry@planet-express.tld)'
     );
     const text3 = 'Add an answer to second discussion, don\'t wait and go to first one.';
     browser.get('/')
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 5 * 1000))
       .then(() => element(discussion2Selector).click())
       .then(() => browser.wait(EC.presenceOf($('.m-message-list')), 5 * 1000))
       .then(() => {
@@ -111,12 +111,12 @@ describe('Save a draft and send', () => {
 
   it('force saves a draft', () => {
     const discussion1Selector = by.cssContainingText(
-      '.s-discussion-list__thread',
-      'test@caliopen.local, john@caliopen.local, zoidberg@planet-express.tld'
+      '.s-timeline .s-message-item',
+      'zoidberg (zoidberg@planet-express.tld)'
     );
     const text1 = 'Force save a draft.';
     browser.get('/')
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 5 * 1000))
       .then(() => element(discussion1Selector).click())
       .then(() => browser.wait(EC.presenceOf($('.m-message-list')), 5 * 1000))
       .then(() => {
@@ -140,12 +140,12 @@ describe('Save a draft and send', () => {
 
   it('sends a draft', () => {
     const discussion1Selector = by.cssContainingText(
-      '.s-discussion-list__thread',
-      'test@caliopen.local, john@caliopen.local, zoidberg@planet-express.tld'
+      '.s-timeline .s-message-item',
+      'zoidberg (zoidberg@planet-express.tld)'
     );
     const text1 = 'yes I am!';
     browser.get('/')
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 5 * 1000))
       .then(() => element(discussion1Selector).click())
       .then(() => browser.wait(EC.presenceOf($('.m-message-list')), 5 * 1000))
       .then(() => {

--- a/src/frontend/web_application/test/functional/features/22-compose-spec.js
+++ b/src/frontend/web_application/test/functional/features/22-compose-spec.js
@@ -80,9 +80,9 @@ describe('Compose new message', () => {
           expect(draftBodyElement1.getText()).toEqual(text1);
         })
         .then(() => element(by.cssContainingText('.m-navbar-item__content', 'Discussions')).click())
-        .then(() => browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 3 * 1000))
+        .then(() => browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 3 * 1000))
         .then(() => expect(
-          element.all(by.cssContainingText('.s-discussion-list__col-title', text1)).count()
+          element.all(by.cssContainingText('.s-message-item__col-title', text1)).count()
         ).toEqual(1))
       ;
     });

--- a/src/frontend/web_application/test/functional/features/23-delete-message-spec.js
+++ b/src/frontend/web_application/test/functional/features/23-delete-message-spec.js
@@ -18,8 +18,8 @@ describe('Delete message', () => {
 
   it('delete message one by one', () => {
     const discussion1Selector = by.cssContainingText(
-      '.s-discussion-list__thread',
-      'delete a message'
+      '.s-timeline .s-message-item',
+      'last message to remove individually'
     );
     const message1ToDel = 'first message to remove individually';
     const message2ToDel = 'last message to remove individually';
@@ -31,29 +31,29 @@ describe('Delete message', () => {
     };
 
     browser.get('/')
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 5 * 1000))
       .then(() => element(discussion1Selector).click())
       .then(() => browser.wait(EC.presenceOf($('.m-message-list')), 5 * 1000))
       .then(() => deleteAMessage(message1ToDel))
       .then(() => browser.wait(EC.presenceOf($('.m-message-list')), 5 * 1000))
       .then(() => expect(element(by.cssContainingText('.m-message', message1ToDel)).isPresent()).toBe(false))
       .then(() => deleteAMessage(message2ToDel))
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline')), 5 * 1000))
       ;
   });
 
   it('delete all messages of a collection', () => {
     const discussionSelector = by.cssContainingText(
-      '.s-discussion-list__thread',
-      'delete all messages'
+      '.s-timeline .s-message-item',
+      'a message of a collection to remove'
     );
 
     browser.get('/')
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list__thread')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline .s-message-item')), 5 * 1000))
       .then(() => element(discussionSelector).click())
       .then(() => browser.wait(EC.presenceOf($('.m-message-list')), 5 * 1000))
       .then(() => element(by.cssContainingText('.m-message-list__action', __('delete'))).click())
-      .then(() => browser.wait(EC.presenceOf($('.s-discussion-list')), 5 * 1000))
+      .then(() => browser.wait(EC.presenceOf($('.s-timeline')), 5 * 1000))
       ;
   });
 });

--- a/src/frontend/web_application/test/functional/protractor.conf.js
+++ b/src/frontend/web_application/test/functional/protractor.conf.js
@@ -5,6 +5,12 @@ const cfg = {
     // firefox
     browserName: 'chrome',
     maxInstances: 1,
+    chromeOptions: {
+      args: ['lang=en-US'],
+      prefs: {
+        intl: { accept_languages: 'en-US' },
+      },
+    },
   },
   specs: ['./features/**/*-spec.js'],
   jasmineNodeOpts: {


### PR DESCRIPTION
After this PR, « X-Caliopen-IL » HTTP header will be mandatory on routes : 

- /v1/discussions
- /v2/messages
- /v2/search

X-Caliopen-IL defaults to [-10,10] if invalid values are provided.
Discussions and messages are filtered according to the importance level range provided.
On route `/search`, the header is always required, but only taken into account if `doctype=message` (see search API documentation).