### PR TITLE
add option to enable syslog

### DIFF
--- a/src/frontend/web_application/config/server.default.js
+++ b/src/frontend/web_application/config/server.default.js
@@ -22,4 +22,5 @@ module.exports = {
     secret: 'D}(2$5q)#_#yKX90,+0d5?4**a6ws8e`', // at least 32 chars
   },
   maxBodySize: '5mb',
+  enableSyslog: false,
 };

--- a/src/frontend/web_application/config/server.env-var.js
+++ b/src/frontend/web_application/config/server.env-var.js
@@ -19,4 +19,5 @@ module.exports = {
     secret: process.env.CALIOPEN_SEAL_SECRET,
   },
   maxBodySize: process.env.CALIOPEN_MAX_BODY_SIZE,
+  enableSyslog: process.env.CALIOPEN_ENABLE_SYSLOG,
 };

--- a/src/frontend/web_application/server/logger/index.js
+++ b/src/frontend/web_application/server/logger/index.js
@@ -1,5 +1,6 @@
 const winston = require('winston');
 const { Syslog } = require('winston-syslog');
+const { getConfig } = require('../config');
 
 const LOGGER_CATEGORY = 'caliopen-frontend';
 const stdFormat = winston.format.combine(
@@ -14,18 +15,21 @@ let logger;
 
 const getLogger = () => {
   if (!logger) {
+    const { enableSyslog } = getConfig();
     logger = winston.createLogger({
       format: winston.format.simple(),
       transports: [
         new winston.transports.Console({
           format: stdFormat,
         }),
-        new Syslog({
-          app_name: LOGGER_CATEGORY,
-          facility: 'user',
-          protocol: 'unix',
-          path: '/dev/log',
-        }),
+        ...(enableSyslog ? [
+          new Syslog({
+            app_name: LOGGER_CATEGORY,
+            facility: 'user',
+            protocol: 'unix',
+            path: '/dev/log',
+          }),
+        ] : []),
       ],
       levels: winston.config.syslog.levels,
     });


### PR DESCRIPTION
syslog is disabled by default

start with the following (or in conf file) to enable it:

```
CALIOPEN_ENABLE_SYSLOG=true bin/server
```