### PR TITLE
Fix TagsForm width

### DIFF
--- a/src/frontend/web_application/src/modules/tags/components/TagsForm/style.scss
+++ b/src/frontend/web_application/src/modules/tags/components/TagsForm/style.scss
@@ -2,6 +2,8 @@
 @import '../../../../styles/vendor/bootstrap_foundation-sites';
 
 .m-tags-form {
+  width: 100%;
+  max-width: map-get($co-form__width, 'xlarge');
 
   &__count {
     padding-left: map-get($co-form__spacing, 'small');


### PR DESCRIPTION
This makes `TagsForm` width fixed to avoid `Modal` to resize while adding or removing tags.