### PR TITLE
Only the first device is named default

### DIFF
--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
@@ -62,11 +62,13 @@ class AuthenticationAPI(Api):
                 device = Device.get(user, in_device['device_id'])
             except NotFound:
                 devices = Device.find(user)
-                if devices:
+                if devices.get('objects', []):
                     in_device['status'] = 'unverified'
+                else:
+                    in_device['name'] = 'default'
                 # we must declare a new device
-                device = Device.create_default(user, in_device,
-                                               self.request.headers)
+                device = Device.create_from_parameter(user, in_device,
+                                                      self.request.headers)
         else:
             device = FakeDevice()
 
@@ -151,8 +153,9 @@ class UserAPI(Api):
         in_device = self.request.swagger_data['user']['device']
         if in_device:
             try:
-                device = Device.create_default(user, in_device,
-                                               self.request.headers)
+                in_device['name'] = 'default'
+                device = Device.create_from_parameter(user, in_device,
+                                                      self.request.headers)
                 log.info('Device %r created' % device.device_id)
             except Exception as exc:
                 log.exception('Error during default device creation %r' % exc)


### PR DESCRIPTION
As spooted by @sapiens-sapide , user can have many 'default' devices with previous logic.

Only the first one is named default, others will be named 'new device <device_type>' 