### PR TITLE
Feature/backend/importance level filtering

### DIFF
--- a/doc/api/Search-API-readme.md
+++ b/doc/api/Search-API-readme.md
@@ -5,6 +5,9 @@
 #####REQUEST:
 For now, search API is triggered by a simple `GET` with few query params :
 
+- ##### Mandatory header : `X-Caliopen-IL`
+    - the header is always required, *but* only taken into account if `doctype=message`.
+    - default values : -10;10
 - ##### Mandatory param : `term`
     - Example : `http://localhost:31415/api/v2/search?term=caliopdev`
     - This is the simplier request. It will trigger a fulltext search across all document types on all fields for the word « **caliopdev** ».

--- a/src/backend/defs/go-objects/search.go
+++ b/src/backend/defs/go-objects/search.go
@@ -15,6 +15,7 @@ type IndexSearch struct {
 	Terms   map[string][]string `json:"terms"`
 	User_id UUID                `json:"user_id"`
 	DocType string              `json:"doc_type"`
+	ILrange [2]int8             `json:"il_range"`
 }
 
 type IndexResult struct {
@@ -42,17 +43,14 @@ type IndexHit struct {
 
 func (is *IndexSearch) FilterQuery(service *elastic.SearchService) *elastic.SearchService {
 
-	if len(is.Terms) == 0 {
-		return service
-	}
-
 	q := elastic.NewBoolQuery()
 	for name, values := range is.Terms {
 		for _, value := range values {
 			q = q.Filter(elastic.NewTermQuery(name, value))
 		}
 	}
-
+	rq := elastic.NewRangeQuery("importance_level").Gte(is.ILrange[0]).Lte(is.ILrange[1])
+	q = q.Filter(rq)
 	service = service.Query(q)
 
 	return service

--- a/src/backend/defs/rest-api/paths/contacts.yaml
+++ b/src/backend/defs/rest-api/paths/contacts.yaml
@@ -13,6 +13,12 @@ contacts:
       description: The PI range requested in form of `1;100`
       type: string
       default: 1;100
+    - name: X-Caliopen-IL
+      in: header
+      required: true
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     - name: limit
       in: query
       required: false

--- a/src/backend/defs/rest-api/paths/discussions.yaml
+++ b/src/backend/defs/rest-api/paths/discussions.yaml
@@ -14,6 +14,12 @@ discussions:
       description: The PI range requested in form of `0;100`
       type: string
       default: 0;100
+    - name: X-Caliopen-IL
+      in: header
+      required: true
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     - name: limit
       in: query
       required: false
@@ -62,6 +68,18 @@ discussions_{discussion_id}:
       in: path
       required: true
       type: string
+    - name: X-Caliopen-PI
+      in: header
+      required: false
+      description: The PI range requested in form of `0;100`
+      type: string
+      default: 0;100
+    - name: X-Caliopen-IL
+      in: header
+      required: false
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     produces:
     - application/json
     responses:

--- a/src/backend/defs/rest-api/paths/messagesV2.yaml
+++ b/src/backend/defs/rest-api/paths/messagesV2.yaml
@@ -14,6 +14,12 @@ messages:
       description: The PI range requested in form of `0;100`
       type: string
       default: 0;100
+    - name: X-Caliopen-IL
+      in: header
+      required: true
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     - name: discussion_id
       in: query
       description: filter messages belonging to a specific discussion

--- a/src/backend/defs/rest-api/paths/search.yaml
+++ b/src/backend/defs/rest-api/paths/search.yaml
@@ -9,6 +9,12 @@ search:
     security:
     - basicAuth: []
     parameters:
+    - name: X-Caliopen-IL
+      in: header
+      required: true
+      description: The Importance Level range requested in form of `-10;10`
+      type: string
+      default: -10;10
     - name: term
       in: query
       description: the search string

--- a/src/backend/doc/api/swagger.json
+++ b/src/backend/doc/api/swagger.json
@@ -7900,6 +7900,14 @@
         ],
         "parameters": [
           {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": true,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
+          },
+          {
             "name": "term",
             "in": "query",
             "description": "the search string",

--- a/src/backend/doc/api/swagger.json
+++ b/src/backend/doc/api/swagger.json
@@ -1311,6 +1311,14 @@
             "default": "1;100"
           },
           {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": true,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,
@@ -3347,6 +3355,14 @@
             "default": "0;100"
           },
           {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": true,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,
@@ -3528,6 +3544,22 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "X-Caliopen-PI",
+            "in": "header",
+            "required": false,
+            "description": "The PI range requested in form of `0;100`",
+            "type": "string",
+            "default": "0;100"
+          },
+          {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": false,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
           }
         ],
         "produces": [
@@ -3936,6 +3968,14 @@
             "description": "The PI range requested in form of `0;100`",
             "type": "string",
             "default": "0;100"
+          },
+          {
+            "name": "X-Caliopen-IL",
+            "in": "header",
+            "required": true,
+            "description": "The Importance Level range requested in form of `-10;10`",
+            "type": "string",
+            "default": "-10;10"
           },
           {
             "name": "discussion_id",

--- a/src/backend/interfaces/REST/go.server/operations/helpers.go
+++ b/src/backend/interfaces/REST/go.server/operations/helpers.go
@@ -1,0 +1,42 @@
+package operations
+
+import (
+	"gopkg.in/gin-gonic/gin.v1"
+	"strconv"
+	"strings"
+)
+
+// fall back to default values if can't extract valid numbers.
+func GetImportanceLevel(ctx *gin.Context) (il [2]int8) {
+	il = [2]int8{-10, 10} // default values
+	var from, to int
+	var err error
+	if il_header, ok := ctx.Request.Header["X-Caliopen-Il"]; !ok {
+		return il
+	} else {
+		il_range_str := strings.Split(il_header[0], ";") // get only first value found
+		if len(il_range_str) != 2 {
+			return il
+		}
+		from, err = strconv.Atoi(il_range_str[0])
+		if err != nil {
+			from = -10
+		}
+		to, err = strconv.Atoi(il_range_str[1])
+		if err != nil {
+			to = 10
+		}
+		if from < -10 || from > 10 {
+			from = -10
+		}
+		if to < -10 || to > 10 {
+			to = 10
+		}
+		if from > to {
+			from = to
+		}
+		il[0] = int8(from)
+		il[1] = int8(to)
+		return
+	}
+}

--- a/src/backend/interfaces/REST/go.server/operations/messages/messages.go
+++ b/src/backend/interfaces/REST/go.server/operations/messages/messages.go
@@ -31,7 +31,7 @@ func GetMessagesList(ctx *gin.Context) {
 	//extract importance level
 	il_header := ctx.Request.Header["X-Caliopen-Il"][0] // get only first value found
 	il_range_str := strings.Split(il_header, ";")
-	il_range := [2]int8{0, 0}
+	il_range := [2]int8{-10, 10} // default values
 	if from, e := strconv.Atoi(il_range_str[0]); e == nil {
 		il_range[0] = int8(from)
 	}

--- a/src/backend/interfaces/REST/go.server/operations/messages/messages.go
+++ b/src/backend/interfaces/REST/go.server/operations/messages/messages.go
@@ -8,13 +8,13 @@ import (
 	"bytes"
 	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/middlewares"
+	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.main"
 	swgErr "github.com/go-openapi/errors"
 	"github.com/satori/go.uuid"
 	"gopkg.in/gin-gonic/gin.v1"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 // GET …/messages
@@ -26,17 +26,6 @@ func GetMessagesList(ctx *gin.Context) {
 		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
 		ctx.Abort()
 		return
-	}
-
-	//extract importance level
-	il_header := ctx.Request.Header["X-Caliopen-Il"][0] // get only first value found
-	il_range_str := strings.Split(il_header, ";")
-	il_range := [2]int8{-10, 10} // default values
-	if from, e := strconv.Atoi(il_range_str[0]); e == nil {
-		il_range[0] = int8(from)
-	}
-	if to, e := strconv.Atoi(il_range_str[1]); e == nil {
-		il_range[1] = int8(to)
 	}
 
 	var limit, offset int
@@ -61,7 +50,7 @@ func GetMessagesList(ctx *gin.Context) {
 		Terms:   map[string][]string(query_values),
 		Limit:   limit,
 		Offset:  offset,
-		ILrange: il_range,
+		ILrange: operations.GetImportanceLevel(ctx),
 	}
 	list, totalFound, err := caliopen.Facilities.RESTfacility.GetMessagesList(filter)
 	if err != nil {

--- a/src/backend/interfaces/REST/go.server/operations/search.go
+++ b/src/backend/interfaces/REST/go.server/operations/search.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/gin-gonic/gin.v1"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
 func SimpleSearch(ctx *gin.Context) {
@@ -21,17 +20,6 @@ func SimpleSearch(ctx *gin.Context) {
 		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
 		ctx.Abort()
 		return
-	}
-
-	//extract importance level
-	il_header := ctx.Request.Header["X-Caliopen-Il"][0] // get only first value found
-	il_range_str := strings.Split(il_header, ";")
-	il_range := [2]int8{-10, 10} // default values
-	if from, e := strconv.Atoi(il_range_str[0]); e == nil {
-		il_range[0] = int8(from)
-	}
-	if to, e := strconv.Atoi(il_range_str[1]); e == nil {
-		il_range[1] = int8(to)
 	}
 
 	user_uuid, _ := uuid.FromString(ctx.MustGet("user_id").(string))
@@ -83,7 +71,7 @@ func SimpleSearch(ctx *gin.Context) {
 		User_id: user_UUID,
 		Limit:   limit,
 		Offset:  offset,
-		ILrange: il_range,
+		ILrange: GetImportanceLevel(ctx),
 	}
 
 	if field, ok := query["field"]; ok {

--- a/src/backend/interfaces/REST/py.server/caliopen_api/message/discussion.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/message/discussion.py
@@ -55,4 +55,4 @@ class Discussion(Api):
         # return resp
         discussion_id = self.request.swagger_data['discussion_id']
         raise HTTPMovedPermanently(
-            location="/V2/messages?discussion_id=" + discussion_id)
+            location="/v2/messages?discussion_id=" + discussion_id)

--- a/src/backend/interfaces/REST/py.server/caliopen_api/message/discussion.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/message/discussion.py
@@ -2,14 +2,9 @@ import logging
 
 from cornice.resource import resource, view
 
-from caliopen_main.discussion.core.discussion import (MainView,
-                                                      Discussion as UserDiscussion,
-                                                      build_discussion)
+from caliopen_main.discussion.core.discussion import MainView
 from ..base import Api
-from caliopen_main.discussion.store.discussion_index import \
-    DiscussionIndexManager as DIM
-from caliopen_storage.exception import NotFound
-from ..base.exception import ResourceNotFound
+from pyramid.httpexceptions import HTTPBadRequest, HTTPMovedPermanently
 
 log = logging.getLogger(__name__)
 
@@ -24,8 +19,15 @@ class Discussion(Api):
     @view(renderer='json', permission='authenticated')
     def collection_get(self):
         pi_range = self.request.authenticated_userid.pi_range
+        try:
+            il_range = self.request.authenticated_userid._get_il_range()
+        except Exception as exc:
+            log.warn(exc)
+            raise HTTPBadRequest
+
         view = MainView()
         result = view.get(self.user, pi_range[0], pi_range[1],
+                          il_range[0], il_range[1],
                           limit=self.get_limit(),
                           offset=self.get_offset())
 
@@ -34,19 +36,23 @@ class Discussion(Api):
 
     @view(renderer='json', permission='authenticated')
     def get(self):
+        # LEGACY CODE. ROUTE MOVED TO API V2
+        # discussion_id = self.request.swagger_data['discussion_id']
+        # try:
+        #     discussion = UserDiscussion.get(self.user, discussion_id)
+        # except NotFound:
+        #     raise ResourceNotFound('No such discussion %r' % discussion_id)
+        #
+        # dim = DIM(self.user.id)
+        #
+        # indexed_discussion = dim.get_by_id(discussion_id)
+        # if indexed_discussion:
+        #     resp = build_discussion(discussion, indexed_discussion)
+        # else:
+        #     raise ResourceNotFound(
+        #         'Discussion {} not found in index'.format(discussion_id))
+        #
+        # return resp
         discussion_id = self.request.swagger_data['discussion_id']
-        try:
-            discussion = UserDiscussion.get(self.user, discussion_id)
-        except NotFound:
-            raise ResourceNotFound('No such discussion %r' % discussion_id)
-
-        dim = DIM(self.user.id)
-
-        indexed_discussion = dim.get_by_id(discussion_id)
-        if indexed_discussion:
-            resp = build_discussion(discussion, indexed_discussion)
-        else:
-            raise ResourceNotFound(
-                'Discussion {} not found in index'.format(discussion_id))
-
-        return resp
+        raise HTTPMovedPermanently(
+            location="/V2/messages?discussion_id=" + discussion_id)

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/authentication.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/authentication.py
@@ -8,7 +8,6 @@ from zope.interface import implements, implementer
 from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
 from pyramid.security import Everyone, NO_PERMISSION_REQUIRED
 
-
 from caliopen_main.user.core import User
 from ..base.exception import AuthenticationError
 
@@ -16,7 +15,6 @@ log = logging.getLogger(__name__)
 
 
 class AuthenticatedUser(object):
-
     """Represent an authenticated user."""
 
     def __init__(self, request):
@@ -63,6 +61,21 @@ class AuthenticatedUser(object):
             log.error('Invalid range for PI {}: {}'.format(pi_range, exc))
         return (-1, -1)
 
+    def _get_il_range(self):
+        il_range = self.request.headers.get('X-Caliopen-IL', None)
+        if not il_range:
+            log.warn('No X-Caliopen-IL header')
+            raise ValueError
+        min_il, max_il = il_range.split(';', 1)
+        try:
+            return (int(min_il), int(max_il))
+        except ValueError:
+            log.error('Invalid value for IL {}'.format(il_range))
+            raise ValueError
+        except Exception as exc:
+            log.error('Invalid range for IL {}: {}'.format(il_range, exc))
+            raise exc
+
     def _load_user(self):
         if self._user:
             return
@@ -80,7 +93,6 @@ class AuthenticatedUser(object):
 
 
 class AuthenticationPolicy(object):
-
     """Global authentication policy."""
 
     implements(IAuthenticationPolicy)
@@ -118,7 +130,6 @@ class AuthenticationPolicy(object):
 
 @implementer(IAuthorizationPolicy)
 class AuthorizationPolicy(object):
-
     """Basic authorization policy."""
 
     def permits(self, context, principals, permission):

--- a/src/backend/main/go.backends/index/elasticsearch/broad_search.go
+++ b/src/backend/main/go.backends/index/elasticsearch/broad_search.go
@@ -23,21 +23,30 @@ func (es *ElasticSearchBackend) Search(search IndexSearch) (result *IndexResult,
 	for field, value := range search.Terms {
 		q = q.Must(elastic.NewCommonTermsQuery(field, value).CutoffFrequency(0.01)) //words that have a document frequency greater than 1% will be treated as common terms.
 	}
-	rq := elastic.NewRangeQuery("importance_level").Gte(search.ILrange[0]).Lte(search.ILrange[1])
-	q = q.Filter(rq)
 
 	// make aggregation to file docs by type:
 	// get only the 5 most relevant doc for each type if search.DocType is empty
 	// otherwise get docs according to limit & offset params.
 	var s *elastic.SearchService
-	if search.DocType == "" {
+	switch search.DocType {
+	case "":
 		// no doctype provided. Trigger search on all document types within index and build an aggregation
 		h := elastic.NewHighlight().Fields(elastic.NewHighlighterField("*").RequireFieldMatch(false))
 		top_hits := elastic.NewTopHitsAggregation().Size(5).FetchSource(true).Highlight(h)
 		by_type := elastic.NewTermsAggregation().Field("_type").SubAggregation(sub_agg_key, top_hits)
-		s = es.Client.Search().Index(search.User_id.String()).Query(q).FetchSource(false).Aggregation(agg_key, by_type)
-	} else {
-		// The search focuses on a specified document type, no aggregation needed.
+		//TODO/WIP
+		/*iq := elastic.NewIndicesQuery(elastic.NewRangeQuery("importance_level").Gte(search.ILrange[0]).Lte(search.ILrange[1]), MessageIndexType)
+		msg_hits := elastic.NewFilterAggregation().Filter(iq)
+		*/
+		s = es.Client.Search().Index(search.User_id.String()).Query(q).FetchSource(false).Aggregation(agg_key, by_type).Highlight(h)
+	case MessageIndexType:
+		// The search focuses on message document type, no aggregation needed, but importance level apply
+		h := elastic.NewHighlight().Fields(elastic.NewHighlighterField("*").RequireFieldMatch(false))
+		rq := elastic.NewRangeQuery("importance_level").Gte(search.ILrange[0]).Lte(search.ILrange[1])
+		q = q.Filter(rq)
+		s = es.Client.Search().Index(search.User_id.String()).Query(q).FetchSource(true).Highlight(h)
+	case ContactIndexType:
+		// The search focuses on message document type, no aggregation needed and importance level not taken into account
 		h := elastic.NewHighlight().Fields(elastic.NewHighlighterField("*").RequireFieldMatch(false))
 		s = es.Client.Search().Index(search.User_id.String()).Query(q).FetchSource(true).Highlight(h)
 	}
@@ -110,7 +119,6 @@ func (es *ElasticSearchBackend) Search(search IndexSearch) (result *IndexResult,
 
 	} else {
 		// elastic returns buckets aggregation as a raw []byte, need to unmarshal
-
 		by_types, _ := response.Aggregations[agg_key] // by_types is a *json.RawMessage
 		var agg map[string]interface{}
 		err = json.Unmarshal(*by_types, &agg)

--- a/src/backend/main/go.backends/index/elasticsearch/broad_search.go
+++ b/src/backend/main/go.backends/index/elasticsearch/broad_search.go
@@ -23,6 +23,8 @@ func (es *ElasticSearchBackend) Search(search IndexSearch) (result *IndexResult,
 	for field, value := range search.Terms {
 		q = q.Must(elastic.NewCommonTermsQuery(field, value).CutoffFrequency(0.01)) //words that have a document frequency greater than 1% will be treated as common terms.
 	}
+	rq := elastic.NewRangeQuery("importance_level").Gte(search.ILrange[0]).Lte(search.ILrange[1])
+	q = q.Filter(rq)
 
 	// make aggregation to file docs by type:
 	// get only the 5 most relevant doc for each type if search.DocType is empty

--- a/src/backend/main/go.backends/index/elasticsearch/messages.go
+++ b/src/backend/main/go.backends/index/elasticsearch/messages.go
@@ -68,6 +68,7 @@ func (es *ElasticSearchBackend) FilterMessages(filter objects.IndexSearch) (mess
 	if filter.Limit > 0 {
 		search = search.Size(filter.Limit)
 	}
+
 	result, err := search.Do(context.TODO())
 
 	if err != nil {

--- a/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
+++ b/src/backend/main/py.main/caliopen_main/discussion/core/discussion.py
@@ -102,12 +102,13 @@ class MainView(object):
             if core:
                 yield build_discussion(core, discussion)
 
-    def get(self, user, min_pi, max_pi, limit, offset):
+    def get(self, user, min_pi, max_pi, min_il, max_il, limit, offset):
         """Build the main view results."""
         # XXX use of correct pagination and correct datasource (index)
         dim = DIM(user.user_id)
         discussions, total = dim.list_discussions(limit=limit, offset=offset,
-                                                  min_pi=min_pi, max_pi=max_pi)
+                                                  min_pi=min_pi, max_pi=max_pi,
+                                                  min_il=min_il, max_il=max_il)
         responses = self.build_responses(user, discussions)
         return {'discussions': list(responses), 'total': total}
 


### PR DESCRIPTION
After this PR, « X-Caliopen-IL » HTTP header will be mandatory on routes : 

- /v1/discussions
- /v2/messages
- /v2/search

X-Caliopen-IL defaults to [-10,10] if invalid values are provided.
Discussions and messages are filtered according to the importance level range provided.
On route `/search`, the header is always required, but only taken into account if `doctype=message` (see search API documentation).