### PR TITLE
Fix Badge button width and style

### DIFF
--- a/src/frontend/web_application/src/components/Badge/index.jsx
+++ b/src/frontend/web_application/src/components/Badge/index.jsx
@@ -1,36 +1,72 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import Button from '../Button';
+import Spinner from '../Spinner';
 import './style.scss';
 
-const Badge = ({
-  low, large, className, radiusType, ...props
-}) => {
-  const badgeClassName = classnames('m-badge', {
-    'm-badge--low': low,
-    'm-badge--large': large,
-    'm-badge--no-radius': radiusType === 'no',
-    'm-badge--normal-radius': radiusType === 'normal',
-    'm-badge--rounded-radius': radiusType === 'rounded',
-  }, className);
+class Badge extends PureComponent {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    large: PropTypes.bool,
+    low: PropTypes.bool,
+    radiusType: PropTypes.oneOf(['no', 'normal', 'rounded']),
+    onDelete: PropTypes.func, // If onDelete is set, the delete button will be shown
+    ariaLabel: PropTypes.string, // option to show aria-label on delete button
+    isLoading: PropTypes.bool, // option to show spinner on delete button
+  };
+  static defaultProps = {
+    children: undefined,
+    className: undefined,
+    large: false,
+    low: false,
+    radiusType: 'normal',
+    onDelete: undefined,
+    ariaLabel: null,
+    isLoading: false,
+  };
 
-  return (
-    <span className={badgeClassName} {...props} />
-  );
-};
+  render() {
+    const {
+      children, className, onDelete, low, large, radiusType, isLoading, ariaLabel, ...props
+    } = this.props;
 
-Badge.propTypes = {
-  low: PropTypes.bool,
-  large: PropTypes.bool,
-  radiusType: PropTypes.oneOf(['no', 'normal', 'rounded']),
-  className: PropTypes.string,
-};
+    const badgeProps = {
+      className: classnames('m-badge', {
+        'm-badge--low': low,
+        'm-badge--large': large,
+        'm-badge--no-radius': radiusType === 'no',
+        'm-badge--normal-radius': radiusType === 'normal',
+        'm-badge--rounded-radius': radiusType === 'rounded',
+      }, className),
+      ...props,
+    };
 
-Badge.defaultProps = {
-  low: false,
-  large: false,
-  radiusType: 'normal',
-  className: undefined,
-};
+    const buttonClassName = classnames('m-badge__button', {
+      'm-badge__button--large': large,
+    });
+
+    const textClassName = classnames('m-badge__text', {
+      'm-badge__text--large': large,
+      'm-badge__text--has-button': onDelete,
+    });
+
+    return (
+      <span {...badgeProps}>
+        {children && <span className={textClassName}>{children}</span>}
+        {onDelete && (
+          <Button
+            className={buttonClassName}
+            display="inline"
+            onClick={onDelete}
+            icon={isLoading ? (<Spinner isLoading display="inline" />) : 'remove'}
+            aria-label={ariaLabel}
+          />
+        )}
+      </span>
+    );
+  }
+}
 
 export default Badge;

--- a/src/frontend/web_application/src/components/Badge/style.scss
+++ b/src/frontend/web_application/src/components/Badge/style.scss
@@ -1,21 +1,51 @@
 @import '../../styles/common';
+@import '../../styles/vendor/bootstrap_foundation-sites';
 
-$m-badge__height: 1.5rem !default;
+$m-badge__height: 1.6rem !default;
 $m-badge__font-size: ($m-badge__height / 2) !default;
+$m-badge__padding: ($m-badge__height - $m-badge__font-size) / 2;
 $m-badge--large__height: $co-component__height !default;
 $m-badge--large__font-size: $co-font__size !default;
