### PR TITLE
Fix search bar width

### DIFF
--- a/src/frontend/web_application/src/layouts/Page/components/Header/components/SearchField/style.scss
+++ b/src/frontend/web_application/src/layouts/Page/components/Header/components/SearchField/style.scss
@@ -1,4 +1,5 @@
 @import '../../../../../../styles/common';
+@import '../../../../../../styles/vendor/bootstrap_foundation-sites';
 
 @mixin m-search-field--width($width) {
   @if ($width == block) {
@@ -16,17 +17,22 @@
 
 .m-search-field {
   position: relative;
+  text-align: right;
 
   &__input {
     display: inline-block;
     width: 5rem;
-    max-width: 45rem;
     margin: 0;
     padding-right: 2rem;
     transition: $co-animation__width-transition;
+    text-align: left;
 
     &:focus {
-      width: 50vw;
+      width: 100%;
+    }
+
+    @include breakpoint(medium) {
+      width: 100%;
     }
   }
 

--- a/src/frontend/web_application/src/layouts/Page/components/Header/style.scss
+++ b/src/frontend/web_application/src/layouts/Page/components/Header/style.scss
@@ -5,13 +5,13 @@ $l-header__brand-icon-height: 32px !default;
 $l-header__margin: ($co-margin / 2) !default;
 
 .l-header {
-  height: $co-header__height;
+  min-height: $co-header__height;
 
   &__wrapper {
     @include flex-grid-row($size: expand);
     position: fixed;
     z-index: $l-z-index__header;
-
+    align-items: center;
     width: 100%;
     min-height: $co-header__height;
     background: $co-color__contrast__back;
@@ -27,7 +27,6 @@ $l-header__margin: ($co-margin / 2) !default;
   }
 
   &__menu-icon {
-    margin-right: ($co-margin / 2);
     border: 0;
     background: transparent;
   }
@@ -45,11 +44,8 @@ $l-header__margin: ($co-margin / 2) !default;
   }
 
   &__search {
-    flex: 0 1;
-    height: $co-header__height;
+    @include flex-grid-size;
     margin-left: auto;
-    padding-right: $co-component__spacing;
-    line-height: $co-header__height;
   }
 
   &__toggle-nav,
@@ -73,8 +69,16 @@ $l-header__margin: ($co-margin / 2) !default;
     &__user {
       display: block;
     }
-    &__user {
-      padding-right: $co-margin;
+
+    &__search {
+      @include flex-grid-size(5);
+      padding-right: $l-header__margin;
+    }
+  }
+
+  @include breakpoint(large) {
+    &__search {
+      @include flex-grid-size(4);
     }
   }
 }


### PR DESCRIPTION
Makes search field larger with no animation on medium and large screens. Keeps animated width on small screens.

![](https://framapic.org/gkg9KQ3xMojI/CdOOOZ52WDFD.png)

![](https://framapic.org/EKuEL9pCWmo8/VpQnGex0BrQ3.gif)