### PR TITLE
Round avatars

### DIFF
--- a/src/frontend/web_application/src/modules/avatar/components/AvatarLetterWrapper/index.jsx
+++ b/src/frontend/web_application/src/modules/avatar/components/AvatarLetterWrapper/index.jsx
@@ -19,7 +19,7 @@ class AvatarLetterWrapper extends PureComponent {
   static defaultProps = {
     children: undefined,
     size: undefined,
-    isRound: false,
+    isRound: true,
     className: undefined,
   };
 

--- a/src/frontend/web_application/src/scenes/SearchResults/components/ContactResultItem/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/SearchResults/components/ContactResultItem/presenter.jsx
@@ -62,7 +62,7 @@ class ContactResultItem extends PureComponent {
     return (
       <Link noDecoration className="m-contact-result-item" to={`/contacts/${contact.contact_id}`}>
         <div className="m-contact-result-item__contact-avatar">
-          <ContactAvatarLetter isRound contact={contact} size={SIZE_SMALL} />
+          <ContactAvatarLetter contact={contact} size={SIZE_SMALL} />
         </div>
         <TextBlock className="m-contact-result-item__col-title">
           {contact.name_prefix && (<span className="m-contact-result-item__contact-prefix"><Highlights term={term} highlights={contact.name_prefix} /></span>)}


### PR DESCRIPTION
- Since latest dependencies update,  some styles are upside-down, specifically: avatars are displayed as squares whereas they should appear as circles.
- According to UI, avatars in every scenes are round-shape so:

-> this puts `true` as default value for `isRound` property in `AvatarLetterWrapper` and et voilà it's fixed.