### PR TITLE
Add a CALIOPEN tag on inbound message that are from an internal domain sender

### DIFF
--- a/src/backend/components/py.pi/caliopen_pi/qualifiers/mail.py
+++ b/src/backend/components/py.pi/caliopen_pi/qualifiers/mail.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
-from datetime import datetime
 from caliopen_main.message.parameters import (NewInboundMessage,
                                               Participant,
                                               Attachment)
@@ -50,7 +49,7 @@ class UserMessageQualifier(object):
         tags = []
         if message.privacy_features.get('is_internal', False):
             # XXX do not hardcode the wanted tag
-            internal_tag = [x for x in self.user.tags if x.name == 'caliopen']
+            internal_tag = [x for x in self.user.tags if x.name == 'internal']
             if internal_tag:
                 tags.append(internal_tag[0].name)
         message.tags = tags

--- a/src/backend/components/py.pi/caliopen_pi/qualifiers/mail.py
+++ b/src/backend/components/py.pi/caliopen_pi/qualifiers/mail.py
@@ -11,7 +11,6 @@ from caliopen_main.message.parameters import (NewInboundMessage,
 from caliopen_storage.exception import NotFound
 from caliopen_storage.config import Configuration
 from caliopen_main.contact.core import Contact
-from caliopen_main.common.parameters.tag import ResourceTag
 from caliopen_main.discussion.core import (DiscussionThreadLookup,
                                            DiscussionListLookup)
 # XXX use a message formatter registry not directly mail format
@@ -51,16 +50,9 @@ class UserMessageQualifier(object):
         tags = []
         if message.privacy_features.get('is_internal', False):
             # XXX do not hardcode the wanted tag
-            internal_tag = [x for x in self.user.tags if x.name == 'CALIOPEN']
+            internal_tag = [x for x in self.user.tags if x.name == 'caliopen']
             if internal_tag:
-                # XXX need to transform UserTag to ResourceTag
-                tag = ResourceTag()
-                tag.date_insert = datetime.utcnow()
-                tag.importance_level = internal_tag[0].importance_level
-                tag.name = internal_tag[0].name
-                tag.tag_id = internal_tag[0].tag_id
-                tag.type = internal_tag[0].type
-                tags.append(tag)
+                tags.append(internal_tag[0].name)
         message.tags = tags
 
     def lookup(self, sequence):

--- a/src/backend/configs/caliopen-docker.yaml
+++ b/src/backend/configs/caliopen-docker.yaml
@@ -46,16 +46,14 @@ system:
     default_tags:
         -
             name: INBOX
-            background: '#000000'
-            color: black
         -
             name: SPAM
-            background: '#AAAAAA'
-            color: white
         -
             name: IMPORTANT
-            background: '#FF0000'
-            color: white
+            importance_level: 5
+        -
+            name: CALIOPEN
+            importance_level: 2
 
 default_domain: caliopen.local
 

--- a/src/backend/configs/caliopen-docker.yaml
+++ b/src/backend/configs/caliopen-docker.yaml
@@ -45,14 +45,14 @@ system:
     max_users: 100
     default_tags:
         -
-            name: INBOX
+            name: inbox
         -
-            name: SPAM
+            name: spam
         -
-            name: IMPORTANT
+            name: important
             importance_level: 5
         -
-            name: CALIOPEN
+            name: caliopen
             importance_level: 2
 
 default_domain: caliopen.local

--- a/src/backend/configs/caliopen-docker.yaml
+++ b/src/backend/configs/caliopen-docker.yaml
@@ -52,7 +52,8 @@ system:
             name: important
             importance_level: 5
         -
-            name: caliopen
+            name: internal
+            label: Caliopen
             importance_level: 2
 
 default_domain: caliopen.local

--- a/src/backend/configs/caliopen.yaml.template
+++ b/src/backend/configs/caliopen.yaml.template
@@ -40,16 +40,14 @@ system:
     default_tags:
         -
             name: inbox
-            background: '#000000'
-            color: black
         -
             name: spam
-            background: '#AAAAAA'
-            color: white
         -
             name: important
-            background: '#FF0000'
-            color: white
+            importance_level: 5
+        -
+            name: CALIOPEN
+            importance_level: 2
 
 default_domain: caliopen.local
 

--- a/src/backend/configs/caliopen.yaml.template
+++ b/src/backend/configs/caliopen.yaml.template
@@ -46,7 +46,8 @@ system:
             name: important
             importance_level: 5
         -
-            name: CALIOPEN
+            name: internal
+            label: Caliopen
             importance_level: 2
 
 default_domain: caliopen.local

--- a/src/backend/main/py.main/caliopen_main/user/core/setups.py
+++ b/src/backend/main/py.main/caliopen_main/user/core/setups.py
@@ -96,7 +96,7 @@ def setup_system_tags(user):
     for tag in default_tags:
         tag['type'] = 'system'
         tag['date_insert'] = datetime.datetime.now(tz=pytz.utc)
-        tag['label'] = tag['name']
+        tag['label'] = tag.get('label', tag['name'])
         from .user import Tag
         Tag.create(user, **tag)
 


### PR DESCRIPTION
A first tag CALIOPEN will appear automatically on incoming message from a sender defined in configuration file (hosted domains).

This should help validate UX/UI around tag display