### PR TITLE
Hot fix call-to-action

### DIFF
--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ActionButton/index.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/components/ActionButton/index.jsx
@@ -25,7 +25,7 @@ class ActionButton extends PureComponent {
 
     return (
       <Tappable {...tappableProps}>
-        <Button {...button} shape="plain" responsive="icon-only">{children}</Button>
+        <Button {...button} shape="plain">{children}</Button>
       </Tappable>
     );
   }

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/index.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/index.jsx
@@ -3,37 +3,44 @@ import { createSelector } from 'reselect';
 import { withRouter, matchPath } from 'react-router-dom';
 import { connect } from 'react-redux';
 import Presenter from './presenter';
-import { ComposeButton, CreateContactButton, ComposeContactButton, ReplyButton } from './components';
+import { ComposeButton, CreateContactButton /* , ComposeContactButton, ReplyButton */} from './components';
 
-const applicationSelector = state => state.application.applicationName;
+// ** hot fix **
+// ** no more principalActionSelector: all actions are stored in availableActionsSelector
+// ** display same call-to-action on every page and every application
+// ** hide ComposeContactButton and ReplyButton
+// FIXME: refactor or delete call-to-action component according to new UI
+
+
+// const applicationSelector = state => state.application.applicationName;
 
 const defaultActionsSelector = createSelector(
   state => state,
   () => ([
     {
-      route: '/contacts',
-      application: 'contacts',
+      route: '/',
+      // application: 'contacts',
       children: props => (<CreateContactButton {...props} />),
     },
-    {
+    /* {
       route: '/contacts/:contactId',
       disabled: true,
       children: props => (<ComposeContactButton {...props} />),
-    },
+    }, */
     {
       route: '/',
-      application: 'discussions',
+      // application: 'discussions',
       children: props => (<ComposeButton {...props} />),
     },
-    {
+    /* {
       route: '/discussions/:discussionId',
       disabled: true,
       children: props => (<ReplyButton {...props} />),
-    },
+    }, */
   ])
 );
 
-export const principalActionSelector = createSelector(
+/* export const principalActionSelector = createSelector(
   [defaultActionsSelector, applicationSelector, (state, props) => props.location],
   (actions, applicationName, location) => actions.reduce(
     (prev, action) => {
@@ -48,22 +55,19 @@ export const principalActionSelector = createSelector(
       return prev;
     },
     undefined)
-);
+);*/
 
 export const availableActionsSelector = createSelector(
   [
     defaultActionsSelector,
-    principalActionSelector,
     (state, props) => props.location,
   ],
-  (actions, principalAction, location) => actions.filter(
-    action => !matchPath(location.pathname, { path: action.route }) &&
-      action.application && action !== principalAction
+  (actions, location) => actions.filter(
+    action => matchPath(location.pathname, { path: action.route })
   )
 );
 
 const mapStateToProps = (state, props) => ({
-  principalAction: principalActionSelector(state, props),
   availableActions: availableActionsSelector(state, props),
 });
 

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/index.spec.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/index.spec.jsx
@@ -8,7 +8,7 @@ describe('component CallToAction', () => {
     const props = { location: { pathname: '/' } };
 
     // expect(selectors.principalActionSelector(state, props).route).toEqual('/');
-    expect(selectors.availableActionsSelector(state, props).length).toEqual(1);
+    expect(selectors.availableActionsSelector(state, props).length).toEqual(2);
     expect(selectors.availableActionsSelector(state, props)[0].route).toEqual('/');
   });
 });

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/index.spec.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/index.spec.jsx
@@ -3,12 +3,12 @@ import * as selectors from './index';
 describe('component CallToAction', () => {
   it('init', () => {
     const state = {
-      application: { applicationName: '' },
+      // application: { applicationName: '' },
     };
     const props = { location: { pathname: '/' } };
 
     // expect(selectors.principalActionSelector(state, props).route).toEqual('/');
-    expect(selectors.availableActionsSelector(state, props).length).toEqual(2);
+    // expect(selectors.availableActionsSelector(state, props).length).toEqual(2);
     expect(selectors.availableActionsSelector(state, props)[0].route).toEqual('/');
   });
 });

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/index.spec.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/index.spec.jsx
@@ -7,8 +7,8 @@ describe('component CallToAction', () => {
     };
     const props = { location: { pathname: '/' } };
 
-    expect(selectors.principalActionSelector(state, props).route).toEqual('/');
+    // expect(selectors.principalActionSelector(state, props).route).toEqual('/');
     expect(selectors.availableActionsSelector(state, props).length).toEqual(1);
-    expect(selectors.availableActionsSelector(state, props)[0].route).toEqual('/contacts');
+    expect(selectors.availableActionsSelector(state, props)[0].route).toEqual('/');
   });
 });

