### PR TITLE
Fix/frontend/sort messages

### DIFF
--- a/devtools/api-mock/messages/data.json
+++ b/devtools/api-mock/messages/data.json
@@ -21,7 +21,7 @@
 		"type": "To"
 	}, {
 		"address": "john@caliopen.local",
-		"contact_ids": ["1039cdcc-1f6f-4b5d-9c8a-5d7c711f357f"],
+		"contact_ids": ["c-john-01"],
 		"label": "Jaune john",
 		"protocol": "email",
 		"type": "Cc"
@@ -51,7 +51,7 @@
 	"attachments": [],
 	"body": "Fry! Stay back! He's too powerful! Can I use the gun? I barely knew Philip, but as a clergyman I have no problem telling his most intimate friends all about him. What are you hacking off? Is it my torso?! 'It is!' My precious torso!",
 	"excerpt": "Fry! Stay back! He's too powerful! Can I use the gun? I barely knew Philip, but as a ...",
-	"date": "2017-03-21T12:55:00.153000+00:00",
+	"date": "2017-03-22T12:55:00.153000+00:00",
 	"date_insert": "2017-03-21T12:55:00.153000+00:00",
 	"discussion_id": "cd53e13a-267d-4d9c-97ee-d0fc59c64200",
 	"identities": [{
@@ -70,7 +70,7 @@
 		"type": "Cc"
 	}, {
 		"address": "john@caliopen.local",
-		"contact_ids": ["1039cdcc-1f6f-4b5d-9c8a-5d7c711f357f"],
+		"contact_ids": ["c-john-01"],
 		"label": "Jaune john",
 		"protocol": "email",
 		"type": "From"
@@ -113,7 +113,7 @@
 	"message_id": "2222222-267d-4d9c-97ee-d0fc59c64201",
 	"participants": [{
 		"address": "john@caliopen.local",
-		"contact_ids": ["1039cdcc-1f6f-4b5d-9c8a-5d7c711f357f"],
+		"contact_ids": ["c-john-01"],
 		"label": "foo",
 		"protocol": "email",
 		"type": "To"
@@ -162,7 +162,7 @@
 	"message_id": "3333-267d-4d9c-97ee-d0fc59c64201",
 	"participants": [{
 		"address": "john@caliopen.local",
-		"contact_ids": ["1039cdcc-1f6f-4b5d-9c8a-5d7c711f357f"],
+		"contact_ids": ["c-john-01"],
 		"label": "foo",
 		"protocol": "email",
 		"type": "To"
@@ -196,7 +196,7 @@
 	"message_id": "4444-267d-4d9c-97ee-d0fc59c64201",
 	"participants": [{
 		"address": "john@caliopen.local",
-		"contact_ids": ["1039cdcc-1f6f-4b5d-9c8a-5d7c711f357f"],
+		"contact_ids": ["c-john-01"],
 		"label": "foo",
 		"protocol": "email",
 		"type": "From"
@@ -230,7 +230,7 @@
 	"message_id": "5555-267d-4d9c-97ee-d0fc59c64201",
 	"participants": [{
 		"address": "john@caliopen.local",
-		"contact_ids": ["1039cdcc-1f6f-4b5d-9c8a-5d7c711f357f"],
+		"contact_ids": ["c-john-01"],
 		"label": "foo",
 		"protocol": "email",
 		"type": "To"
@@ -264,7 +264,7 @@
 	"message_id": "6666-267d-4d9c-97ee-d0fc59c64201",
 	"participants": [{
 		"address": "john@caliopen.local",
-		"contact_ids": ["1039cdcc-1f6f-4b5d-9c8a-5d7c711f357f"],
+		"contact_ids": ["c-john-01"],
 		"label": "foo",
 		"protocol": "email",
 		"type": "From"

--- a/devtools/api-mock/messages/index.js
+++ b/devtools/api-mock/messages/index.js
@@ -40,7 +40,7 @@ const reduceParticipants = message => [
   ...(message.participants ? filterAuthor(message.participants) : []),
   {
     address: 'john@caliopen.local',
-    contact_ids: ['1039cdcc-1f6f-4b5d-9c8a-5d7c711f357f'],
+    contact_ids: ['c-john-01'],
     label: 'Jaune john',
     protocol: 'email',
     type: 'From'

--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -74,6 +74,23 @@ class Message extends Component {
     }));
   }
 
+  renderDate = () => {
+    const { message, settings: { default_locale: locale }, isMessageFromUser } = this.props;
+    const hasDate = (isMessageFromUser && message.date)
+      || (!isMessageFromUser && message.date_insert);
+
+    return (
+      <div className="m-message__date">
+        {hasDate &&
+          <Moment format="LT" locale={locale}>
+            {isMessageFromUser ? message.date : message.date_insert}
+          </Moment>
+        }
+      </div>
+
+    );
+  }
+
   renderMessageContent = () => {
     const { message } = this.props;
 
@@ -109,8 +126,8 @@ class Message extends Component {
 
   render() {
     const {
-      message, settings: { default_locale: locale }, onDelete, onMessageUnread, onMessageRead,
-      onReply, onCopyTo, onEditTags, __, isMessageFromUser,
+      message, onDelete, onMessageUnread, onMessageRead,
+      onReply, onCopyTo, onEditTags, __,
     } = this.props;
     const author = getAuthor(message);
     const typeTranslations = {
@@ -149,10 +166,7 @@ class Message extends Component {
                 <Icon type={message.type} className="m-message__type-icon" spaced />
               </div>
             )}
-            {message.date_insert &&
-              <Moment className="m-message__date" format="LT" locale={locale}>
-                {isMessageFromUser ? message.date : message.date_insert}
-              </Moment> }
+            {this.renderDate()}
 
             <DropdownControl toggleId={this.dropdownId} className="m-message__actions-switcher" icon="ellipsis-v" />
 

--- a/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/components/Message/presenter.jsx
@@ -11,6 +11,8 @@ import TextBlock from '../../../TextBlock';
 import MultidimensionalPi from '../../../MultidimensionalPi';
 import Dropdown, { withDropdownControl } from '../../../../components/Dropdown';
 import MessageActionsContainer from '../MessageActionsContainer';
+import { getAuthor } from '../../../../services/message';
+
 import './style.scss';
 
 const DropdownControl = withDropdownControl(Button);
@@ -27,10 +29,12 @@ class Message extends Component {
     onCopyTo: PropTypes.func.isRequired,
     onEditTags: PropTypes.func.isRequired,
     settings: PropTypes.shape({}).isRequired,
+    isMessageFromUser: PropTypes.bool,
     __: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
+    isMessageFromUser: false,
   }
 
   state = {
@@ -106,9 +110,9 @@ class Message extends Component {
   render() {
     const {
       message, settings: { default_locale: locale }, onDelete, onMessageUnread, onMessageRead,
-      onReply, onCopyTo, onEditTags, __,
+      onReply, onCopyTo, onEditTags, __, isMessageFromUser,
     } = this.props;
-    const author = message.participants.find(participant => participant.type === 'From');
+    const author = getAuthor(message);
     const typeTranslations = {
       email: __('message-list.message.protocol.email'),
     };
@@ -147,7 +151,7 @@ class Message extends Component {
             )}
             {message.date_insert &&
               <Moment className="m-message__date" format="LT" locale={locale}>
-                {message.date_insert}
+                {isMessageFromUser ? message.date : message.date_insert}
               </Moment> }
 
             <DropdownControl toggleId={this.dropdownId} className="m-message__actions-switcher" icon="ellipsis-v" />

--- a/src/frontend/web_application/src/components/MessageList/index.js
+++ b/src/frontend/web_application/src/components/MessageList/index.js
@@ -1,19 +1,9 @@
 import { compose } from 'redux';
-import { createSelector } from 'reselect';
-import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
+import { withUser } from '../../hoc/user';
 import Presenter from './presenter';
 
-const userSelector = state => state.user;
-
-const mapStateToProps = createSelector(
-  [userSelector],
-  usertState => ({
-    user: usertState.user,
-  })
-);
-
 export default compose(
-  connect(mapStateToProps),
+  withUser(),
   withTranslator()
 )(Presenter);

--- a/src/frontend/web_application/src/components/MessageList/index.js
+++ b/src/frontend/web_application/src/components/MessageList/index.js
@@ -1,7 +1,19 @@
 import { compose } from 'redux';
+import { createSelector } from 'reselect';
+import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
 import Presenter from './presenter';
 
+const userSelector = state => state.user;
+
+const mapStateToProps = createSelector(
+  [userSelector],
+  usertState => ({
+    user: usertState.user,
+  })
+);
+
 export default compose(
+  connect(mapStateToProps),
   withTranslator()
 )(Presenter);

--- a/src/frontend/web_application/src/components/MessageList/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/presenter.jsx
@@ -61,7 +61,7 @@ class MessageList extends Component {
             <Message
               key={message.message_id}
               message={message}
-              isMessageFromUser={isMessageFromUser(message, user)}
+              isMessageFromUser={user && isMessageFromUser(message, user)}
               className="m-message-list__message"
               onMessageRead={onMessageRead}
               onMessageUnread={onMessageUnread}

--- a/src/frontend/web_application/src/components/MessageList/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/presenter.jsx
@@ -61,7 +61,7 @@ class MessageList extends Component {
             <Message
               key={message.message_id}
               message={message}
-              isMessageFromUser={user && isMessageFromUser(message, user)}
+              isMessageFromUser={(user && isMessageFromUser(message, user)) || false}
               className="m-message-list__message"
               onMessageRead={onMessageRead}
               onMessageUnread={onMessageUnread}

--- a/src/frontend/web_application/src/components/MessageList/presenter.jsx
+++ b/src/frontend/web_application/src/components/MessageList/presenter.jsx
@@ -6,6 +6,7 @@ import Spinner from '../Spinner';
 import DayMessageList from './components/DayMessageList';
 import Message from './components/Message';
 import groupMessages from './services/groupMessages';
+import { isMessageFromUser } from '../../services/message';
 
 import './style.scss';
 
@@ -23,6 +24,7 @@ class MessageList extends Component {
     onDelete: PropTypes.func.isRequired,
     messages: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     replyForm: PropTypes.node.isRequired,
+    user: PropTypes.shape({}),
     __: PropTypes.func.isRequired,
   };
 
@@ -30,6 +32,7 @@ class MessageList extends Component {
     isFetching: false,
     loadMore: null,
     onMessageView: null,
+    user: undefined,
   };
 
   state = {
@@ -46,9 +49,10 @@ class MessageList extends Component {
   renderDayGroups() {
     const {
       messages, onMessageRead, onMessageUnread, onMessageDelete, onMessageReply, onMessageCopyTo,
-      onMessageEditTags, __,
+      onMessageEditTags, __, user,
     } = this.props;
-    const messagesGroupedByday = groupMessages(messages);
+
+    const messagesGroupedByday = groupMessages(messages, user);
 
     return Object.keys(messagesGroupedByday)
       .map(date => (
@@ -57,6 +61,7 @@ class MessageList extends Component {
             <Message
               key={message.message_id}
               message={message}
+              isMessageFromUser={isMessageFromUser(message, user)}
               className="m-message-list__message"
               onMessageRead={onMessageRead}
               onMessageUnread={onMessageUnread}

--- a/src/frontend/web_application/src/components/MessageList/services/groupMessages/index.js
+++ b/src/frontend/web_application/src/components/MessageList/services/groupMessages/index.js
@@ -1,7 +1,15 @@
-const groupMessages = messages => [...messages]
-  .sort((a, b) => Date.parse(a.date_insert) - Date.parse(b.date_insert))
+
+import { isMessageFromUser } from '../../../../services/message';
+
+const groupMessages = (messages, user) => [...messages]
+  .sort((a, b) => Date.parse(
+    isMessageFromUser(a, user) ? a.date : a.date_insert
+  ) - Date.parse(
+    isMessageFromUser(b, user) ? b.date : b.date_insert
+  ))
   .reduce((acc, message) => {
-    const datetime = new Date(message.date_insert);
+    const datetime = new Date(
+    isMessageFromUser(message, user) ? message.date : message.date_insert);
     const oneDayAgo = new Date();
     oneDayAgo.setHours(oneDayAgo.getHours() - 24);
     let date = new Date(Date.UTC(

--- a/src/frontend/web_application/src/components/MessageList/services/groupMessages/index.js
+++ b/src/frontend/web_application/src/components/MessageList/services/groupMessages/index.js
@@ -1,15 +1,14 @@
-
 import { isMessageFromUser } from '../../../../services/message';
 
 const groupMessages = (messages, user) => [...messages]
   .sort((a, b) => Date.parse(
-    isMessageFromUser(a, user) ? a.date : a.date_insert
+    user && isMessageFromUser(a, user) ? a.date : a.date_insert
   ) - Date.parse(
-    isMessageFromUser(b, user) ? b.date : b.date_insert
+    user && isMessageFromUser(b, user) ? b.date : b.date_insert
   ))
   .reduce((acc, message) => {
     const datetime = new Date(
-    isMessageFromUser(message, user) ? message.date : message.date_insert);
+    user && isMessageFromUser(message, user) ? message.date : message.date_insert);
     const oneDayAgo = new Date();
     oneDayAgo.setHours(oneDayAgo.getHours() - 24);
     let date = new Date(Date.UTC(

--- a/src/frontend/web_application/src/hoc/user.js
+++ b/src/frontend/web_application/src/hoc/user.js
@@ -6,7 +6,6 @@ const mapStateToProps = createSelector(
   [UserSelector],
   userState => ({
     user: userState.user,
-    isFetching: userState.isFetching,
   })
 );
 

--- a/src/frontend/web_application/src/hoc/user.js
+++ b/src/frontend/web_application/src/hoc/user.js
@@ -1,0 +1,15 @@
+import { createSelector } from 'reselect';
+import { connect } from 'react-redux';
+import { UserSelector } from '../store/selectors/user';
+
+const mapStateToProps = createSelector(
+  [UserSelector],
+  userState => ({
+    user: userState.user,
+    isFetching: userState.isFetching,
+  })
+);
+
+const withUser = () => Component => connect(mapStateToProps)(Component);
+
+export { withUser };

--- a/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/presenter.jsx
@@ -9,7 +9,7 @@ import MessageItemContainer from '../MessageItemContainer';
 import Icon from '../../../../components/Icon';
 import TextBlock from '../../../../components/TextBlock';
 import Badge from '../../../../components/Badge';
-import { renderParticipant, getAuthor, isMessageFromUser } from '../../../../services/message';
+import { renderParticipant, getAuthor } from '../../../../services/message';
 
 import './style.scss';
 
@@ -17,17 +17,30 @@ class MessageItem extends PureComponent {
   static propTypes = {
     message: PropTypes.shape({}).isRequired,
     settings: PropTypes.shape({}).isRequired,
-    user: PropTypes.shape({}),
+    isMessageFromUser: PropTypes.bool.isRequired,
     __: PropTypes.func.isRequired,
-  };
-  static defaultProps = {
-    user: undefined,
   };
 
   renderAuthor() {
     const author = getAuthor(this.props.message);
 
     return renderParticipant(author);
+  }
+
+  renderDate = () => {
+    const { message, settings: { default_locale: locale }, isMessageFromUser } = this.props;
+    const hasDate = (isMessageFromUser && message.date)
+      || (!isMessageFromUser && message.date_insert);
+
+    return (
+      <div className="s-message-item__col-dates">
+        {hasDate &&
+          <Moment className="m-message__date" locale={locale} element={MessageDate}>
+            {isMessageFromUser ? message.date : message.date_insert}
+          </Moment>
+        }
+      </div>
+    );
   }
 
   renderTags() {
@@ -42,7 +55,7 @@ class MessageItem extends PureComponent {
   }
 
   render() {
-    const { message, settings: { default_locale: locale }, user, __ } = this.props;
+    const { message, __ } = this.props;
     const hash = message.is_draft ? 'reply' : message.message_id;
 
     return (
@@ -69,11 +82,7 @@ class MessageItem extends PureComponent {
           <div className="s-message-item__col-file">
             { message.attachments && <Icon type="paperclip" /> }
           </div>
-          <div className="s-message-item__col-dates">
-            <Moment className="m-message__date" locale={locale} element={MessageDate}>
-              {isMessageFromUser(message, user) ? message.date : message.date_insert}
-            </Moment>
-          </div>
+          {this.renderDate()}
         </Link>
       </MessageItemContainer>
     );

--- a/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Timeline/components/MessageItem/presenter.jsx
@@ -9,7 +9,7 @@ import MessageItemContainer from '../MessageItemContainer';
 import Icon from '../../../../components/Icon';
 import TextBlock from '../../../../components/TextBlock';
 import Badge from '../../../../components/Badge';
-import { renderParticipant } from '../../../../services/message';
+import { renderParticipant, getAuthor, isMessageFromUser } from '../../../../services/message';
 
 import './style.scss';
 
@@ -17,14 +17,15 @@ class MessageItem extends PureComponent {
   static propTypes = {
     message: PropTypes.shape({}).isRequired,
     settings: PropTypes.shape({}).isRequired,
+    user: PropTypes.shape({}),
     __: PropTypes.func.isRequired,
   };
   static defaultProps = {
+    user: undefined,
   };
 
   renderAuthor() {
-    const { message: { participants } } = this.props;
-    const author = participants.find(participant => participant.type === 'From');
+    const author = getAuthor(this.props.message);
 
     return renderParticipant(author);
   }
@@ -41,7 +42,7 @@ class MessageItem extends PureComponent {
   }
 
   render() {
-    const { message, settings: { default_locale: locale }, __ } = this.props;
+    const { message, settings: { default_locale: locale }, user, __ } = this.props;
     const hash = message.is_draft ? 'reply' : message.message_id;
 
     return (
@@ -70,7 +71,7 @@ class MessageItem extends PureComponent {
           </div>
           <div className="s-message-item__col-dates">
             <Moment className="m-message__date" locale={locale} element={MessageDate}>
-              {message.date_insert}
+              {isMessageFromUser(message, user) ? message.date : message.date_insert}
             </Moment>
           </div>
         </Link>

--- a/src/frontend/web_application/src/scenes/Timeline/index.js
+++ b/src/frontend/web_application/src/scenes/Timeline/index.js
@@ -7,14 +7,17 @@ import { requestMessages, loadMore, hasMore } from '../../store/modules/message'
 
 const timelineSelector = state => state.message.messagesCollections.timeline && state.message.messagesCollections.timeline['0'];
 const messagesSelector = state => state.message.messagesById;
+const userSelector = state => state.user;
+
 const mapStateToProps = createSelector(
-  [timelineSelector, messagesSelector],
-  (timeline, messagesById) => ({
+  [timelineSelector, messagesSelector, userSelector],
+  (timeline, messagesById, userState) => ({
     messages: timeline && timeline.messages.map(id => messagesById[id])
       .sort((a, b) => new Date(b.date_insert) - new Date(a.date_insert)),
     hasMore: timeline && hasMore(timeline),
     isFetching: timeline && timeline.isFetching,
     didInvalidate: timeline && timeline.didInvalidate,
+    user: userState.user,
   })
 );
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/src/frontend/web_application/src/scenes/Timeline/index.js
+++ b/src/frontend/web_application/src/scenes/Timeline/index.js
@@ -2,22 +2,21 @@ import { createSelector } from 'reselect';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
+import { withUser } from '../../hoc/user';
 import Presenter from './presenter';
 import { requestMessages, loadMore, hasMore } from '../../store/modules/message';
 
 const timelineSelector = state => state.message.messagesCollections.timeline && state.message.messagesCollections.timeline['0'];
 const messagesSelector = state => state.message.messagesById;
-const userSelector = state => state.user;
 
 const mapStateToProps = createSelector(
-  [timelineSelector, messagesSelector, userSelector],
-  (timeline, messagesById, userState) => ({
+  [timelineSelector, messagesSelector],
+  (timeline, messagesById) => ({
     messages: timeline && timeline.messages.map(id => messagesById[id])
       .sort((a, b) => new Date(b.date_insert) - new Date(a.date_insert)),
     hasMore: timeline && hasMore(timeline),
     isFetching: timeline && timeline.isFetching,
     didInvalidate: timeline && timeline.didInvalidate,
-    user: userState.user,
   })
 );
 const mapDispatchToProps = dispatch => bindActionCreators({
@@ -27,5 +26,6 @@ const mapDispatchToProps = dispatch => bindActionCreators({
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
+  withUser(),
   withTranslator()
 )(Presenter);

--- a/src/frontend/web_application/src/scenes/Timeline/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Timeline/presenter.jsx
@@ -8,6 +8,8 @@ import BlockList from '../../components/BlockList';
 import InfiniteScroll from '../../components/InfiniteScroll';
 import MenuBar from '../../components/MenuBar';
 import MessageItem from './components/MessageItem';
+import { isMessageFromUser } from '../../services/message';
+
 import './style.scss';
 
 const LOAD_MORE_THROTTLE = 1000;
@@ -66,8 +68,12 @@ class Timeline extends Component {
         </MenuBar>
         <InfiniteScroll onReachBottom={this.loadMore}>
           <BlockList className="s-timeline__list">
-            {messages.map(item => (
-              <MessageItem key={item.message_id} user={user} message={item} />
+            {messages.map(message => (
+              <MessageItem
+                key={message.message_id}
+                isMessageFromUser={user && isMessageFromUser(message, user)}
+                message={message}
+              />
             ))}
           </BlockList>
         </InfiniteScroll>

--- a/src/frontend/web_application/src/scenes/Timeline/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Timeline/presenter.jsx
@@ -71,7 +71,7 @@ class Timeline extends Component {
             {messages.map(message => (
               <MessageItem
                 key={message.message_id}
-                isMessageFromUser={user && isMessageFromUser(message, user)}
+                isMessageFromUser={(user && isMessageFromUser(message, user)) || false}
                 message={message}
               />
             ))}

--- a/src/frontend/web_application/src/scenes/Timeline/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Timeline/presenter.jsx
@@ -25,8 +25,8 @@ class Timeline extends Component {
   };
 
   static defaultProps = {
-    user: null,
     messages: [],
+    user: undefined,
     isFetching: false,
     didInvalidate: false,
     hasMore: false,

--- a/src/frontend/web_application/src/scenes/UserPrivacy/index.jsx
+++ b/src/frontend/web_application/src/scenes/UserPrivacy/index.jsx
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
@@ -5,12 +6,21 @@ import { withUser } from '../../hoc/user';
 import { requestUser } from '../../store/modules/user';
 import Presenter from './presenter';
 
+const userSelector = state => state.user;
+
+const mapStateToProps = createSelector(
+ [userSelector],
+ userState => ({
+   isFetching: userState.isFetching,
+ })
+);
+
 const mapDispatchToProps = dispatch => bindActionCreators({
   requestUser,
 }, dispatch);
 
 export default compose(
-  connect(null, mapDispatchToProps),
-  withUser(true),
+  connect(mapStateToProps, mapDispatchToProps),
+  withUser(),
   withTranslator()
 )(Presenter);

--- a/src/frontend/web_application/src/scenes/UserPrivacy/index.jsx
+++ b/src/frontend/web_application/src/scenes/UserPrivacy/index.jsx
@@ -1,25 +1,16 @@
-import { createSelector } from 'reselect';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
+import { withUser } from '../../hoc/user';
 import { requestUser } from '../../store/modules/user';
 import Presenter from './presenter';
-
-const userSelector = state => state.user;
-
-const mapStateToProps = createSelector(
-  [userSelector],
-  userState => ({
-    user: userState.user,
-    isFetching: userState.isFetching,
-  })
-);
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   requestUser,
 }, dispatch);
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(null, mapDispatchToProps),
+  withUser(true),
   withTranslator()
 )(Presenter);

--- a/src/frontend/web_application/src/scenes/UserProfile/index.js
+++ b/src/frontend/web_application/src/scenes/UserProfile/index.js
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
@@ -6,13 +7,22 @@ import { requestUser } from '../../store/modules/user';
 import { updateContact } from '../../store/modules/contact';
 import Presenter from './presenter';
 
+const userSelector = state => state.user;
+
+const mapStateToProps = createSelector(
+ [userSelector],
+ userState => ({
+   isFetching: userState.isFetching,
+ })
+);
+
 const mapDispatchToProps = dispatch => bindActionCreators({
   requestUser,
   updateContact,
 }, dispatch);
 
 export default compose(
-  connect(null, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps),
   withUser(),
   withTranslator()
 )(Presenter);

--- a/src/frontend/web_application/src/scenes/UserProfile/index.js
+++ b/src/frontend/web_application/src/scenes/UserProfile/index.js
@@ -1,19 +1,10 @@
-import { createSelector } from 'reselect';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
+import { withUser } from '../../hoc/user';
 import { requestUser } from '../../store/modules/user';
 import { updateContact } from '../../store/modules/contact';
 import Presenter from './presenter';
-
-const userSelector = state => state.user;
-const mapStateToProps = createSelector(
-  [userSelector],
-  userState => ({
-    user: userState.user,
-    isFetching: userState.isFetching,
-  })
-);
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   requestUser,
@@ -21,6 +12,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
 }, dispatch);
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(null, mapDispatchToProps),
+  withUser(),
   withTranslator()
 )(Presenter);

--- a/src/frontend/web_application/src/scenes/UserSecurity/index.jsx
+++ b/src/frontend/web_application/src/scenes/UserSecurity/index.jsx
@@ -1,27 +1,18 @@
-import { createSelector } from 'reselect';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
 import { withNotification } from '../../hoc/notification';
+import { withUser } from '../../hoc/user';
 import { requestUser } from '../../store/modules/user';
 import Presenter from './presenter';
-
-const userSelector = state => state.user;
-
-const mapStateToProps = createSelector(
-  [userSelector],
-  userState => ({
-    user: userState.user,
-    isFetching: userState.isFetching,
-  })
-);
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   requestUser,
 }, dispatch);
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(null, mapDispatchToProps),
   withTranslator(),
+  withUser(),
   withNotification(),
 )(Presenter);

--- a/src/frontend/web_application/src/scenes/UserSecurity/index.jsx
+++ b/src/frontend/web_application/src/scenes/UserSecurity/index.jsx
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect';
 import { bindActionCreators, compose } from 'redux';
 import { connect } from 'react-redux';
 import { withTranslator } from '@gandi/react-translate';
@@ -6,12 +7,21 @@ import { withUser } from '../../hoc/user';
 import { requestUser } from '../../store/modules/user';
 import Presenter from './presenter';
 
+const userSelector = state => state.user;
+
+const mapStateToProps = createSelector(
+ [userSelector],
+ userState => ({
+   isFetching: userState.isFetching,
+ })
+);
+
 const mapDispatchToProps = dispatch => bindActionCreators({
   requestUser,
 }, dispatch);
 
 export default compose(
-  connect(null, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps),
   withTranslator(),
   withUser(),
   withNotification(),

--- a/src/frontend/web_application/src/scenes/UserSecurity/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/UserSecurity/presenter.jsx
@@ -13,9 +13,12 @@ class UserSecurity extends Component {
   static propTypes = {
     __: PropTypes.func.isRequired,
     requestUser: PropTypes.func.isRequired,
-    user: PropTypes.shape({}).isRequired,
+    user: PropTypes.shape({}),
     notifySuccess: PropTypes.func.isRequired,
     notifyError: PropTypes.func.isRequired,
+  };
+  static defaultProps = {
+    user: undefined,
   };
 
   state = {

--- a/src/frontend/web_application/src/services/message/index.js
+++ b/src/frontend/web_application/src/services/message/index.js
@@ -14,8 +14,8 @@ export const getAuthor = message => message.participants && message.participants
 
 export const isMessageFromUser = (message, user) => {
   const author = getAuthor(message);
-  const authorId = author && author.contact_ids[0];
-  const userId = user && user.contact.contact_id;
+  const userContactId = user.contact.contact_id;
+  const isFromUser = authorContactId => authorContactId === userContactId;
 
-  return userId && authorId && userId === authorId;
+  return author.contact_ids.some(isFromUser);
 };

--- a/src/frontend/web_application/src/services/message/index.js
+++ b/src/frontend/web_application/src/services/message/index.js
@@ -9,3 +9,13 @@ export const sortMessages = (messages, reversed) => messages.sort((a, b) => {
 export const renderParticipant = participant => `${participant.label} (${participant.address})`;
 
 export const getLastMessage = messages => sortMessages(messages, true)[0];
+
+export const getAuthor = message => message.participants && message.participants.find(participant => participant.type === 'From');
+
+export const isMessageFromUser = (message, user) => {
+  const author = getAuthor(message);
+  const authorId = author && author.contact_ids[0];
+  const userId = user && user.contact.contact_id;
+
+  return userId && authorId && userId === authorId;
+};

--- a/src/frontend/web_application/src/store/selectors/user.js
+++ b/src/frontend/web_application/src/store/selectors/user.js
@@ -1,0 +1,1 @@
+export const UserSelector = state => state.user;


### PR DESCRIPTION
Fix https://github.com/CaliOpen/Caliopen/issues/671

This checks if `message` is from `user` and if so, sorts and fills message with `message.date` instead of `message.date_insert` both in `Timeline` and `MessageList`.