### PR TITLE
Bright default style for Button 

### DIFF
--- a/src/frontend/web_application/src/modules/draftMessage/components/AttachmentManager/style.scss
+++ b/src/frontend/web_application/src/modules/draftMessage/components/AttachmentManager/style.scss
@@ -12,8 +12,6 @@
     @include flex-grid-size(shrink);
     margin-top: $co-component__spacing;
     margin-left: auto;
-    color: $co-color__primary;
-    font-weight: 700;
   }
 
   &__item {

--- a/src/frontend/web_application/src/modules/draftMessage/components/NewDraftForm/presenter.jsx
+++ b/src/frontend/web_application/src/modules/draftMessage/components/NewDraftForm/presenter.jsx
@@ -176,7 +176,6 @@ class NewDraftForm extends Component {
           <BottomRow className="m-new-draft__bottom-bar">
             <Button
               className="m-new-draft__bottom-action"
-              shape="plain"
               onClick={this.handleSend}
               icon={isSending ? (<Spinner isLoading display="inline" />) : 'send'}
               responsive="icon-only"
@@ -193,7 +192,13 @@ class NewDraftForm extends Component {
             >
               <Trans id="messages.compose.action.save">Save</Trans>
             </Button>
-            <Button className="m-new-draft__bottom-action m-new-draft__bottom-action--editor" icon="editor" responsive="icon-only" />
+            {/* TODO: enable rich text editor
+              <Button
+              className="m-new-draft__bottom-action m-new-draft__bottom-action--editor"
+              icon="editor"
+              responsive="icon-only"
+            />
+            */}
           </BottomRow>
         </form>
       </DiscussionDraft>

--- a/src/frontend/web_application/src/modules/draftMessage/components/NewDraftForm/style.scss
+++ b/src/frontend/web_application/src/modules/draftMessage/components/NewDraftForm/style.scss
@@ -68,7 +68,6 @@
   &__bottom-action {
     @include flex-grid-size(shrink);
     margin-right: $co-component__spacing;
-    background-color: $co-color__fg__back;
 
     &--editor {
       margin-right: 0;

--- a/src/frontend/web_application/src/modules/draftMessage/components/ReplyForm/presenter.jsx
+++ b/src/frontend/web_application/src/modules/draftMessage/components/ReplyForm/presenter.jsx
@@ -153,7 +153,6 @@ class ReplyForm extends Component {
           <BottomRow className="m-reply__bottom-bar">
             <Button
               className="m-reply__bottom-action"
-              shape="plain"
               onClick={this.handleSend}
               icon={isSending ? (<Spinner isLoading display="inline" />) : 'send'}
               responsive="icon-only"
@@ -173,7 +172,13 @@ class ReplyForm extends Component {
             <Button className="m-reply__bottom-action" onClick={this.handleSave} icon="share-alt" responsive="icon-only">
               <Trans id="messages.compose.action.copy">Copy to</Trans>
             </Button>
-            <Button className="m-new-reply__bottom-action m-reply__bottom-action--editor" icon="editor" responsive="icon-only" />
+            {/* TODO: enable rich text editor
+              <Button
+              className="m-new-reply__bottom-action m-reply__bottom-action--editor"
+              icon="editor"
+              responsive="icon-only"
+            />
+            */}
           </BottomRow>
         </form>
       </DiscussionDraft>

--- a/src/frontend/web_application/src/modules/draftMessage/components/ReplyForm/style.scss
+++ b/src/frontend/web_application/src/modules/draftMessage/components/ReplyForm/style.scss
@@ -76,7 +76,6 @@
   &__bottom-action {
     @include flex-grid-size(shrink);
     margin-right: $co-component__spacing;
-    background-color: $co-color__fg__back;
 
     &--editor {
       margin-right: 0;

--- a/src/frontend/web_application/src/styles/object/o-clickable.scss
+++ b/src/frontend/web_application/src/styles/object/o-clickable.scss
@@ -1,7 +1,8 @@
 @mixin o-clickable {
   transition: $co-animation__clickable-transition;
   border-color: $co-color__primary;
-  color: $co-color__fg__text;
+  color: $co-color__primary;
+  font-weight: 700;
   text-decoration: none;
   cursor: pointer;
 


### PR DESCRIPTION
This make default button's style bold and blue (according to UI)
- also fix #851 by re-styling 'send' button on draft.
- also hides rich text editor's button for alpha.

![](https://framapic.org/Rez1Ne6uQWBJ/TDUW3WpoJLmK.png)