### PR TITLE
Update models and interfaces to get rid of `identifier`

### DIFF
--- a/src/backend/defs/rest-api/objects/RemoteIdentity.yaml
+++ b/src/backend/defs/rest-api/objects/RemoteIdentity.yaml
@@ -7,8 +7,6 @@ properties:
       type: string
   display_name:
     type: string
-  identifier:
-    type: string
   infos:          # set of key/value strings
     type: object
     additionalProperties:
@@ -16,6 +14,8 @@ properties:
   last_check:
     type: string
     format: date-time
+  remote_id:
+    type: string
   status:
     type: string
     enum:

--- a/src/backend/doc/api/swagger.json
+++ b/src/backend/doc/api/swagger.json
@@ -2351,9 +2351,6 @@
                       "display_name": {
                         "type": "string"
                       },
-                      "identifier": {
-                        "type": "string"
-                      },
                       "infos": {
                         "type": "object",
                         "additionalProperties": {
@@ -2363,6 +2360,9 @@
                       "last_check": {
                         "type": "string",
                         "format": "date-time"
+                      },
+                      "remote_id": {
+                        "type": "string"
                       },
                       "status": {
                         "type": "string",
@@ -2443,9 +2443,6 @@
                 "display_name": {
                   "type": "string"
                 },
-                "identifier": {
-                  "type": "string"
-                },
                 "infos": {
                   "type": "object",
                   "additionalProperties": {
@@ -2455,6 +2452,9 @@
                 "last_check": {
                   "type": "string",
                   "format": "date-time"
+                },
+                "remote_id": {
+                  "type": "string"
                 },
                 "status": {
                   "type": "string",
@@ -2537,9 +2537,6 @@
                 "display_name": {
                   "type": "string"
                 },
-                "identifier": {
-                  "type": "string"
-                },
                 "infos": {
                   "type": "object",
                   "additionalProperties": {
@@ -2549,6 +2546,9 @@
                 "last_check": {
                   "type": "string",
                   "format": "date-time"
+                },
+                "remote_id": {
+                  "type": "string"
                 },
                 "status": {
                   "type": "string",
@@ -2729,9 +2729,6 @@
                     "display_name": {
                       "type": "string"
                     },
-                    "identifier": {
-                      "type": "string"
-                    },
                     "infos": {
                       "type": "object",
                       "additionalProperties": {
@@ -2741,6 +2738,9 @@
                     "last_check": {
                       "type": "string",
                       "format": "date-time"
+                    },
+                    "remote_id": {
+                      "type": "string"
                     },
                     "status": {
                       "type": "string",
@@ -2767,9 +2767,6 @@
                 "display_name": {
                   "type": "string"
                 },
-                "identifier": {
-                  "type": "string"
-                },
                 "infos": {
                   "type": "object",
                   "additionalProperties": {
@@ -2779,6 +2776,9 @@
                 "last_check": {
                   "type": "string",
                   "format": "date-time"
+                },
+                "remote_id": {
+                  "type": "string"
                 },
                 "status": {
                   "type": "string",

--- a/src/backend/interfaces/REST/go.server/api_server.go
+++ b/src/backend/interfaces/REST/go.server/api_server.go
@@ -185,9 +185,9 @@ func (server *REST_API) AddHandlers(api *gin.RouterGroup) {
 	ids.GET("/locals/:identity_id", identities.GetLocalIdentity)
 	ids.GET("/remotes", identities.GetRemoteIdentities)
 	ids.POST("/remotes", identities.NewRemoteIdentity)
-	ids.GET("/remotes/:identifier", identities.GetRemoteIdentity)
-	ids.PATCH("/remotes/:identifier", identities.PatchRemoteIdentity)
-	ids.DELETE("/remotes/:identifier", identities.DeleteRemoteIdentity)
+	ids.GET("/remotes/:remote_id", identities.GetRemoteIdentity)
+	ids.PATCH("/remotes/:remote_id", identities.PatchRemoteIdentity)
+	ids.DELETE("/remotes/:remote_id", identities.DeleteRemoteIdentity)
 
 	/** passwords API **/
 	passwords := api.Group("/passwords")

--- a/src/backend/main/go.backends/IdentitiesInterface.go
+++ b/src/backend/main/go.backends/IdentitiesInterface.go
@@ -14,7 +14,7 @@ type (
 	IdentityStorage interface {
 		RetrieveLocalsIdentities(user_id string) ([]LocalIdentity, error)
 		CreateRemoteIdentity(rId *RemoteIdentity) CaliopenError
-		RetrieveRemoteIdentity(userId, identifier string) (*RemoteIdentity, error)
+		RetrieveRemoteIdentity(userId, RemoteId string) (*RemoteIdentity, error)
 		UpdateRemoteIdentity(rId *RemoteIdentity, fields map[string]interface{}) error
 		DeleteRemoteIdentity(rId *RemoteIdentity) error
 		RetrieveRemoteIdentities(userId string) ([]*RemoteIdentity, error)

--- a/src/backend/main/go.main/facilities/REST/RESTfacility.go
+++ b/src/backend/main/go.main/facilities/REST/RESTfacility.go
@@ -36,10 +36,10 @@ type (
 		RetrieveLocalsIdentities(user_id string) (identities []LocalIdentity, err error)
 		CreateRemoteIdentity(identity *RemoteIdentity) CaliopenError
 		RetrieveRemoteIdentities(userId string) (ids []*RemoteIdentity, err CaliopenError)
-		RetrieveRemoteIdentity(userId, identifier string) (id *RemoteIdentity, err CaliopenError)
+		RetrieveRemoteIdentity(userId, RemoteId string) (id *RemoteIdentity, err CaliopenError)
 		UpdateRemoteIdentity(identity, oldIdentity *RemoteIdentity, update map[string]interface{}) CaliopenError
-		PatchRemoteIdentity(patch []byte, userId, identifier string) CaliopenError
-		DeleteRemoteIdentity(userId, identifier string) CaliopenError
+		PatchRemoteIdentity(patch []byte, userId, RemoteId string) CaliopenError
+		DeleteRemoteIdentity(userId, RemoteId string) CaliopenError
 		//messages
 		GetMessagesList(filter IndexSearch) (messages []*Message, totalFound int64, err error)
 		GetMessage(user_id, message_id string) (message *Message, err error)

--- a/src/backend/main/py.main/caliopen_main/user/store/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/store/user.py
@@ -87,7 +87,7 @@ class RemoteIdentity(BaseModel):
     """User remote identities model."""
 
     user_id = columns.UUID(primary_key=True)
-    identifier = columns.Text(primary_key=True)
+    remote_id = columns.UUID(primary_key=True)
     credentials = columns.Map(columns.Text, columns.Text)
     display_name = columns.Text()
     type = columns.Text()


### PR DESCRIPTION
Remote Identities have now a property `UUID` that is a primary key, instead of former `identifier`