### PR TITLE
Not try to unmarshal nil map if nested objects are empty.

### DIFF
--- a/src/backend/defs/go-objects/contact.go
+++ b/src/backend/defs/go-objects/contact.go
@@ -172,7 +172,7 @@ func (c *Contact) UnmarshalMap(input map[string]interface{}) error {
 
 	c.AdditionalName, _ = input["additional_name"].(string)
 	//addresses
-	if pa, ok := input["addresses"]; ok {
+	if pa, ok := input["addresses"]; ok && pa != nil {
 		for _, address := range pa.([]interface{}) {
 			PA := new(PostalAddress)
 			if err := PA.UnmarshalMap(address.(map[string]interface{})); err == nil {
@@ -194,7 +194,7 @@ func (c *Contact) UnmarshalMap(input map[string]interface{}) error {
 	}
 	c.Deleted, _ = input["deleted"].(bool)
 	//emails
-	if emails, ok := input["emails"]; ok {
+	if emails, ok := input["emails"]; ok && emails != nil {
 		for _, email := range emails.([]interface{}) {
 			E := new(EmailContact)
 			if err := E.UnmarshalMap(email.(map[string]interface{})); err == nil {
@@ -207,7 +207,7 @@ func (c *Contact) UnmarshalMap(input map[string]interface{}) error {
 	c.GivenName, _ = input["given_name"].(string)
 	c.Groups, _ = input["groups"].([]string)
 	//identities
-	if identities, ok := input["identities"]; ok {
+	if identities, ok := input["identities"]; ok && identities != nil {
 		for _, identity := range identities.([]interface{}) {
 			I := new(SocialIdentity)
 			if err := I.UnmarshalMap(identity.(map[string]interface{})); err == nil {
@@ -216,7 +216,7 @@ func (c *Contact) UnmarshalMap(input map[string]interface{}) error {
 		}
 	}
 	//Ims
-	if ims, ok := input["ims"]; ok {
+	if ims, ok := input["ims"]; ok && ims != nil {
 		for _, im := range ims.([]interface{}) {
 			I := new(IM)
 			if err := I.UnmarshalMap(im.(map[string]interface{})); err == nil {
@@ -228,7 +228,7 @@ func (c *Contact) UnmarshalMap(input map[string]interface{}) error {
 	c.NamePrefix, _ = input["name_prefix"].(string)
 	c.NameSuffix, _ = input["name_suffix"].(string)
 	//organizations
-	if orgas, ok := input["organizations"]; ok {
+	if orgas, ok := input["organizations"]; ok && orgas != nil {
 		for _, orga := range orgas.([]interface{}) {
 			O := new(Organization)
 			if err := O.UnmarshalMap(orga.(map[string]interface{})); err == nil {
@@ -237,7 +237,7 @@ func (c *Contact) UnmarshalMap(input map[string]interface{}) error {
 		}
 	}
 	//phones
-	if phones, ok := input["phones"]; ok {
+	if phones, ok := input["phones"]; ok && phones != nil {
 		for _, phone := range phones.([]interface{}) {
 			P := new(Phone)
 			if err := P.UnmarshalMap(phone.(map[string]interface{})); err == nil {
@@ -262,13 +262,13 @@ func (c *Contact) UnmarshalMap(input map[string]interface{}) error {
 		}
 	}
 	// Privacy features
-	if pf, ok := input["privacy_features"]; ok {
+	if pf, ok := input["privacy_features"]; ok && pf != nil {
 		PF := &PrivacyFeatures{}
 		PF.UnmarshalMap(pf.(map[string]interface{}))
 		c.PrivacyFeatures = PF
 	}
 	//tags
-	if tags, ok := input["tags"]; ok {
+	if tags, ok := input["tags"]; ok && tags != nil {
 		for _, tag := range tags.([]interface{}) {
 			T := new(Tag)
 			if err := T.UnmarshalMap(tag.(map[string]interface{})); err == nil {

--- a/src/backend/defs/go-objects/message.go
+++ b/src/backend/defs/go-objects/message.go
@@ -165,8 +165,8 @@ func (msg *Message) UnmarshalJSON(b []byte) error {
 }
 
 func (msg *Message) UnmarshalMap(input map[string]interface{}) error {
-	if _, ok := input["attachments"]; ok {
-		for _, attachment := range input["attachments"].([]interface{}) {
+	if attachments, ok := input["attachments"]; ok && attachments != nil {
+		for _, attachment := range attachments.([]interface{}) {
 			A := new(Attachment)
 			if err := A.UnmarshalMap(attachment.(map[string]interface{})); err == nil {
 				msg.Attachments = append(msg.Attachments, *A)
@@ -192,11 +192,11 @@ func (msg *Message) UnmarshalMap(input map[string]interface{}) error {
 	msg.External_references = ExternalReferences{
 		Ancestors_ids: []string{},
 	}
-	if ex_ref, ok := input["external_references"].(map[string]interface{}); ok {
-		msg.External_references.UnmarshalMap(ex_ref)
+	if ex_ref, ok := input["external_references"]; ok && ex_ref != nil {
+		msg.External_references.UnmarshalMap(ex_ref.(map[string]interface{}))
 	}
-	if _, ok := input["identities"]; ok {
-		for _, identity := range input["identities"].([]interface{}) {
+	if identities, ok := input["identities"]; ok && identities != nil {
+		for _, identity := range identities.([]interface{}) {
 			I := new(Identity)
 			if err := I.UnmarshalMap(identity.(map[string]interface{})); err == nil {
 				msg.Identities = append(msg.Identities, *I)
@@ -221,22 +221,22 @@ func (msg *Message) UnmarshalMap(input map[string]interface{}) error {
 	}
 
 	msg.Participants = []Participant{}
-	if _, ok := input["participants"]; ok {
-		for _, participant := range input["participants"].([]interface{}) {
+	if participants, ok := input["participants"]; ok && participants != nil {
+		for _, participant := range participants.([]interface{}) {
 			P := new(Participant)
 			if err := P.UnmarshalMap(participant.(map[string]interface{})); err == nil {
 				msg.Participants = append(msg.Participants, *P)
 			}
 		}
 	}
-	if i_pi, ok := input["pi"]; ok {
+	if i_pi, ok := input["pi"]; ok && i_pi != nil {
 		pi := new(PrivacyIndex)
 		pi.UnmarshalMap(i_pi.(map[string]interface{}))
 		msg.PrivacyIndex = pi
 	} else {
 		msg.PrivacyIndex = new(PrivacyIndex)
 	}
-	if pf, ok := input["privacy_features"]; ok {
+	if pf, ok := input["privacy_features"]; ok && pf != nil {
 		PF := &PrivacyFeatures{}
 		PF.UnmarshalMap(pf.(map[string]interface{}))
 		msg.Privacy_features = *PF
@@ -247,7 +247,7 @@ func (msg *Message) UnmarshalMap(input map[string]interface{}) error {
 		}
 	}
 	msg.Subject, _ = input["subject"].(string)
-	if tags, ok := input["tags"]; ok {
+	if tags, ok := input["tags"]; ok && tags != nil {
 		for _, tag := range tags.([]interface{}) {
 			T := new(Tag)
 			if err := T.UnmarshalMap(tag.(map[string]interface{})); err == nil {
@@ -287,10 +287,10 @@ func (msg *Message) UnmarshalCQLMap(input map[string]interface{}) error {
 	if discussion_id, ok := input["discussion_id"].(gocql.UUID); ok {
 		msg.Discussion_id.UnmarshalBinary(discussion_id.Bytes())
 	}
-	if ex_ref, ok := input["external_references"].(map[string]interface{}); ok {
-		msg.External_references = ExternalReferences{
-			Ancestors_ids: []string{},
-		}
+	msg.External_references = ExternalReferences{
+		Ancestors_ids: []string{},
+	}
+	if ex_ref, ok := input["external_references"].(map[string]interface{}); ok && ex_ref != nil {
 		if ids, ok := ex_ref["ancestors_ids"]; ok && len(ids.([]string)) > 0 {
 			msg.External_references.Ancestors_ids, _ = ids.([]string)
 		} else {
@@ -299,8 +299,8 @@ func (msg *Message) UnmarshalCQLMap(input map[string]interface{}) error {
 		msg.External_references.Message_id, _ = ex_ref["message_id"].(string)
 		msg.External_references.Parent_id, _ = ex_ref["parent_id"].(string)
 	}
-	if _, ok := input["identities"]; ok {
-		for _, identity := range input["identities"].([]map[string]interface{}) {
+	if identities, ok := input["identities"]; ok && identities != nil {
+		for _, identity := range identities.([]map[string]interface{}) {
 			i := Identity{}
 			i.Identifier, _ = identity["identifier"].(string)
 			i.Type, _ = identity["type"].(string)
@@ -320,8 +320,8 @@ func (msg *Message) UnmarshalCQLMap(input map[string]interface{}) error {
 	parent_id, _ := input["parent_id"].(gocql.UUID)
 	msg.Parent_id.UnmarshalBinary(parent_id.Bytes())
 
-	if _, ok := input["participants"]; ok {
-		for _, participant := range input["participants"].([]map[string]interface{}) {
+	if participants, ok := input["participants"]; ok && participants != nil {
+		for _, participant := range participants.([]map[string]interface{}) {
 			p := Participant{}
 			p.Address, _ = participant["address"].(string)
 			p.Label, _ = participant["label"].(string)
@@ -338,14 +338,17 @@ func (msg *Message) UnmarshalCQLMap(input map[string]interface{}) error {
 			msg.Participants = append(msg.Participants, p)
 		}
 	}
-	i_pi, _ := input["pi"].(map[string]interface{})
-	pi := PrivacyIndex{}
-	pi.Comportment, _ = i_pi["comportment"].(int)
-	pi.Context, _ = i_pi["context"].(int)
-	pi.DateUpdate, _ = i_pi["date_update"].(time.Time)
-	pi.Technic, _ = i_pi["technic"].(int)
-	pi.Version, _ = i_pi["version"].(int)
-	msg.PrivacyIndex = &pi
+	if i_pi, ok := input["pi"].(map[string]interface{}); ok && i_pi != nil {
+		pi := PrivacyIndex{}
+		pi.Comportment, _ = i_pi["comportment"].(int)
+		pi.Context, _ = i_pi["context"].(int)
+		pi.DateUpdate, _ = i_pi["date_update"].(time.Time)
+		pi.Technic, _ = i_pi["technic"].(int)
+		pi.Version, _ = i_pi["version"].(int)
+		msg.PrivacyIndex = &pi
+	} else {
+		msg.PrivacyIndex = new(PrivacyIndex)
+	}
 	//TODO: privacy_features
 	if raw_msg_id, ok := input["raw_msg_id"].(gocql.UUID); ok {
 		msg.Raw_msg_id.UnmarshalBinary(raw_msg_id.Bytes())

--- a/src/backend/defs/go-objects/participant.go
+++ b/src/backend/defs/go-objects/participant.go
@@ -28,8 +28,8 @@ func (p *Participant) UnmarshalMap(input map[string]interface{}) error {
 	p.Protocol, _ = input["protocol"].(string)
 	p.Type, _ = input["type"].(string)
 	p.Contact_ids = []UUID{}
-	if _, ok := input["contact_ids"]; ok {
-		for _, contact_id := range input["contact_ids"].([]interface{}) {
+	if contact_ids, ok := input["contact_ids"]; ok && contact_ids != nil {
+		for _, contact_id := range contact_ids.([]interface{}) {
 			c_id := contact_id.(string)
 			var contact_uuid UUID
 			if id, err := uuid.FromString(c_id); err == nil {

--- a/src/backend/defs/go-objects/public_key.go
+++ b/src/backend/defs/go-objects/public_key.go
@@ -68,7 +68,7 @@ func (pk *PublicKey) UnmarshalMap(input map[string]interface{}) error {
 	pk.Key, _ = input["key"].(string)
 	pk.Name, _ = input["name"].(string)
 
-	if pf, ok := input["privacy_features"]; ok {
+	if pf, ok := input["privacy_features"]; ok && pf != nil {
 		PF := &PrivacyFeatures{}
 		PF.UnmarshalMap(pf.(map[string]interface{}))
 		pk.PrivacyFeatures = PF

--- a/src/backend/defs/go-objects/user.go
+++ b/src/backend/defs/go-objects/user.go
@@ -107,14 +107,14 @@ func (user *User) UnmarshalMap(input map[string]interface{}) error {
 	password, _ := input["password"].(string)
 	user.Password = []byte(password)
 
-	if pi, ok := input["pi"]; ok {
+	if pi, ok := input["pi"]; ok && pi != nil {
 		PI := new(PrivacyIndex)
 		if err := PI.UnmarshalMap(pi.(map[string]interface{})); err == nil {
 			user.PrivacyIndex = PI
 		}
 	}
 
-	if pf, ok := input["privacy_features"]; ok {
+	if pf, ok := input["privacy_features"]; ok && pf != nil {
 		PF := &PrivacyFeatures{}
 		PF.UnmarshalMap(pf.(map[string]interface{}))
 		user.PrivacyFeatures = PF


### PR DESCRIPTION
fix errors when unmarshalling empty nested struct in go-objects in : 

* [lmtp]
* [caliopen_rest]