--- a/src/frontend/web_application/src/layouts/Page/components/CallToAction/presenter.jsx
+++ b/src/frontend/web_application/src/layouts/Page/components/CallToAction/presenter.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import Button from '../../../../components/Button';
 import './style.scss';
 
 class Presenter extends Component {
   static propTypes = {
     availableActions: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-    principalAction: PropTypes.shape({}).isRequired,
   };
 
   state = {
@@ -14,7 +14,7 @@ class Presenter extends Component {
   };
 
   render() {
-    const { availableActions, principalAction } = this.props;
+    const { availableActions } = this.props;
 
     return (
       <div className="l-call-to-action">
@@ -25,11 +25,21 @@ class Presenter extends Component {
               key: idx,
             }))
           }
-          {
+
+          { /*
             principalAction.children({
-              className: classnames('m-call-to-action__btn', 'm-call-to-action__btn--principal', { 'm-call-to-action__btn--disabled': !!principalAction.disabled }),
+              className: classnames('m-call-to-action__btn',
+              'm-call-to-action__btn--principal',
+              { 'm-call-to-action__btn--disabled': !!principalAction.disabled },
+            ),
             })
-          }
+           */ }
+
+          <Button
+            icon="plus"
+            shape="plain"
+            className={classnames('m-call-to-action__btn', 'm-call-to-action__btn--principal')}
+          />
         </div>
       </div>
     );

--- a/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/style.scss
+++ b/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/style.scss
@@ -50,10 +50,8 @@
     font-weight: 600;
   }
 
-  &__draft-prefix,
   &__subject {
     color: $co-color__fg__text--low;
-    font-style: italic;
     margin-right: $co-component__spacing * 2;
   }
 

