### PR TITLE
Limit the number of users that can be created 

### DIFF
--- a/src/backend/configs/caliopen-docker.yaml
+++ b/src/backend/configs/caliopen-docker.yaml
@@ -41,6 +41,7 @@ object_store:
     location: eu-fr-localhost
 
 system:
+    max_users: 100
     default_tags:
         -
             name: INBOX

--- a/src/backend/configs/caliopen.yaml.template
+++ b/src/backend/configs/caliopen.yaml.template
@@ -35,6 +35,7 @@ object_store:
         temporary_attachments: caliopen-tmp-attachments
 
 system:
+    max_users: 2000
     default_tags:
         -
             name: INBOX

--- a/src/backend/main/py.main/caliopen_main/user/core/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/core/user.py
@@ -153,6 +153,16 @@ class User(BaseCore):
                     raise ValueError('user email not in whitelist')
 
     @classmethod
+    def _check_max_users(cls):
+        """Check if maximum number of users reached."""
+        conf = Configuration('global').get('system', {})
+        max_users = conf.get('max_users', 0)
+        if max_users:
+            nb_users = User._model_class.objects.count()
+            if nb_users >= max_users:
+                raise ValueError('Max number of users reached')
+
+    @classmethod
     def create(cls, new_user):
         """Create a new user.
 
@@ -171,8 +181,9 @@ class User(BaseCore):
         def rollback_username_storage(username):
             UserName.get(username).delete()
 
-        # 0. check for user email white list
+        # 0. check for user email white list and max number of users
         cls._check_whitelistes(new_user)
+        cls._check_max_users()
         # 1.
         try:
             validators.is_valid_username(new_user.name)


### PR DESCRIPTION
Define a system.max_users configuration key and then API will refuse to create another user if this limit is reached