### PR TITLE
Copy swagger.json into release directory

### DIFF
--- a/devtools/make_release
+++ b/devtools/make_release
@@ -161,6 +161,11 @@ def make_packages(config, version, languages):
         release = {'version': version, 'date': datetime.utcnow().isoformat(),
                    'packages': RELEASE_PACKAGES}
         f.write(json.dumps(release, indent=4))
+    # Copy swagger.json into release directory
+    swagger_src_file = '{}/src/backend/doc/api/swagger.json'.format(basedir)
+    swagger_dst_file = '{}/swagger.json'.format(output_directory)
+    shutil.copyfile(swagger_src_file, swagger_dst_file)
+
     return True
 
 


### PR DESCRIPTION
Add the swagger.json in the dist/<version> repository. This file is needed during deployment for both apiv1 and api2 (and will be deployed as /etc/caliopen/swagger.json)