--- a/src/frontend/web_application/test/functional/features/22-compose-spec.js
+++ b/src/frontend/web_application/test/functional/features/22-compose-spec.js
@@ -21,7 +21,7 @@ describe('Compose new message', () => {
   describe('navigation between drafts', () => {
     it('creates a new draft', () => {
       const text1 = 'Compose creates a new draft';
-      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn--principal', __('Compose'));
+      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
 
       browser.get('/')
         .then(() => element(writeButtonSelector).click())
@@ -55,7 +55,7 @@ describe('Compose new message', () => {
     it('composes a new message with no recipients', () => {
       const text1 = 'new message with no rcpts ';
 
-      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn--principal', __('Compose'));
+      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
 
       browser.get('/')
         .then(() => element(writeButtonSelector).click())
@@ -90,7 +90,7 @@ describe('Compose new message', () => {
     it('composes a new message with a known recipient', () => {
       const text1 = 'new message for a known recipient';
 
-      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn--principal', __('Compose'));
+      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
 
       browser.get('/')
         .then(() => element(writeButtonSelector).click())
@@ -128,7 +128,7 @@ describe('Compose new message', () => {
 
   describe('recipient search results manipulation', () => {
     it('has no suggestions for an already selected recipient', () => {
-      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn--principal', __('Compose'));
+      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
 
       browser.get('/')
         .then(() => element(writeButtonSelector).click())
@@ -169,7 +169,7 @@ describe('Compose new message', () => {
     });
 
     it('shows and hide rcpt search results', () => {
-      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn--principal', __('Compose'));
+      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
       const dropdownSelector = by.css('.m-recipient-list__search .m-dropdown');
 
       browser.get('/')
@@ -207,7 +207,7 @@ describe('Compose new message', () => {
     });
 
     it('can use keyboard arrows to select search result', () => {
-      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn--principal', __('Compose'));
+      const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
       const searchResultItemsSelector = by.css('.m-recipient-list__search-result');
 
       browser.get('/')

--- a/src/frontend/web_application/test/functional/features/22-compose-spec.js
+++ b/src/frontend/web_application/test/functional/features/22-compose-spec.js
@@ -24,6 +24,8 @@ describe('Compose new message', () => {
       const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
 
       browser.get('/')
+      // XXX: click .btn--principal to force :hover callback actions
+        .then(() => element(by.css('.m-call-to-action__btn--principal')).click())
         .then(() => element(writeButtonSelector).click())
         .then(() => browser.wait(EC.presenceOf($('.m-new-draft')), 1000))
         .then(() => element.all(by.css('.m-navbar-item .m-item-link'))
@@ -58,6 +60,8 @@ describe('Compose new message', () => {
       const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
 
       browser.get('/')
+      // XXX: click .btn--principal to force :hover callback actions
+        .then(() => element(by.css('.m-call-to-action__btn--principal')).click())
         .then(() => element(writeButtonSelector).click())
         .then(() => browser.wait(EC.presenceOf($('.m-new-draft')), 1000))
         .then(() =>
@@ -93,6 +97,8 @@ describe('Compose new message', () => {
       const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
 
       browser.get('/')
+      // XXX: click .btn--principal to force :hover callback actions
+        .then(() => element(by.css('.m-call-to-action__btn--principal')).click())
         .then(() => element(writeButtonSelector).click())
         .then(() => browser.wait(EC.presenceOf($('.m-new-draft')), 1000))
         .then(() => {
@@ -131,6 +137,8 @@ describe('Compose new message', () => {
       const writeButtonSelector = by.cssContainingText('.m-call-to-action__btn', __('Compose'));
 
       browser.get('/')
+      // XXX: click .btn--principal to force :hover callback actions
+        .then(() => element(by.css('.m-call-to-action__btn--principal')).click())
         .then(() => element(writeButtonSelector).click())
         .then(() => browser.wait(EC.presenceOf($('.m-new-draft')), 1000))
         .then(() => {
@@ -173,6 +181,8 @@ describe('Compose new message', () => {
       const dropdownSelector = by.css('.m-recipient-list__search .m-dropdown');
 
       browser.get('/')
+      // XXX: click .btn--principal to force :hover callback actions
+        .then(() => element(by.css('.m-call-to-action__btn--principal')).click())
         .then(() => element(writeButtonSelector).click())
         .then(() => browser.wait(EC.presenceOf($('.m-new-draft')), 1000))
         .then(() => {
@@ -211,6 +221,8 @@ describe('Compose new message', () => {
       const searchResultItemsSelector = by.css('.m-recipient-list__search-result');
 
       browser.get('/')
+      // XXX: click .btn--principal to force :hover callback actions
+        .then(() => element(by.css('.m-call-to-action__btn--principal')).click())
         .then(() => element(writeButtonSelector).click())
         .then(() => browser.wait(EC.presenceOf($('.m-new-draft')), 1000))
         .then(() => {

--- a/src/frontend/web_application/test/functional/features/40-new-contact-spec.js
+++ b/src/frontend/web_application/test/functional/features/40-new-contact-spec.js
@@ -26,8 +26,8 @@ describe('Create new contact', () => {
     const name = 'Foobar';
 
     browser.get('./')
-      // XXX: click compose to force :hover callback actions
-      .then(() => element(by.cssContainingText('.m-call-to-action__btn--principal', __('compose'))).click())
+      // XXX: click .btn--principal to force :hover callback actions
+      .then(() => element(by.css('.m-call-to-action__btn--principal')).click())
       .then(() => element(createButtonSelector).click())
       .then(() => browser.wait(EC.presenceOf($('.s-contact .m-contact-profile-form')), 1000))
       .then(() => element(by.css('.m-contact-profile-form__input input[name="given_name"]')).sendKeys(name))


### PR DESCRIPTION
- no more principalActionSelector: all actions are stored in
availableActionsSelector
- display same call-to-action on every page (ComposeButton,
CreateContactButton)
- hide ComposeContactButton and ReplyButton