### PR TITLE
Get inputs' values when browser autofills fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Show correctly the message in reply on the current draft
 - Notify when saving contact failed
 - Refresh contacts after a deletion
+- Get browsers' autofills on SigninForm
 
 ## [0.6.0] 2017-11-24
 

--- a/src/frontend/web_application/src/components/form/InputText/index.jsx
+++ b/src/frontend/web_application/src/components/form/InputText/index.jsx
@@ -19,7 +19,7 @@ class InputText extends PureComponent {
     bottomSpace: false,
     hasError: false,
     className: null,
-    inputRef: null,
+    inputRef: undefined,
   };
 
   state = {}

--- a/src/frontend/web_application/src/components/form/InputText/index.jsx
+++ b/src/frontend/web_application/src/components/form/InputText/index.jsx
@@ -1,35 +1,52 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import './style.scss';
 
-const InputText = ({ expanded, theme, bottomSpace, className, hasError, ...props }) => {
-  const inputTextClassName = classnames(
-    'm-input-text',
-    {
-      'm-input-text--expanded': expanded,
-      'm-input-text--light': theme === 'light',
-      'm-input-text--bottom-space': bottomSpace,
-      'm-input-text--error': hasError,
-    },
-    className
-  );
+class InputText extends PureComponent {
+  static propTypes = {
+    expanded: PropTypes.bool,
+    theme: PropTypes.string,
+    bottomSpace: PropTypes.bool,
+    hasError: PropTypes.bool,
+    className: PropTypes.string,
+    inputRef: PropTypes.func,
+  };
 
-  return (
-    <input
-      type="text"
-      className={inputTextClassName}
-      {...props}
-    />
-  );
-};
+  static defaultProps = {
+    expanded: false,
+    theme: 'dark',
+    bottomSpace: false,
+    hasError: false,
+    className: null,
+    inputRef: null,
+  };
 
-InputText.propTypes = {
-  expanded: PropTypes.bool,
-  theme: PropTypes.string,
-  bottomSpace: PropTypes.bool,
-  hasError: PropTypes.bool,
-  className: PropTypes.string,
-};
+  state = {}
+
+  render() {
+    const { expanded, theme, bottomSpace, className, hasError, inputRef, ...props } = this.props;
+    const inputTextClassName = classnames(
+      'm-input-text',
+      {
+        'm-input-text--expanded': expanded,
+        'm-input-text--light': theme === 'light',
+        'm-input-text--bottom-space': bottomSpace,
+        'm-input-text--error': hasError,
+      },
+      className
+    );
+
+
+    return (
+      <input
+        type="text"
+        className={inputTextClassName}
+        ref={inputRef}
+        {...props}
+      />
+    );
+  }
+}
 
 export default InputText;

--- a/src/frontend/web_application/src/components/form/TextFieldGroup/index.jsx
+++ b/src/frontend/web_application/src/components/form/TextFieldGroup/index.jsx
@@ -59,6 +59,7 @@ TextFieldGroup.propTypes = {
   expanded: PropTypes.bool,
   className: PropTypes.string,
   display: PropTypes.oneOf(['inline', 'block']),
+  inputRef: PropTypes.func,
 };
 TextFieldGroup.defaultProps = {
   id: undefined,
@@ -67,6 +68,7 @@ TextFieldGroup.defaultProps = {
   expanded: true,
   className: undefined,
   display: 'block',
+  inputRef: null,
 };
 
 export default TextFieldGroup;

--- a/src/frontend/web_application/src/components/form/TextFieldGroup/index.jsx
+++ b/src/frontend/web_application/src/components/form/TextFieldGroup/index.jsx
@@ -59,7 +59,6 @@ TextFieldGroup.propTypes = {
   expanded: PropTypes.bool,
   className: PropTypes.string,
   display: PropTypes.oneOf(['inline', 'block']),
-  inputRef: PropTypes.func,
 };
 TextFieldGroup.defaultProps = {
   id: undefined,
@@ -68,7 +67,6 @@ TextFieldGroup.defaultProps = {
   expanded: true,
   className: undefined,
   display: 'block',
-  inputRef: null,
 };
 
 export default TextFieldGroup;

--- a/src/frontend/web_application/src/scenes/Signin/components/SigninForm/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Signin/components/SigninForm/presenter.jsx
@@ -37,8 +37,23 @@ class SigninForm extends Component {
     this.setState(generateStateFromProps(this.props));
   }
 
+  componentDidMount() {
+    setTimeout(this.setValues(), 1);
+  }
+
   componentWillReceiveProps(newProps) {
     this.setState(generateStateFromProps(newProps));
+  }
+
+  setValues = () => {
+    const password = this.passwordInputRef.value;
+    const username = this.usernameInputRef.value;
+    this.setState(prevState => ({
+      formValues: {
+        password: prevState.password !== password && password,
+        username: prevState.username !== password && username,
+      },
+    }));
   }
 
   handleInputChange = (event) => {
@@ -87,6 +102,7 @@ class SigninForm extends Component {
                   errors={errors.username}
                   onChange={this.handleInputChange}
                   showLabelforSr
+                  inputRef={(input) => { this.usernameInputRef = input; }}
                 />
               </FormColumn>
               <FormColumn rightSpace={false} bottomSpace>
@@ -100,6 +116,7 @@ class SigninForm extends Component {
                   errors={errors.password}
                   onChange={this.handleInputChange}
                   showLabelforSr
+                  inputRef={(input) => { this.passwordInputRef = input; }}
                 />
               </FormColumn>
             </FormRow>

--- a/src/frontend/web_application/src/scenes/Signin/components/SigninForm/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Signin/components/SigninForm/presenter.jsx
@@ -48,12 +48,12 @@ class SigninForm extends Component {
   setValues = () => {
     const password = this.passwordInputRef.value;
     const username = this.usernameInputRef.value;
-    this.setState(prevState => ({
+    this.setState({
       formValues: {
-        password: prevState.password !== password && password,
-        username: prevState.username !== password && username,
+        password,
+        username,
       },
-    }));
+    });
   }
 
   handleInputChange = (event) => {


### PR DESCRIPTION
this checks if inputs' values are changing after component did mount (ex. if browser auto-fills fields).
- also refactor InputText in order to pass `ref` prop.

Fix https://github.com/CaliOpen/Caliopen/issues/611