### PR TITLE
fix rendering server side with a modal

### DIFF
--- a/src/frontend/web_application/src/components/Modal/index.jsx
+++ b/src/frontend/web_application/src/components/Modal/index.jsx
@@ -20,7 +20,7 @@ class Modal extends Component {
     onClose: () => {},
   };
 
-  componentWillMount() {
+  componentDidMount() {
     ReactModal.setAppElement('#root');
   }
 


### PR DESCRIPTION
With Confirm the Modal is instanciated at runtime on server side, the static function ReactModal.setAppElement uses "document" directly, so it should be used on componentDidMount