### PR TITLE
Upgrade react-redux-scroll

### DIFF
--- a/src/frontend/web_application/package.json
+++ b/src/frontend/web_application/package.json
@@ -83,7 +83,7 @@
     "react-moment": "^0.6.5",
     "react-redux": "^5.0.6",
     "react-redux-notify": "^2.0.0",
-    "react-redux-scroll": "^0.0.10",
+    "react-redux-scroll": "^0.0.12",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "next",
     "react-swipeable": "^4.1.0",

--- a/src/frontend/web_application/src/scenes/MessageList/components/DraftForm/index.js
+++ b/src/frontend/web_application/src/scenes/MessageList/components/DraftForm/index.js
@@ -1,16 +1,11 @@
 import { createSelector } from 'reselect';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
+import { scrollToWhen } from 'react-redux-scroll';
 import { editDraft, requestDraft, saveDraft, sendDraft } from '../../../../store/modules/draft-message';
 import { REPLY_TO_MESSAGE } from '../../../../store/modules/message';
 import { getLastMessage } from '../../../../services/message';
 import Presenter from './presenter';
-
-let scrollToWhen;
-
-if (BUILD_TARGET === 'browser') {
-  scrollToWhen = require('react-redux-scroll').scrollToWhen; // eslint-disable-line
-}
 
 const messageDraftSelector = state => state.draftMessage.draftsByInternalId;
 const discussionIdSelector = (state, ownProps) => ownProps.discussionId;
@@ -54,5 +49,5 @@ const mapDispatchToProps = dispatch => bindActionCreators({
 
 export default compose(...[
   connect(mapStateToProps, mapDispatchToProps),
-  ...(scrollToWhen ? [scrollToWhen(REPLY_TO_MESSAGE)] : []),
+  scrollToWhen(REPLY_TO_MESSAGE),
 ])(Presenter);

--- a/src/frontend/web_application/src/store/configure-store.js
+++ b/src/frontend/web_application/src/store/configure-store.js
@@ -1,4 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
+import { createScrollMiddleware } from 'react-redux-scroll';
 import rootReducer from './reducer';
 import applicationMiddleware from './middlewares/application-middleware';
 import axiosMiddleware from './middlewares/axios-middleware';
@@ -32,6 +33,7 @@ const middlewares = [
   tabsMiddleware,
   tagsMiddleware,
   thunkMiddleware,
+  createScrollMiddleware(),
 ];
 
 if (CALIOPEN_ENV === 'development' || CALIOPEN_ENV === 'staging') {
@@ -40,7 +42,6 @@ if (CALIOPEN_ENV === 'development' || CALIOPEN_ENV === 'staging') {
 }
 
 if (BUILD_TARGET === 'browser') {
-  middlewares.push(require('react-redux-scroll').createScrollMiddleware()); // eslint-disable-line
   middlewares.push(require('./middlewares/openpgp-middleware').default); // eslint-disable-line
 }
 

--- a/src/frontend/web_application/yarn.lock
+++ b/src/frontend/web_application/yarn.lock
@@ -8825,9 +8825,9 @@ react-redux-notify@^2.0.0:
     classnames "^2.2.5"
     react-transition-group "^1.2.1"
 
-react-redux-scroll@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/react-redux-scroll/-/react-redux-scroll-0.0.10.tgz#6272d8e70db20ba003d6f7c2a7121e9485e6be6f"
+react-redux-scroll@0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/react-redux-scroll/-/react-redux-scroll-0.0.12.tgz#fca13f490ffb1d24131b34df1e282c2730cb8938"
 
 react-redux@^5.0.6:
   version "5.0.6"


### PR DESCRIPTION
I think that with the [latest version of `react-redux-scroll`](https://github.com/josepot/react-redux-scroll/pull/8/files) there won't be a need to check for the `BUILD_TARGET` value.

See the discussion [here](https://github.com/josepot/react-redux-scroll/pull/7#issuecomment-339272974).

cc @iamdey 