### PR TITLE
Disable pseudo-classes automatically applied to `invalid` inputs

### DIFF
--- a/src/frontend/web_application/src/styles/base/reset.scss
+++ b/src/frontend/web_application/src/styles/base/reset.scss
@@ -5,9 +5,24 @@
   }
 }
 
-button, input, optgroup, select, textarea {
+button,
+input,
+optgroup,
+select,
+textarea {
   // force custom font-family on form elements
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, 'Roboto', Arial, sans-serif;
+}
+
+input {
+  &:invalid,
+  &:required,
+  &:-moz-submit-invalid,
+  &:-moz-ui-invalid {
+    // disable pseudo-classes automatically applied to `required` or `invalid` inputs
+    // https://developer.mozilla.org/fr/docs/Web/CSS/:invalid
+    box-shadow: none;
+  }
 }
 
 fieldset {


### PR DESCRIPTION
Fix https://github.com/CaliOpen/Caliopen/issues/722 "[Firefox] adding contact info should have no error on pristine field"