### PR TITLE
Feature/backend/relax contact normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- do not force phone nnumber normalization, accept everything and try to normalize
+- permit to set contact title on user input, do not compute it strictly
+
 ### Fixed
 
 - Set max file size for contact import

--- a/src/backend/defs/rest-api/objects/NewContact.yaml
+++ b/src/backend/defs/rest-api/objects/NewContact.yaml
@@ -17,6 +17,8 @@ properties:
     type: string
   given_name:
     type: string
+  title:
+    type: string
   groups:
     type: array
     items:

--- a/src/backend/defs/rest-api/objects/Phone.yaml
+++ b/src/backend/defs/rest-api/objects/Phone.yaml
@@ -4,6 +4,8 @@ properties:
   "$ref": NewPhone.yaml#/properties
   phone_id:
       type: string
+  normalized_number:
+    type: string
 required:
 - number
 additionalProperties: false

--- a/src/backend/doc/api/swagger.json
+++ b/src/backend/doc/api/swagger.json
@@ -233,6 +233,9 @@
                     "given_name": {
                       "type": "string"
                     },
+                    "title": {
+                      "type": "string"
+                    },
                     "groups": {
                       "type": "array",
                       "items": {
@@ -347,6 +350,9 @@
                         "type": "object",
                         "properties": {
                           "phone_id": {
+                            "type": "string"
+                          },
+                          "normalized_number": {
                             "type": "string"
                           },
                           "is_primary": {
@@ -482,9 +488,6 @@
                         ],
                         "additionalProperties": false
                       }
-                    },
-                    "title": {
-                      "type": "string"
                     },
                     "user_id": {
                       "type": "string"
@@ -650,6 +653,9 @@
                     "given_name": {
                       "type": "string"
                     },
+                    "title": {
+                      "type": "string"
+                    },
                     "groups": {
                       "type": "array",
                       "items": {
@@ -707,6 +713,9 @@
                         "type": "object",
                         "properties": {
                           "phone_id": {
+                            "type": "string"
+                          },
+                          "normalized_number": {
                             "type": "string"
                           },
                           "is_primary": {
@@ -2519,6 +2528,9 @@
                       "given_name": {
                         "type": "string"
                       },
+                      "title": {
+                        "type": "string"
+                      },
                       "groups": {
                         "type": "array",
                         "items": {
@@ -2633,6 +2645,9 @@
                           "type": "object",
                           "properties": {
                             "phone_id": {
+                              "type": "string"
+                            },
+                            "normalized_number": {
                               "type": "string"
                             },
                             "is_primary": {
@@ -2769,9 +2784,6 @@
                           "additionalProperties": false
                         }
                       },
-                      "title": {
-                        "type": "string"
-                      },
                       "user_id": {
                         "type": "string"
                       }
@@ -2884,6 +2896,9 @@
                 "given_name": {
                   "type": "string"
                 },
+                "title": {
+                  "type": "string"
+                },
                 "groups": {
                   "type": "array",
                   "items": {
@@ -2941,6 +2956,9 @@
                     "type": "object",
                     "properties": {
                       "phone_id": {
+                        "type": "string"
+                      },
+                      "normalized_number": {
                         "type": "string"
                       },
                       "is_primary": {
@@ -3172,6 +3190,9 @@
                 "given_name": {
                   "type": "string"
                 },
+                "title": {
+                  "type": "string"
+                },
                 "groups": {
                   "type": "array",
                   "items": {
@@ -3286,6 +3307,9 @@
                     "type": "object",
                     "properties": {
                       "phone_id": {
+                        "type": "string"
+                      },
+                      "normalized_number": {
                         "type": "string"
                       },
                       "is_primary": {
@@ -3421,9 +3445,6 @@
                     ],
                     "additionalProperties": false
                   }
-                },
-                "title": {
-                  "type": "string"
                 },
                 "user_id": {
                   "type": "string"
@@ -3674,6 +3695,9 @@
                     "given_name": {
                       "type": "string"
                     },
+                    "title": {
+                      "type": "string"
+                    },
                     "groups": {
                       "type": "array",
                       "items": {
@@ -3788,6 +3812,9 @@
                         "type": "object",
                         "properties": {
                           "phone_id": {
+                            "type": "string"
+                          },
+                          "normalized_number": {
                             "type": "string"
                           },
                           "is_primary": {
@@ -3924,9 +3951,6 @@
                         "additionalProperties": false
                       }
                     },
-                    "title": {
-                      "type": "string"
-                    },
                     "user_id": {
                       "type": "string"
                     }
@@ -4022,6 +4046,9 @@
                   "type": "string"
                 },
                 "given_name": {
+                  "type": "string"
+                },
+                "title": {
                   "type": "string"
                 },
                 "groups": {
@@ -4138,6 +4165,9 @@
                     "type": "object",
                     "properties": {
                       "phone_id": {
+                        "type": "string"
+                      },
+                      "normalized_number": {
                         "type": "string"
                       },
                       "is_primary": {
@@ -4273,9 +4303,6 @@
                     ],
                     "additionalProperties": false
                   }
-                },
-                "title": {
-                  "type": "string"
                 },
                 "user_id": {
                   "type": "string"

--- a/src/backend/doc/api/swagger.json
+++ b/src/backend/doc/api/swagger.json
@@ -233,9 +233,6 @@
                     "given_name": {
                       "type": "string"
                     },
-                    "title": {
-                      "type": "string"
-                    },
                     "groups": {
                       "type": "array",
                       "items": {
@@ -488,6 +485,9 @@
                         ],
                         "additionalProperties": false
                       }
+                    },
+                    "title": {
+                      "type": "string"
                     },
                     "user_id": {
                       "type": "string"
@@ -2528,9 +2528,6 @@
                       "given_name": {
                         "type": "string"
                       },
-                      "title": {
-                        "type": "string"
-                      },
                       "groups": {
                         "type": "array",
                         "items": {
@@ -2783,6 +2780,9 @@
                           ],
                           "additionalProperties": false
                         }
+                      },
+                      "title": {
+                        "type": "string"
                       },
                       "user_id": {
                         "type": "string"
@@ -3190,9 +3190,6 @@
                 "given_name": {
                   "type": "string"
                 },
-                "title": {
-                  "type": "string"
-                },
                 "groups": {
                   "type": "array",
                   "items": {
@@ -3446,6 +3443,9 @@
                     "additionalProperties": false
                   }
                 },
+                "title": {
+                  "type": "string"
+                },
                 "user_id": {
                   "type": "string"
                 }
@@ -3693,9 +3693,6 @@
                       "type": "string"
                     },
                     "given_name": {
-                      "type": "string"
-                    },
-                    "title": {
                       "type": "string"
                     },
                     "groups": {
@@ -3951,6 +3948,9 @@
                         "additionalProperties": false
                       }
                     },
+                    "title": {
+                      "type": "string"
+                    },
                     "user_id": {
                       "type": "string"
                     }
@@ -4046,9 +4046,6 @@
                   "type": "string"
                 },
                 "given_name": {
-                  "type": "string"
-                },
-                "title": {
                   "type": "string"
                 },
                 "groups": {
@@ -4303,6 +4300,9 @@
                     ],
                     "additionalProperties": false
                   }
+                },
+                "title": {
+                  "type": "string"
                 },
                 "user_id": {
                   "type": "string"

--- a/src/backend/main/py.main/caliopen_main/contact/core.py
+++ b/src/backend/main/py.main/caliopen_main/contact/core.py
@@ -165,12 +165,12 @@ class Contact(BaseUserCore, MixinCoreRelation, MixinCoreNested):
             title = cls._compute_title(contact)
         else:
             title = contact.title
-            if not contact.given_name and contact.family_name:
+            if not contact.given_name and not contact.family_name:
                 # XXX more complex logic and not arbitrary order and character
                 if ',' in contact.title:
                     gn, fn = contact.title.split(',', 2)
-                    contact.given_name = gn
-                    contact.family_name = fn
+                    contact.given_name = gn.rstrip().lstrip()
+                    contact.family_name = fn.rstrip().lstrip()
 
         # XXX PI compute
         pi = PIModel()

--- a/src/backend/main/py.main/caliopen_main/contact/core.py
+++ b/src/backend/main/py.main/caliopen_main/contact/core.py
@@ -159,9 +159,18 @@ class Contact(BaseUserCore, MixinCoreRelation, MixinCoreNested):
                 [x.validate() for x in v]
             else:
                 raise Exception('Invalid argument to contact.create : %s' % k)
-        # XXX check and format tags and groups
-        title = cls._compute_title(contact)
+
         contact_id = uuid.uuid4()
+        if not contact.title:
+            title = cls._compute_title(contact)
+        else:
+            title = contact.title
+            if not contact.given_name and contact.family_name:
+                # XXX more complex logic and not arbitrary order and character
+                if ',' in contact.title:
+                    gn, fn = contact.title.split(',', 2)
+                    contact.given_name = gn
+                    contact.family_name = fn
 
         # XXX PI compute
         pi = PIModel()

--- a/src/backend/main/py.main/caliopen_main/contact/objects/phone.py
+++ b/src/backend/main/py.main/caliopen_main/contact/objects/phone.py
@@ -2,27 +2,50 @@
 """Caliopen contact parameters classes."""
 from __future__ import absolute_import, print_function, unicode_literals
 
+import logging
 import types
+from uuid import UUID
+import phonenumbers
+
 from caliopen_main.common.objects.base import ObjectIndexable
 from caliopen_main.common.parameters.types import PhoneNumberType
-from uuid import UUID
 from ..store.contact import Phone as ModelPhone
 from ..store.contact_index import IndexedPhone
 from ..returns import PhoneParam
 
 
+log = logging.getLogger(__name__)
+
+
 class Phone(ObjectIndexable):
 
     _attrs = {
-        "contact_id":               UUID,
-        "is_primary":               types.BooleanType,
-        "number":                   PhoneNumberType,
-        "phone_id":                 UUID,
-        "type":                     types.StringType,
-        "uri":                      types.StringType,
-        "user_id":                  UUID
+        "contact_id": UUID,
+        "is_primary": types.BooleanType,
+        "number": types.StringType,
+        "normalized_number": PhoneNumberType,
+        "phone_id": UUID,
+        "type": types.StringType,
+        "uri": types.StringType,
+        "user_id": UUID
     }
 
     _model_class = ModelPhone
     _json_model = PhoneParam
     _index_class = IndexedPhone
+
+    def normalize_number(self, number):
+        try:
+            normalized = phonenumbers.parse(number, None)
+            phone_format = phonenumbers.PhoneNumberFormat.INTERNATIONAL
+            return phonenumbers.format_number(normalized, phone_format)
+        except Exception as exc:
+            log.warn('Unable to normalize phone number {0} : {1}'.
+                     format(number, exc))
+
+    def unmarshall_dict(self, document, **options):
+        """Marshall into db object but normalized number if possible."""
+        super(self, ObjectIndexable).unmarshall_dict(document, options)
+        normalized = self.normalize_number(self.number)
+        if normalized:
+            setattr(self, 'normalized_number', normalized)

--- a/src/backend/main/py.main/caliopen_main/contact/parameters.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parameters.py
@@ -250,6 +250,7 @@ class NewContact(Model):
     emails = ListType(ModelType(NewEmail), default=lambda: [])
     family_name = StringType()
     given_name = StringType()
+    title = StringType()
     groups = ListType(StringType)
     identities = ListType(ModelType(NewSocialIdentity), default=lambda: [])
     ims = ListType(ModelType(NewIM), default=lambda: [], )
@@ -284,9 +285,7 @@ class Contact(NewContact):
     organizations = ListType(ModelType(Organization), default=lambda: [])
     phones = ListType(ModelType(Phone), default=lambda: [])
     public_keys = ListType(ModelType(PublicKey), default=lambda: [])
-    pi = ModelType(PIParameter)
-    # XXX not such default here
-    title = StringType()
+    pi = ModelType(PIParameter)    
     user_id = UUIDType()
 
     class Options:

--- a/src/backend/main/py.main/caliopen_main/contact/parameters.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parameters.py
@@ -162,7 +162,8 @@ class NewPhone(Model):
     """Input structure for a new phone."""
 
     is_primary = BooleanType(default=False)
-    number = PhoneNumberType()
+    number = StringType(required=True)
+    normalized_number = PhoneNumberType()
     type = StringType(choices=PHONE_TYPES, default='other')
     uri = StringType()
 

--- a/src/backend/main/py.main/caliopen_main/contact/parsers.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parsers.py
@@ -112,9 +112,10 @@ def parse_vcard(vcard):
                 add.postal_code = ad.value.code
                 add.region = ad.value.region
                 add.street = ad.value.street
+                adr_type = ad.params.get('TYPE', [None])[0]
                 for i in ADDRESS_TYPES:
-                    if i == ad.type_param:
-                        add.type = ad.type_param
+                    if i == adr_type:
+                        add.type = adr_type
                 if not add.type:
                     add.type = ADDRESS_TYPES[2]
                 new_contact.addresses.append(add)
@@ -193,13 +194,14 @@ def parse_vcard(vcard):
             for tel in vcard.contents['tel']:
                 phone = NewPhone()
                 phone.is_primary = False
+                phone.number = tel.value
                 try:
                     func = PhoneNumberType.validate_phone
-                    phone.number = func(PhoneNumberType(), tel.value)
-                    new_contact.phones.append(phone)
+                    phone.normalized_number = func(PhoneNumberType(),
+                                                   tel.value)
                 except:
                     pass
-
+                new_contact.phones.append(phone)
     return new_contact
 
 

--- a/src/backend/main/py.main/caliopen_main/contact/store/contact.py
+++ b/src/backend/main/py.main/caliopen_main/contact/store/contact.py
@@ -82,6 +82,7 @@ class Phone(BaseUserType):
 
     is_primary = columns.Boolean(default=False)
     number = columns.Text()
+    normalized_number = columns.Text()
     phone_id = columns.UUID(default=uuid.uuid4)
     type = columns.Text()
     uri = columns.Text()    # RFC3966

--- a/src/backend/main/py.main/caliopen_main/contact/store/contact_index.py
+++ b/src/backend/main/py.main/caliopen_main/contact/store/contact_index.py
@@ -57,6 +57,7 @@ class IndexedPhone(InnerObjectWrapper):
 
     is_primary = Boolean()
     number = Text()
+    normalized_number = Text()
     phone_id = Keyword()
     type = Keyword()
     uri = Keyword()
@@ -171,6 +172,7 @@ class IndexedContact(BaseIndexDocument):
                         properties={
                             "is_primary": "boolean",
                             "number": "text",
+                            "normalized_number": "text",
                             "phone_id": "keyword",
                             "type": "keyword",
                             "uri": "keyword"


### PR DESCRIPTION
Relax formatting constraint backend side for contact informations:
- phone number can be not normalized, will be store in Phone.normalized_value if possible
- contact title can be set by user input (not yet done)

Related to : 
https://feedback.caliopen.org/t/titre-des-contacts/96
https://feedback.caliopen.org/t/impossible-dajouter-un-numero-de-telephone/229/6