+$m-badge--large__padding: ($m-badge--large__height - $m-badge--large__font-size) / 2;
 
 .m-badge {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   height: $m-badge__height;
-  padding-right: .5rem;
-  padding-left: .5rem;
   background: $co-color__primary--low;
   color: $co-color__contrast__text;
   font-size: $m-badge__font-size;
   font-weight: 600;
   line-height: $m-badge__height;
   white-space: nowrap;
+
+  &__text {
+    @include flex-grid-size;
+    padding: $m-badge__padding;
+
+    &--large {
+      padding: $m-badge--large__padding;
+    }
+
+    &--has-button {
+      padding-right: 0;
+    }
+  }
+
+  &__button {
+    @include flex-grid-size(shrink);
+    padding: $m-badge__padding;
+    color: $co-color__contrast__text;
+    font-size: $co-font__size;
+
+    &--large {
+      padding: $m-badge--large__padding;
+    }
+
+    &:hover {
+      color: $co-color__primary;
+    }
+  }
 
   &--no-radius {
     border-radius: 0;

--- a/src/frontend/web_application/src/modules/draftMessage/components/Recipient/presenter.jsx
+++ b/src/frontend/web_application/src/modules/draftMessage/components/Recipient/presenter.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Badge, Button, Icon } from '../../../../components';
+import { Badge, Icon } from '../../../../components';
 import { ASSOC_PROTOCOL_ICON } from '../../../../services/protocols-config';
 
 const getIconType = protocol => ASSOC_PROTOCOL_ICON[protocol] || ASSOC_PROTOCOL_ICON.unknown;
@@ -25,18 +25,13 @@ class Recipient extends Component {
     const { participant, className, i18n } = this.props;
 
     return (
-      <Badge large className={className}>
-        <span>
-          <Icon type={getIconType(participant.protocol)} spaced />
-          <span>{participant.address}</span>
-        </span>
-        <Button
-          className="m-recipient__col-remove"
-          onClick={this.handleClickRemove}
-          title={i18n._('messages.compose.action.remove-recipient', { defaults: 'Remove recipient' })}
-        >
-          <Icon type="remove" spaced />
-        </Button>
+      <Badge
+        large
+        className={className}
+        onDelete={this.handleClickRemove}
+        ariaLabel={i18n._('messages.compose.action.remove-recipient', { defaults: 'Remove recipient' })}
+      >
+        <Icon type={getIconType(participant.protocol)} rightSpaced />{participant.address}
       </Badge>
     );
   }

--- a/src/frontend/web_application/src/modules/tags/components/TagItem/index.jsx
+++ b/src/frontend/web_application/src/modules/tags/components/TagItem/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withI18n } from 'lingui-react';
-import { Button, Spinner, Badge } from '../../../../components';
+import { Badge } from '../../../../components';
 import { getTagLabel } from '../../';
 
 import './style.scss';
@@ -30,15 +30,13 @@ class TagItem extends Component {
     const { tag, i18n } = this.props;
 
     return (
-      <Badge className="m-tag-item">
-        <span className="m-tag-item__text">{getTagLabel(i18n, tag)}</span>
-        <Button
-          className="m-tag-item__button"
-          display="inline"
-          onClick={this.handleDeleteTag}
-          icon={this.state.isTagCollectionUpdating ? (<Spinner isLoading display="inline" />) : 'remove'}
-          aria-label={i18n._('tags.action.remove', { defaults: 'Remove' })}
-        />
+      <Badge
+        className="m-tag-item"
+        onDelete={this.handleDeleteTag}
+        isLoading={this.state.isTagCollectionUpdating}
+        ariaLabel={i18n._('tags.action.remove', { defaults: 'Remove' })}
+      >
+        {getTagLabel(i18n, tag)}
       </Badge>
     );
   }

--- a/src/frontend/web_application/src/modules/tags/components/TagItem/index.spec.jsx
+++ b/src/frontend/web_application/src/modules/tags/components/TagItem/index.spec.jsx
@@ -20,6 +20,6 @@ describe('component TagItem', () => {
 
     const comp = shallow(<TagItem {...props} {...connectedProps} />);
 
-    expect(comp.render().find('.m-tag-item__text').text()).toEqual('Foo');
+    expect(comp.find('Badge').length).toEqual(1);
   });
 });

--- a/src/frontend/web_application/src/modules/tags/components/TagItem/style.scss
+++ b/src/frontend/web_application/src/modules/tags/components/TagItem/style.scss
@@ -1,15 +1,7 @@
 @import '../../../../styles/common';
+@import '../../../../styles/vendor/bootstrap_foundation-sites';
 
 .m-tag-item {
+  margin-right: map-get($co-form__spacing, 'small');
   margin-bottom: map-get($co-form__spacing, 'small');
-  margin-left: map-get($co-form__spacing, 'small');
-
-  &:first-child {
-    margin-left: 0;
-  }
-
-  // FIXME: the button is too small for mobile devices
-  &__button {
-    color: $co-color__contrast__text;
-  }
 }


### PR DESCRIPTION
Related to https://trello.com/c/cUX2hgMt/40-bouton-dans-les-badges-sont-trop-petits-sur-mobile

On small badges, buttons are now more easily touchable for mobile users (larger font size + more padding). It also fix style consistency on buttons in `Badge` component.

- adds `onDelete`, `isLoading` and `ariaLabel` props on Badge component
- fix `Badge` and `TagItem` styles
- updates badges on `Recipient` and `TagItem`

before:
![](https://framapic.org/gkgwx3KkHGo0/OzBbKUXH2FTM.jpg)
after:
![](https://framapic.org/pdWSdytOYhNG/498d9enMZC60.jpg)