### PR TITLE
rewrite draft sync to make sure only readonly message props  are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- a discussion_id should not be removed when patching a draft
+
 ## [0.10.0] 2018-05-14
 
 ### Added

--- a/src/frontend/web_application/src/scenes/MessageList/components/ReplyForm/index.js
+++ b/src/frontend/web_application/src/scenes/MessageList/components/ReplyForm/index.js
@@ -45,20 +45,11 @@ const mapStateToProps = createSelector(
   }
 );
 
-const onEditDraft = ({ internalId, draft, message }) => async (dispatch) => {
-  const result = await dispatch(saveDraft({ internalId, draft, message }, { withThrottle: true }));
+const onEditDraft = ({ internalId, draft, message }) => dispatch =>
+  dispatch(saveDraft({ internalId, draft, message }, { withThrottle: true }));
 
-  dispatch(invalidate('discussion', internalId));
-
-  return result;
-};
-
-const onSaveDraft = ({ internalId, draft, message }) => async (dispatch) => {
-  const result = await dispatch(saveDraft({ internalId, draft, message }, { force: true }));
-  dispatch(invalidate('discussion', internalId));
-
-  return result;
-};
+const onSaveDraft = ({ internalId, draft, message }) => dispatch =>
+  dispatch(saveDraft({ internalId, draft, message }, { force: true }));
 
 const onDeleteMessage = ({ message, internalId, isNewDiscussion }) => dispatch =>
   dispatch(deleteMessage({ message }))

--- a/src/frontend/web_application/src/store/modules/draft-message.js
+++ b/src/frontend/web_application/src/store/modules/draft-message.js
@@ -81,18 +81,22 @@ export function setRecipientSearchTerms({ internalId, searchTerms }) {
   };
 }
 
-function syncReadOnlyProps(state, draft) {
+function syncDraftReducer(state, message) {
   const {
-    excerpt,
-    tags,
-    attachments,
-  } = draft;
+    body,
+    subject,
+    participants,
+    parent_id: parentId,
+    identities,
+  } = state;
 
   return {
-    ...state,
-    excerpt,
-    tags,
-    attachments,
+    ...message,
+    body,
+    subject,
+    participants,
+    parent_id: parentId,
+    identities,
   };
 }
 
@@ -106,11 +110,7 @@ function draftReducer(state = {}, action) {
         ...action.payload.draft,
       };
     case SYNC_DRAFT:
-      return {
-        ...action.payload.draft,
-        ...state,
-        ...syncReadOnlyProps(state, action.payload.draft),
-      };
+      return syncDraftReducer(state, action.payload.draft);
     default:
       return state;
   }

--- a/src/frontend/web_application/src/store/modules/draft-message.spec.js
+++ b/src/frontend/web_application/src/store/modules/draft-message.spec.js
@@ -49,6 +49,34 @@ describe('ducks module draft-message', () => {
         });
       });
 
+      it('should write discussion_id or read only props', () => {
+        const draft = { participants: [], body: 'new body', discussion_id: undefined };
+        const initialState = {
+          ...reducer(undefined, { type: '@@INIT' }),
+          draftsByInternalId: {
+            a111: draft,
+          },
+        };
+        const message = {
+          body: 'old body',
+          message_id: '111',
+          discussion_id: '112',
+          tags: ['foo'],
+        };
+        expect(reducer(initialState, module.syncDraft({ internalId: 'a111', draft: message }))).toEqual({
+          ...initialState,
+          draftsByInternalId: {
+            a111: {
+              participants: [],
+              body: 'new body',
+              message_id: '111',
+              discussion_id: '112',
+              tags: ['foo'],
+            },
+          },
+        });
+      });
+
       it('message with new attachments', () => {
         const draft = { participants: [], body: 'new body', attachments: [{ file_name: 'foo.png', temp_id: 'aabbb111' }] };
         const initialState = {
@@ -72,6 +100,32 @@ describe('ducks module draft-message', () => {
               message_id: '111',
               discussion_id: '112',
               attachments: [{ file_name: 'foo.png', temp_id: 'aabbb111' }, { file_name: 'bar.png', temp_id: 'aabbb222' }],
+            },
+          },
+        });
+      });
+
+      it('message with removed attachments', () => {
+        const draft = { participants: [], body: 'new body', attachments: [{ file_name: 'foo.png', temp_id: 'aabbb111' }] };
+        const initialState = {
+          ...reducer(undefined, { type: '@@INIT' }),
+          draftsByInternalId: {
+            a111: draft,
+          },
+        };
+        const message = {
+          body: 'old body',
+          message_id: '111',
+          discussion_id: '112',
+        };
+        expect(reducer(initialState, module.syncDraft({ internalId: 'a111', draft: message }))).toEqual({
+          ...initialState,
+          draftsByInternalId: {
+            a111: {
+              participants: [],
+              body: 'new body',
+              message_id: '111',
+              discussion_id: '112',
             },
           },
         });


### PR DESCRIPTION
fix #926 