### PR TITLE
Feature/backend/vault for credentials

### DIFF
--- a/src/backend/configs/caliopen-go-api_dev.yaml
+++ b/src/backend/configs/caliopen-go-api_dev.yaml
@@ -18,7 +18,7 @@ ApiConfig:
         buckets:
           raw_messages: caliopen-raw-messages                # bucket name to put raw messages to
           temporary_attachments: caliopen-tmp-attachments    # bucket name to store draft attachments
-      use_vault: false
+      use_vault: true
   IndexConfig:
     index_name: elasticsearch
     index_settings:

--- a/src/backend/configs/caliopen-go-api_dev.yaml
+++ b/src/backend/configs/caliopen-go-api_dev.yaml
@@ -18,6 +18,7 @@ ApiConfig:
         buckets:
           raw_messages: caliopen-raw-messages                # bucket name to put raw messages to
           temporary_attachments: caliopen-tmp-attachments    # bucket name to store draft attachments
+      use_vault: true
   IndexConfig:
     index_name: elasticsearch
     index_settings:

--- a/src/backend/configs/caliopen-go-api_dev.yaml
+++ b/src/backend/configs/caliopen-go-api_dev.yaml
@@ -19,6 +19,10 @@ ApiConfig:
           raw_messages: caliopen-raw-messages                # bucket name to put raw messages to
           temporary_attachments: caliopen-tmp-attachments    # bucket name to store draft attachments
       use_vault: true
+      vault_settings:
+        url: http://127.0.0.1:8200
+        username: api2                                       # password authentication for now ; later we'll make use of more secure auth methods (TLScert, kubernetes…)
+        password: weak_password
   IndexConfig:
     index_name: elasticsearch
     index_settings:

--- a/src/backend/configs/caliopen-go-api_dev.yaml
+++ b/src/backend/configs/caliopen-go-api_dev.yaml
@@ -18,7 +18,7 @@ ApiConfig:
         buckets:
           raw_messages: caliopen-raw-messages                # bucket name to put raw messages to
           temporary_attachments: caliopen-tmp-attachments    # bucket name to store draft attachments
-      use_vault: true
+      use_vault: false
   IndexConfig:
     index_name: elasticsearch
     index_settings:

--- a/src/backend/configs/caliopen-go-api_dev.yaml
+++ b/src/backend/configs/caliopen-go-api_dev.yaml
@@ -18,7 +18,7 @@ ApiConfig:
         buckets:
           raw_messages: caliopen-raw-messages                # bucket name to put raw messages to
           temporary_attachments: caliopen-tmp-attachments    # bucket name to store draft attachments
-      use_vault: true
+      use_vault: false
       vault_settings:
         url: http://127.0.0.1:8200
         username: api2                                       # password authentication for now ; later we'll make use of more secure auth methods (TLScert, kubernetes…)

--- a/src/backend/configs/caliopen-imap-worker_dev.yaml
+++ b/src/backend/configs/caliopen-imap-worker_dev.yaml
@@ -20,6 +20,11 @@ store_settings:
     buckets:
       raw_messages: caliopen-raw-messages                # bucket name to put raw messages to
       temporary_attachments: caliopen-tmp-attachments    # bucket name to store draft attachments
+  use_vault: false
+  vault_settings:
+    url: http://127.0.0.1:8200
+    username: imapworker                                 # password authentication for now ; later we'll make use of more secure auth methods (TLScert, kubernetes…)
+    password: a_weak_password
 LDAConfig:
   broker_type: imap                                      # types are : smtp, imap, mailboxe, etc.
   lda_workers_size: 2                                    # number of concurrent workers

--- a/src/backend/defs/go-objects/configs.go
+++ b/src/backend/defs/go-objects/configs.go
@@ -22,6 +22,7 @@ type (
 		SizeLimit    uint64   `mapstructure:"raw_size_limit"` // max size for db (in bytes)
 		ObjStoreType string   `mapstructure:"object_store"`
 		OSSConfig    `mapstructure:"object_store_settings"`
+		UseVault     bool `mapstructure:"use_vault"`
 	}
 
 	RESTIndexConfig struct {

--- a/src/backend/defs/go-objects/configs.go
+++ b/src/backend/defs/go-objects/configs.go
@@ -46,12 +46,14 @@ type (
 	}
 	// Cassandra
 	StoreConfig struct {
-		Hosts       []string  `mapstructure:"hosts"`
-		Keyspace    string    `mapstructure:"keyspace"`
-		Consistency uint16    `mapstructure:"consistency_level"`
-		SizeLimit   uint64    `mapstructure:"raw_size_limit"` // max size to store (in bytes)
-		ObjectStore string    `mapstructure:"object_store"`
-		OSSConfig   OSSConfig `mapstructure:"object_store_settings"`
+		Hosts       []string    `mapstructure:"hosts"`
+		Keyspace    string      `mapstructure:"keyspace"`
+		Consistency uint16      `mapstructure:"consistency_level"`
+		SizeLimit   uint64      `mapstructure:"raw_size_limit"` // max size to store (in bytes)
+		ObjectStore string      `mapstructure:"object_store"`
+		OSSConfig   OSSConfig   `mapstructure:"object_store_settings"`
+		UseVault    bool        `mapstructure:"use_vault"`
+		VaultConfig VaultConfig `mapstructure:"vault_settings"`
 	}
 
 	// Objects Store

--- a/src/backend/defs/go-objects/configs.go
+++ b/src/backend/defs/go-objects/configs.go
@@ -23,6 +23,7 @@ type (
 		ObjStoreType string   `mapstructure:"object_store"`
 		OSSConfig    `mapstructure:"object_store_settings"`
 		UseVault     bool `mapstructure:"use_vault"`
+		VaultConfig  `mapstructure:"vault_settings"`
 	}
 
 	RESTIndexConfig struct {
@@ -67,5 +68,12 @@ type (
 		AdminUsername string `mapstructure:"admin_username"`
 		BaseUrl       string `mapstructure:"base_url"`       // url upon which to build custom links sent to users. No trailing slash please.
 		TemplatesPath string `mapstructure:"templates_path"` // path to templates Notifiers may need to access to
+	}
+
+	// Hashicorp Vault
+	VaultConfig struct {
+		Url      string `mapstructure:"url"`
+		Username string `mapstructure:"username"`
+		Password string `mapstructure:"password"`
 	}
 )

--- a/src/backend/defs/go-objects/identities.go
+++ b/src/backend/defs/go-objects/identities.go
@@ -55,7 +55,7 @@ type (
 
 	//struct to store external user accounts
 	RemoteIdentity struct {
-		Credentials Credentials       `cql:"credentials"        json:"credentials,omitempty" frontend:"omit"            patch:"user"`
+		Credentials Credentials       `cql:"credentials"        json:"credentials,omitempty"                            patch:"user"`
 		DisplayName string            `cql:"display_name"       json:"display_name"                                     patch:"user"`
 		Infos       map[string]string `cql:"infos"              json:"infos"                                            patch:"user"`
 		LastCheck   time.Time         `cql:"last_check"         json:"last_check"           formatter:"RFC3339Milli"`

--- a/src/backend/interfaces/REST/go.server/api_server.go
+++ b/src/backend/interfaces/REST/go.server/api_server.go
@@ -50,13 +50,14 @@ type (
 	}
 
 	BackendSettings struct {
-		Hosts            []string      `mapstructure:"hosts"`
-		Keyspace         string        `mapstructure:"keyspace"`
-		Consistency      uint16        `mapstructure:"consistency_level"`
-		SizeLimit        uint64        `mapstructure:"raw_size_limit"` // max size for db (in bytes)
-		ObjStoreType     string        `mapstructure:"object_store"`
-		ObjStoreSettings obj.OSSConfig `mapstructure:"object_store_settings"`
-		UseVault         bool          `mapstructure:"use_vault"`
+		Hosts            []string        `mapstructure:"hosts"`
+		Keyspace         string          `mapstructure:"keyspace"`
+		Consistency      uint16          `mapstructure:"consistency_level"`
+		SizeLimit        uint64          `mapstructure:"raw_size_limit"` // max size for db (in bytes)
+		ObjStoreType     string          `mapstructure:"object_store"`
+		ObjStoreSettings obj.OSSConfig   `mapstructure:"object_store_settings"`
+		UseVault         bool            `mapstructure:"use_vault"`
+		VaultSettings    obj.VaultConfig `mapstructure:"vault_settings"`
 	}
 
 	IndexConfig struct {
@@ -106,6 +107,7 @@ func (server *REST_API) initialize(config APIConfig) error {
 			ObjStoreType: config.BackendConfig.Settings.ObjStoreType,
 			OSSConfig:    config.BackendConfig.Settings.ObjStoreSettings,
 			UseVault:     config.BackendConfig.Settings.UseVault,
+			VaultConfig:  config.BackendConfig.Settings.VaultSettings,
 		},
 		RESTindexConfig: obj.RESTIndexConfig{
 			IndexName: config.IndexConfig.IndexName,

--- a/src/backend/interfaces/REST/go.server/api_server.go
+++ b/src/backend/interfaces/REST/go.server/api_server.go
@@ -56,6 +56,7 @@ type (
 		SizeLimit        uint64        `mapstructure:"raw_size_limit"` // max size for db (in bytes)
 		ObjStoreType     string        `mapstructure:"object_store"`
 		ObjStoreSettings obj.OSSConfig `mapstructure:"object_store_settings"`
+		UseVault         bool          `mapstructure:"use_vault"`
 	}
 
 	IndexConfig struct {
@@ -104,6 +105,7 @@ func (server *REST_API) initialize(config APIConfig) error {
 			SizeLimit:    config.BackendConfig.Settings.SizeLimit,
 			ObjStoreType: config.BackendConfig.Settings.ObjStoreType,
 			OSSConfig:    config.BackendConfig.Settings.ObjStoreSettings,
+			UseVault:     config.BackendConfig.Settings.UseVault,
 		},
 		RESTindexConfig: obj.RESTIndexConfig{
 			IndexName: config.IndexConfig.IndexName,

--- a/src/backend/interfaces/REST/go.server/operations/identities/identities.go
+++ b/src/backend/interfaces/REST/go.server/operations/identities/identities.go
@@ -58,7 +58,7 @@ func GetRemoteIdentities(ctx *gin.Context) {
 		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
 		ctx.Abort()
 	}
-	noCredentials := false
+	noCredentials := false // by default do not return Credentials
 	list, e := caliopen.Facilities.RESTfacility.RetrieveRemoteIdentities(userID, noCredentials)
 	if e != nil && e.Code() != NotFoundCaliopenErr {
 		returnedErr := new(swgErr.CompositeError)
@@ -102,7 +102,7 @@ func GetRemoteIdentity(ctx *gin.Context) {
 		ctx.Abort()
 		return
 	}
-	noCredentials := false
+	noCredentials := false // by default do not return Credentials
 	identity, e := caliopen.Facilities.RESTfacility.RetrieveRemoteIdentity(userID, remote_id, noCredentials)
 	if e != nil {
 		returnedErr := new(swgErr.CompositeError)

--- a/src/backend/interfaces/REST/go.server/operations/identities/identities.go
+++ b/src/backend/interfaces/REST/go.server/operations/identities/identities.go
@@ -58,8 +58,8 @@ func GetRemoteIdentities(ctx *gin.Context) {
 		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
 		ctx.Abort()
 	}
-
-	list, e := caliopen.Facilities.RESTfacility.RetrieveRemoteIdentities(userID)
+	noCredentials := false
+	list, e := caliopen.Facilities.RESTfacility.RetrieveRemoteIdentities(userID, noCredentials)
 	if e != nil && e.Code() != NotFoundCaliopenErr {
 		returnedErr := new(swgErr.CompositeError)
 		returnedErr = swgErr.CompositeValidationError(swgErr.New(http.StatusFailedDependency, "RESTfacility returned error"), e, e.Cause())
@@ -102,7 +102,8 @@ func GetRemoteIdentity(ctx *gin.Context) {
 		ctx.Abort()
 		return
 	}
-	identity, e := caliopen.Facilities.RESTfacility.RetrieveRemoteIdentity(userID, remote_id)
+	noCredentials := false
+	identity, e := caliopen.Facilities.RESTfacility.RetrieveRemoteIdentity(userID, remote_id, noCredentials)
 	if e != nil {
 		returnedErr := new(swgErr.CompositeError)
 		if e.Code() == NotFoundCaliopenErr {

--- a/src/backend/main/go.backends/CredentialsInterfaces.go
+++ b/src/backend/main/go.backends/CredentialsInterfaces.go
@@ -1,0 +1,14 @@
+/*
+ * // Copyleft (ɔ) 2018 The Caliopen contributors.
+ * // Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+ * // license (AGPL) that can be found in the LICENSE file.
+ */
+
+package backends
+
+type CredentialsStorage interface {
+	CreateCredential()
+	RetrieveCredential()
+	UpdateCredential()
+	DeleteCredential()
+}

--- a/src/backend/main/go.backends/CredentialsInterfaces.go
+++ b/src/backend/main/go.backends/CredentialsInterfaces.go
@@ -6,9 +6,13 @@
 
 package backends
 
+import (
+	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
+)
+
 type CredentialsStorage interface {
-	CreateCredential()
-	RetrieveCredential()
-	UpdateCredential()
-	DeleteCredential()
+	CreateCredentials(rId *RemoteIdentity, cred Credentials) error
+	RetrieveCredentials(userId, identifier string) (Credentials, error)
+	UpdateCredentials()
+	DeleteCredentials()
 }

--- a/src/backend/main/go.backends/CredentialsInterfaces.go
+++ b/src/backend/main/go.backends/CredentialsInterfaces.go
@@ -12,7 +12,7 @@ import (
 
 type CredentialsStorage interface {
 	CreateCredentials(rId *RemoteIdentity, cred Credentials) error
-	RetrieveCredentials(userId, identifier string) (Credentials, error)
-	UpdateCredentials(userId, identifier string, cred Credentials) error
-	DeleteCredentials(userId, identifier string) error
+	RetrieveCredentials(userId, remoteId string) (Credentials, error)
+	UpdateCredentials(userId, remoteId string, cred Credentials) error
+	DeleteCredentials(userId, remoteId string) error
 }

--- a/src/backend/main/go.backends/CredentialsInterfaces.go
+++ b/src/backend/main/go.backends/CredentialsInterfaces.go
@@ -13,6 +13,6 @@ import (
 type CredentialsStorage interface {
 	CreateCredentials(rId *RemoteIdentity, cred Credentials) error
 	RetrieveCredentials(userId, identifier string) (Credentials, error)
-	UpdateCredentials()
-	DeleteCredentials()
+	UpdateCredentials(userId, identifier string, cred Credentials) error
+	DeleteCredentials(userId, identifier string) error
 }

--- a/src/backend/main/go.backends/IdentitiesInterface.go
+++ b/src/backend/main/go.backends/IdentitiesInterface.go
@@ -14,10 +14,10 @@ type (
 	IdentityStorage interface {
 		RetrieveLocalsIdentities(user_id string) ([]LocalIdentity, error)
 		CreateRemoteIdentity(rId *RemoteIdentity) CaliopenError
-		RetrieveRemoteIdentity(userId, RemoteId string) (*RemoteIdentity, error)
+		RetrieveRemoteIdentity(userId, RemoteId string, withCredentials bool) (*RemoteIdentity, error)
 		UpdateRemoteIdentity(rId *RemoteIdentity, fields map[string]interface{}) error
 		DeleteRemoteIdentity(rId *RemoteIdentity) error
-		RetrieveRemoteIdentities(userId string) ([]*RemoteIdentity, error)
+		RetrieveRemoteIdentities(userId string, withCredentials bool) ([]*RemoteIdentity, error)
 		RetrieveAllRemotes() (<-chan *RemoteIdentity, error)
 		Close()
 	}

--- a/src/backend/main/go.backends/IdentitiesInterface.go
+++ b/src/backend/main/go.backends/IdentitiesInterface.go
@@ -18,7 +18,7 @@ type (
 		UpdateRemoteIdentity(rId *RemoteIdentity, fields map[string]interface{}) error
 		DeleteRemoteIdentity(rId *RemoteIdentity) error
 		RetrieveRemoteIdentities(userId string, withCredentials bool) ([]*RemoteIdentity, error)
-		RetrieveAllRemotes() (<-chan *RemoteIdentity, error)
+		RetrieveAllRemotes(withCredentials bool) (<-chan *RemoteIdentity, error)
 		Close()
 	}
 )

--- a/src/backend/main/go.backends/RESTInterfaces.go
+++ b/src/backend/main/go.backends/RESTInterfaces.go
@@ -10,13 +10,14 @@ import (
 
 type APIStorage interface {
 	AttachmentStorage
+	CredentialsStorage
 	ContactStorage
+	DevicesStorage
 	IdentityStorage
 	MessageStorage
 	TagsStorage
 	UserNameStorage
 	UserStorage
-	DevicesStorage
 }
 
 type APIIndex interface {

--- a/src/backend/main/go.backends/store/cassandra/cassandra.go
+++ b/src/backend/main/go.backends/store/cassandra/cassandra.go
@@ -42,6 +42,24 @@ const DefaultTimeout = time.Second * 2
 func InitializeCassandraBackend(config CassandraConfig) (cb *CassandraBackend, err error) {
 	cb = new(CassandraBackend)
 	err = cb.initialize(config)
+	if err != nil {
+		return nil, err
+	}
+	// objects store
+	if config.WithObjStore {
+		cb.ObjectsStore, err = object_store.InitializeObjectsStore(config.OSSConfig)
+		if err != nil {
+			log.Warn("Object store initialization failed.")
+			return nil, err
+		}
+	}
+
+	// credentials store
+	err = cb.initializeCredentialBackend()
+	if err != nil {
+		return nil, err
+	}
+
 	return
 }
 
@@ -71,16 +89,14 @@ func (cb *CassandraBackend) initialize(config CassandraConfig) (err error) {
 	connection := gocassa.NewConnection(gocassa.GoCQLSessionToQueryExecutor(cb.Session))
 	cb.IKeyspace = connection.KeySpace(cb.Keyspace)
 
-	if config.WithObjStore {
-		cb.ObjectsStore, err = object_store.InitializeObjectsStore(config.OSSConfig)
-		if err != nil {
-			log.Warn("Object store initialization failed.")
-			return err
-		}
-	}
 	return
 }
 
 func (cb *CassandraBackend) Close() {
 	cb.Session.Close()
+}
+
+func (cb *CassandraBackend) initializeCredentialBackend() error {
+
+	return nil
 }

--- a/src/backend/main/go.backends/store/cassandra/cassandra.go
+++ b/src/backend/main/go.backends/store/cassandra/cassandra.go
@@ -31,6 +31,7 @@ type (
 		WithObjStore bool              // whether to use an objects store service for objects above SizeLimit
 		object_store.OSSConfig
 		UseVault bool `mapstructure:"use_vault"`
+		vault.HVaultConfig
 	}
 
 	HasTable interface {
@@ -60,7 +61,7 @@ func InitializeCassandraBackend(config CassandraConfig) (cb *CassandraBackend, e
 	// credentials store
 	cb.UseVault = config.UseVault
 	if cb.UseVault {
-		cb.Vault, err = vault.InitializeVaultBackend()
+		cb.Vault, err = vault.InitializeVaultBackend(config.HVaultConfig)
 		if err != nil {
 			log.Warn("[InitializeCassandraBackend] vault initialization failed")
 			return nil, err

--- a/src/backend/main/go.backends/store/cassandra/credentials.go
+++ b/src/backend/main/go.backends/store/cassandra/credentials.go
@@ -1,0 +1,12 @@
+/*
+ * // Copyleft (ɔ) 2018 The Caliopen contributors.
+ * // Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+ * // license (AGPL) that can be found in the LICENSE file.
+ */
+
+package store
+
+func (cb *CassandraBackend) CreateCredential()   {}
+func (cb *CassandraBackend) RetrieveCredential() {}
+func (cb *CassandraBackend) UpdateCredential()   {}
+func (cb *CassandraBackend) DeleteCredential()   {}

--- a/src/backend/main/go.backends/store/cassandra/credentials.go
+++ b/src/backend/main/go.backends/store/cassandra/credentials.go
@@ -6,7 +6,33 @@
 
 package store
 
-func (cb *CassandraBackend) CreateCredential()   {}
-func (cb *CassandraBackend) RetrieveCredential() {}
-func (cb *CassandraBackend) UpdateCredential()   {}
-func (cb *CassandraBackend) DeleteCredential()   {}
+import (
+	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
+)
+
+func (cb *CassandraBackend) CreateCredentials(rId *RemoteIdentity, cred Credentials) error {
+
+	if cb.UseVault {
+		return cb.Vault.CreateCredentials(rId, cred)
+	}
+
+	//(re)embed credentials into RemoteIdentity that has already been created
+	(*rId).Credentials = cred
+	return cb.UpdateRemoteIdentity(rId, map[string]interface{}{
+		"Credentials": cred,
+	})
+}
+
+func (cb *CassandraBackend) RetrieveCredentials(userId, identifier string) (cred Credentials, err error) {
+
+	if cb.UseVault {
+		return cb.Vault.RetrieveCredentials(userId, identifier)
+	}
+
+	err = cb.Session.Query(`SELECT credentials FROM remote_identity WHERE user_id = ? AND identifier = ?`, userId, identifier).Scan(&cred)
+
+	return
+}
+
+func (cb *CassandraBackend) UpdateCredentials() {}
+func (cb *CassandraBackend) DeleteCredentials() {}

--- a/src/backend/main/go.backends/store/cassandra/identities.go
+++ b/src/backend/main/go.backends/store/cassandra/identities.go
@@ -153,7 +153,8 @@ func (cb *CassandraBackend) RetrieveRemoteIdentities(userId string, withCredenti
 		if withCredentials {
 			cred, err := cb.RetrieveCredentials(userId, id.RemoteId.String())
 			if err != nil {
-				return nil, err
+				// return remote identity even if credentials retrieval failed
+				cred = Credentials{}
 			}
 			id.Credentials = cred
 		} else {

--- a/src/backend/main/go.backends/store/vault/credentials.go
+++ b/src/backend/main/go.backends/store/vault/credentials.go
@@ -8,31 +8,63 @@ package vault
 
 import (
 	"errors"
+	"fmt"
 	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
 )
 
 type VaultCredentials interface {
 	CreateCredentials(rId *RemoteIdentity, cred Credentials) error
-	RetrieveCredentials(userId, identifier string) (Credentials, error)
-	UpdateCredentials(userId, identifier string, cred Credentials) error
-	DeleteCredentials(userId, identifier string) error
+	RetrieveCredentials(userId, remoteId string) (Credentials, error)
+	UpdateCredentials(userId, remoteId string, cred Credentials) error
+	DeleteCredentials(userId, remoteId string) error
 }
 
 func (vault *HVaultClient) CreateCredentials(rId *RemoteIdentity, cred Credentials) error {
-	return errors.New("[HVaultClient] CreateCredentials not implemented")
+	return vault.UpdateCredentials(rId.UserId.String(), rId.RemoteId.String(), cred)
 }
 
 // RetrieveCrendentials gets credentials from vault, if application has read rights on vault
-func (vault *HVaultClient) RetrieveCredentials(userId, identifier string) (cred Credentials, err error) {
+func (vault *HVaultClient) RetrieveCredentials(userId, remoteId string) (cred Credentials, err error) {
 	cred = Credentials{}
-	err = errors.New("[HVaultClient] RetrieveCredentials not implemented")
+	path := fmt.Sprintf(credentialsPath, userId, remoteId)
+	secret, err := vault.hclient.Logical().Read(path)
+	if err != nil {
+		return
+	}
+	if secret == nil || secret.Data == nil {
+		// secret not found
+		err = errors.New("secret not found")
+		return
+	}
+
+	data, ok := secret.Data["data"]
+	if !ok {
+		err = errors.New("secret not found")
+		return
+	}
+	// Credentials is a map[string]string
+	// only copy values from secret.Data that are strings
+	for k, v := range data.(map[string]interface{}) {
+		switch v.(type) {
+		case string:
+			cred[k] = v.(string)
+		default:
+			continue
+		}
+	}
 	return
 }
 
-func (vault *HVaultClient) UpdateCredentials(userId, identifier string, cred Credentials) error {
-	return errors.New("[HVaultClient] UpdateCredentials not implemented")
+func (vault *HVaultClient) UpdateCredentials(userId, remoteId string, cred Credentials) error {
+	payload := make(map[string]interface{})
+	payload["data"] = cred
+	path := fmt.Sprintf(credentialsPath, userId, remoteId)
+	_, err := vault.hclient.Logical().Write(path, payload)
+	return err
 }
 
-func (vault *HVaultClient) DeleteCredentials(userId, identifier string) error {
-	return errors.New("[HVaultClient] UpdateCredentials not implemented")
+func (vault *HVaultClient) DeleteCredentials(userId, remoteId string) error {
+	path := fmt.Sprintf(credentialsPath, userId, remoteId)
+	_, err := vault.hclient.Logical().Delete(path)
+	return err
 }

--- a/src/backend/main/go.backends/store/vault/credentials.go
+++ b/src/backend/main/go.backends/store/vault/credentials.go
@@ -14,8 +14,8 @@ import (
 type VaultCredentials interface {
 	CreateCredentials(rId *RemoteIdentity, cred Credentials) error
 	RetrieveCredentials(userId, identifier string) (Credentials, error)
-	UpdateCredentials()
-	DeleteCredentials()
+	UpdateCredentials(userId, identifier string, cred Credentials) error
+	DeleteCredentials(userId, identifier string) error
 }
 
 func (vault *HVaultClient) CreateCredentials(rId *RemoteIdentity, cred Credentials) error {
@@ -27,4 +27,12 @@ func (vault *HVaultClient) RetrieveCredentials(userId, identifier string) (cred 
 	cred = Credentials{}
 	err = errors.New("[HVaultClient] RetrieveCredentials not implemented")
 	return
+}
+
+func (vault *HVaultClient) UpdateCredentials(userId, identifier string, cred Credentials) error {
+	return errors.New("[HVaultClient] UpdateCredentials not implemented")
+}
+
+func (vault *HVaultClient) DeleteCredentials(userId, identifier string) error {
+	return errors.New("[HVaultClient] UpdateCredentials not implemented")
 }

--- a/src/backend/main/go.backends/store/vault/credentials.go
+++ b/src/backend/main/go.backends/store/vault/credentials.go
@@ -6,9 +6,25 @@
 
 package vault
 
-type VaultCredential interface {
-	CreateCredential()
-	RetrieveCredential()
-	UpdateCredential()
-	DeleteCredential()
+import (
+	"errors"
+	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
+)
+
+type VaultCredentials interface {
+	CreateCredentials(rId *RemoteIdentity, cred Credentials) error
+	RetrieveCredentials(userId, identifier string) (Credentials, error)
+	UpdateCredentials()
+	DeleteCredentials()
+}
+
+func (vault *HVaultClient) CreateCredentials(rId *RemoteIdentity, cred Credentials) error {
+	return errors.New("[HVaultClient] CreateCredentials not implemented")
+}
+
+// RetrieveCrendentials gets credentials from vault, if application has read rights on vault
+func (vault *HVaultClient) RetrieveCredentials(userId, identifier string) (cred Credentials, err error) {
+	cred = Credentials{}
+	err = errors.New("[HVaultClient] RetrieveCredentials not implemented")
+	return
 }

--- a/src/backend/main/go.backends/store/vault/credentials.go
+++ b/src/backend/main/go.backends/store/vault/credentials.go
@@ -1,0 +1,14 @@
+/*
+ * // Copyleft (ɔ) 2018 The Caliopen contributors.
+ * // Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+ * // license (AGPL) that can be found in the LICENSE file.
+ */
+
+package vault
+
+type VaultCredential interface {
+	CreateCredential()
+	RetrieveCredential()
+	UpdateCredential()
+	DeleteCredential()
+}

--- a/src/backend/main/go.backends/store/vault/hvault_interface.go
+++ b/src/backend/main/go.backends/store/vault/hvault_interface.go
@@ -1,0 +1,13 @@
+/*
+ * // Copyleft (ɔ) 2018 The Caliopen contributors.
+ * // Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+ * // license (AGPL) that can be found in the LICENSE file.
+ */
+
+// interfaces definition to Hashicorp Vault server
+package vault
+
+// As of june 2018, only one interface for CRUD operation on credentials. Later on, we may add Cubbyhole secrets engine, databases secret engine and so on…
+type HVault interface {
+	VaultCredential
+}

--- a/src/backend/main/go.backends/store/vault/hvault_interface.go
+++ b/src/backend/main/go.backends/store/vault/hvault_interface.go
@@ -9,5 +9,5 @@ package vault
 
 // As of june 2018, only one interface for CRUD operation on credentials. Later on, we may add Cubbyhole secrets engine, databases secret engine and so on…
 type HVault interface {
-	VaultCredential
+	VaultCredentials
 }

--- a/src/backend/main/go.backends/store/vault/vault_client.go
+++ b/src/backend/main/go.backends/store/vault/vault_client.go
@@ -10,6 +10,9 @@ package vault
 
 import "errors"
 
+type HVaultClient struct {
+}
+
 // InitializeVaultBackend checks if a Vault server is available and returns a VaultClient
 func InitializeVaultBackend() (vault HVault, err error) {
 

--- a/src/backend/main/go.backends/store/vault/vault_client.go
+++ b/src/backend/main/go.backends/store/vault/vault_client.go
@@ -8,13 +8,35 @@
 
 package vault
 
-import "errors"
+import (
+	hvault "github.com/hashicorp/vault/api"
+)
 
 type HVaultClient struct {
+	hclient *hvault.Client
 }
 
-// InitializeVaultBackend checks if a Vault server is available and returns a VaultClient
-func InitializeVaultBackend() (vault HVault, err error) {
+const credentialsPath = "secret/data/%s/%s" // path to store credentials => secret/data/user_id/remote_id
 
-	return nil, errors.New("HVault not implemented")
+// InitializeVaultBackend checks if a Vault server is available and returns a VaultClient
+func InitializeVaultBackend() (hv HVault, err error) {
+	config := hvault.DefaultConfig()
+	config.Address = "http://127.0.0.1:8200"
+
+	var hc HVaultClient
+
+	hc.hclient, err = hvault.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	hc.hclient.SetToken("3a995021-7b93-b4bd-f327-28a7bfa4ef50")
+	hc.hclient.Auth()
+
+	_, err = hc.hclient.Sys().Health()
+	if err != nil {
+		return nil, err
+	}
+
+	return &hc, nil
 }

--- a/src/backend/main/go.backends/store/vault/vault_client.go
+++ b/src/backend/main/go.backends/store/vault/vault_client.go
@@ -1,0 +1,14 @@
+/*
+ * // Copyleft (ɔ) 2018 The Caliopen contributors.
+ * // Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+ * // license (AGPL) that can be found in the LICENSE file.
+ */
+
+// vault_client provides an interface to interact with HashiCorp Vault server
+
+package vault
+
+// InitializeVaultBackend checks if a Vault server is available and returns a VaultClient
+func InitializeVaultBackend() {
+
+}

--- a/src/backend/main/go.backends/store/vault/vault_client.go
+++ b/src/backend/main/go.backends/store/vault/vault_client.go
@@ -8,7 +8,10 @@
 
 package vault
 
-// InitializeVaultBackend checks if a Vault server is available and returns a VaultClient
-func InitializeVaultBackend() {
+import "errors"
 
+// InitializeVaultBackend checks if a Vault server is available and returns a VaultClient
+func InitializeVaultBackend() (vault HVault, err error) {
+
+	return nil, errors.New("HVault not implemented")
 }

--- a/src/backend/main/go.backends/store/vault/vault_test.go
+++ b/src/backend/main/go.backends/store/vault/vault_test.go
@@ -1,0 +1,46 @@
+/*
+ * // Copyleft (ɔ) 2018 The Caliopen contributors.
+ * // Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+ * // license (AGPL) that can be found in the LICENSE file.
+ */
+
+package vault
+
+import (
+	"github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
+	hvault "github.com/hashicorp/vault/api"
+	"testing"
+)
+
+func TestInitializeVaultBackend(t *testing.T) {
+	config := hvault.DefaultConfig()
+	config.Address = "http://127.0.0.1:8200"
+	hclient, err := hvault.NewClient(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hclient.SetToken("3a995021-7b93-b4bd-f327-28a7bfa4ef50")
+	hclient.Auth()
+
+	_, err = hclient.Sys().Health()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cred := objects.Credentials{
+		"password": "pass",
+		"username": "user",
+	}
+	payload := make(map[string]interface{})
+	payload["data"] = cred
+	_, err = hclient.Logical().Write("secret/data/userid/remoteid", payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret, err := hclient.Logical().Read("secret/data/userid/remoteid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(secret.Data["data"])
+}

--- a/src/backend/main/go.main/caliopen.go
+++ b/src/backend/main/go.main/caliopen.go
@@ -54,6 +54,7 @@ func (facilities *CaliopenFacilities) initialize(config CaliopenConfig) (err err
 	// REST facility initialization
 	rest := REST.NewRESTfacility(config, facilities.nats)
 	facilities.RESTfacility = rest
+
 	// copy cache facility from REST facility
 	facilities.Cache = rest.Cache
 

--- a/src/backend/main/go.main/facilities/REST/RESTfacility.go
+++ b/src/backend/main/go.main/facilities/REST/RESTfacility.go
@@ -97,6 +97,7 @@ func NewRESTfacility(config CaliopenConfig, nats_conn *nats.Conn) (rest_facility
 			Hosts:       config.RESTstoreConfig.Hosts,
 			Keyspace:    config.RESTstoreConfig.Keyspace,
 			Consistency: gocql.Consistency(config.RESTstoreConfig.Consistency),
+			UseVault:    config.RESTstoreConfig.UseVault,
 		}
 		if config.RESTstoreConfig.ObjStoreType == "s3" {
 			cassaConfig.WithObjStore = true

--- a/src/backend/main/go.main/facilities/REST/RESTfacility.go
+++ b/src/backend/main/go.main/facilities/REST/RESTfacility.go
@@ -35,8 +35,8 @@ type (
 		RetrieveContactIdentities(user_id, contact_id string) (identities []ContactIdentity, err error)
 		RetrieveLocalsIdentities(user_id string) (identities []LocalIdentity, err error)
 		CreateRemoteIdentity(identity *RemoteIdentity) CaliopenError
-		RetrieveRemoteIdentities(userId string) (ids []*RemoteIdentity, err CaliopenError)
-		RetrieveRemoteIdentity(userId, RemoteId string) (id *RemoteIdentity, err CaliopenError)
+		RetrieveRemoteIdentities(userId string, withCredentials bool) (ids []*RemoteIdentity, err CaliopenError)
+		RetrieveRemoteIdentity(userId, RemoteId string, withCredentials bool) (id *RemoteIdentity, err CaliopenError)
 		UpdateRemoteIdentity(identity, oldIdentity *RemoteIdentity, update map[string]interface{}) CaliopenError
 		PatchRemoteIdentity(patch []byte, userId, RemoteId string) CaliopenError
 		DeleteRemoteIdentity(userId, RemoteId string) CaliopenError

--- a/src/backend/main/go.main/facilities/REST/RESTfacility.go
+++ b/src/backend/main/go.main/facilities/REST/RESTfacility.go
@@ -108,6 +108,11 @@ func NewRESTfacility(config CaliopenConfig, nats_conn *nats.Conn) (rest_facility
 			cassaConfig.OSSConfig.RawMsgBucket = config.RESTstoreConfig.OSSConfig.Buckets["raw_messages"]
 			cassaConfig.OSSConfig.AttachmentBucket = config.RESTstoreConfig.OSSConfig.Buckets["temporary_attachments"]
 		}
+		if config.RESTstoreConfig.UseVault {
+			cassaConfig.HVaultConfig.Url = config.RESTstoreConfig.VaultConfig.Url
+			cassaConfig.HVaultConfig.Username = config.RESTstoreConfig.VaultConfig.Username
+			cassaConfig.HVaultConfig.Password = config.RESTstoreConfig.VaultConfig.Password
+		}
 		backend, err := store.InitializeCassandraBackend(cassaConfig)
 		if err != nil {
 			log.WithError(err).Fatalf("initalization of %s backend failed", config.RESTstoreConfig.BackendName)

--- a/src/backend/main/go.main/facilities/REST/RESTfacility.go
+++ b/src/backend/main/go.main/facilities/REST/RESTfacility.go
@@ -109,11 +109,13 @@ func NewRESTfacility(config CaliopenConfig, nats_conn *nats.Conn) (rest_facility
 		}
 		backend, err := store.InitializeCassandraBackend(cassaConfig)
 		if err != nil {
-			log.WithError(err).Fatalf("Initalization of %s backend failed", config.RESTstoreConfig.BackendName)
+			log.WithError(err).Fatalf("initalization of %s backend failed", config.RESTstoreConfig.BackendName)
 		}
+
 		rest_facility.store = backends.APIStorage(backend) // type conversion
+
 	default:
-		log.Fatalf("Unknown backend: %s", config.RESTstoreConfig.BackendName)
+		log.Fatalf("unknown backend: %s", config.RESTstoreConfig.BackendName)
 	}
 
 	switch config.RESTindexConfig.IndexName {
@@ -123,16 +125,16 @@ func NewRESTfacility(config CaliopenConfig, nats_conn *nats.Conn) (rest_facility
 		}
 		indx, err := index.InitializeElasticSearchIndex(esConfig)
 		if err != nil {
-			log.WithError(err).Fatalf("Initalization of %s index failed", config.RESTindexConfig.IndexName)
+			log.WithError(err).Fatalf("initalization of %s index failed", config.RESTindexConfig.IndexName)
 		}
 		rest_facility.index = backends.APIIndex(indx) // type conversion
 	default:
-		log.Fatalf("Unknown index: %s", config.RESTindexConfig.IndexName)
+		log.Fatalf("unknown index: %s", config.RESTindexConfig.IndexName)
 	}
 
 	cach, err := cache.InitializeRedisBackend(config.CacheConfig)
 	if err != nil {
-		log.WithError(err).Fatal("Initialization of Redis cache failed")
+		log.WithError(err).Fatal("initialization of Redis cache failed")
 	}
 
 	rest_facility.Cache = backends.APICache(cach) // type conversion

--- a/src/backend/main/go.main/facilities/REST/identities.go
+++ b/src/backend/main/go.main/facilities/REST/identities.go
@@ -79,9 +79,9 @@ func (rest *RESTfacility) RetrieveContactIdentities(user_id, contact_id string) 
 	return
 }
 
-func (rest *RESTfacility) RetrieveRemoteIdentities(userId string) (ids []*RemoteIdentity, err CaliopenError) {
+func (rest *RESTfacility) RetrieveRemoteIdentities(userId string, withCredentials bool) (ids []*RemoteIdentity, err CaliopenError) {
 	var e error
-	ids, e = rest.store.RetrieveRemoteIdentities(userId)
+	ids, e = rest.store.RetrieveRemoteIdentities(userId, withCredentials)
 	if e != nil {
 		if e.Error() == "remote ids not found" {
 			err = WrapCaliopenErr(e, NotFoundCaliopenErr, "store did not found remote ids")
@@ -114,9 +114,9 @@ func (rest *RESTfacility) CreateRemoteIdentity(identity *RemoteIdentity) Caliope
 	return nil
 }
 
-func (rest *RESTfacility) RetrieveRemoteIdentity(userId, remoteId string) (id *RemoteIdentity, err CaliopenError) {
+func (rest *RESTfacility) RetrieveRemoteIdentity(userId, remoteId string, withCredentials bool) (id *RemoteIdentity, err CaliopenError) {
 	var e error
-	id, e = rest.store.RetrieveRemoteIdentity(userId, remoteId)
+	id, e = rest.store.RetrieveRemoteIdentity(userId, remoteId, withCredentials)
 	if e != nil {
 		if e.Error() == "not found" {
 			err = WrapCaliopenErr(e, NotFoundCaliopenErr, "remote identity not found")
@@ -136,7 +136,7 @@ func (rest *RESTfacility) UpdateRemoteIdentity(identity, oldIdentity *RemoteIden
 }
 
 func (rest *RESTfacility) PatchRemoteIdentity(patch []byte, userId, remoteId string) CaliopenError {
-	currentRemoteID, err1 := rest.RetrieveRemoteIdentity(userId, remoteId)
+	currentRemoteID, err1 := rest.RetrieveRemoteIdentity(userId, remoteId, true)
 	if err1 != nil {
 		if err1.Error() == "not found" {
 			return WrapCaliopenErr(err1, NotFoundCaliopenErr, "remote identity not found")
@@ -170,7 +170,7 @@ func (rest *RESTfacility) PatchRemoteIdentity(patch []byte, userId, remoteId str
 }
 
 func (rest *RESTfacility) DeleteRemoteIdentity(userId, remoteId string) CaliopenError {
-	remoteID, err1 := rest.RetrieveRemoteIdentity(userId, remoteId)
+	remoteID, err1 := rest.RetrieveRemoteIdentity(userId, remoteId, false)
 	if err1 != nil {
 		if err1.Error() == "not found" {
 			return WrapCaliopenErr(err1, NotFoundCaliopenErr, "remote identity not found")

--- a/src/backend/protocols/go.imap/fetcher.go
+++ b/src/backend/protocols/go.imap/fetcher.go
@@ -37,7 +37,7 @@ func (f *Fetcher) SyncRemoteWithLocal(order IMAPfetchOrder) error {
 	log.Infof("[Fetcher] will fetch mails for remote %s", order.RemoteId)
 
 	// 1. retrieve infos from db
-	rId, err := f.Store.RetrieveRemoteIdentity(order.UserId, order.RemoteId)
+	rId, err := f.Store.RetrieveRemoteIdentity(order.UserId, order.RemoteId, true)
 	if err != nil {
 		log.WithError(err).Infof("[SyncRemoteWithLocal] failed to retrieve remote identity <%s> : <%s>", order.UserId, order.RemoteId)
 		return err

--- a/src/backend/protocols/go.imap/worker.go
+++ b/src/backend/protocols/go.imap/worker.go
@@ -60,6 +60,7 @@ func NewWorker(config WorkerConfig, id uint8) (worker *Worker, err error) {
 			Keyspace:    config.StoreConfig.Keyspace,
 			Consistency: gocql.Consistency(config.StoreConfig.Consistency),
 			SizeLimit:   config.StoreConfig.SizeLimit,
+			UseVault:    config.StoreConfig.UseVault,
 		}
 		if config.StoreConfig.ObjectStore == "s3" {
 			c.WithObjStore = true
@@ -69,6 +70,11 @@ func NewWorker(config WorkerConfig, id uint8) (worker *Worker, err error) {
 			c.RawMsgBucket = config.StoreConfig.OSSConfig.Buckets["raw_messages"]
 			c.AttachmentBucket = config.StoreConfig.OSSConfig.Buckets["temporary_attachments"]
 			c.Location = config.StoreConfig.OSSConfig.Location
+		}
+		if c.UseVault {
+			c.Url = config.StoreConfig.VaultConfig.Url
+			c.Username = config.StoreConfig.VaultConfig.Username
+			c.Password = config.StoreConfig.VaultConfig.Password
 		}
 		w.Store, err = store.InitializeCassandraBackend(c)
 		if err != nil {

--- a/src/backend/vendor/vendor.json
+++ b/src/backend/vendor/vendor.json
@@ -289,10 +289,22 @@
 			"revisionTime": "2014-10-28T05:47:10Z"
 		},
 		{
+			"checksumSHA1": "YAq1rqZIp+M74Q+jMBQkkMKm3VM=",
+			"path": "github.com/hashicorp/go-cleanhttp",
+			"revision": "d5fe4b57a186c716b0e00b8c301cbd9b4182694d",
+			"revisionTime": "2017-12-18T14:54:08Z"
+		},
+		{
 			"checksumSHA1": "4fgV2vzKKVyIlQ9nMyXIP5muq9E=",
 			"path": "github.com/hashicorp/go-multierror",
 			"revision": "ed905158d87462226a13fe39ddf685ea65f1c11f",
 			"revisionTime": "2016-12-16T18:43:04Z"
+		},
+		{
+			"checksumSHA1": "A1PcINvF3UiwHRKn8UcgARgvGRs=",
+			"path": "github.com/hashicorp/go-rootcerts",
+			"revision": "6bb64b370b90e7ef1fa532be9e591a81c3493e00",
+			"revisionTime": "2016-05-03T14:34:40Z"
 		},
 		{
 			"checksumSHA1": "o3XZZdOnSnwQSpYw215QV75ZDeI=",
@@ -347,6 +359,30 @@
 			"path": "github.com/hashicorp/hcl/json/token",
 			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
 			"revisionTime": "2017-05-04T19:02:34Z"
+		},
+		{
+			"checksumSHA1": "JSf2CkOiPHlxi6hGFvjlZuac+LY=",
+			"path": "github.com/hashicorp/vault/api",
+			"revision": "85d7ffea83a62f6c9cacfbce37948044bfed2b1d",
+			"revisionTime": "2018-06-14T04:06:19Z"
+		},
+		{
+			"checksumSHA1": "bSdPFOHaTwEvM4PIvn0PZfn75jM=",
+			"path": "github.com/hashicorp/vault/helper/compressutil",
+			"revision": "85d7ffea83a62f6c9cacfbce37948044bfed2b1d",
+			"revisionTime": "2018-06-14T04:06:19Z"
+		},
+		{
+			"checksumSHA1": "RlqPBLOexQ0jj6jomhiompWKaUg=",
+			"path": "github.com/hashicorp/vault/helper/hclutil",
+			"revision": "85d7ffea83a62f6c9cacfbce37948044bfed2b1d",
+			"revisionTime": "2018-06-14T04:06:19Z"
+		},
+		{
+			"checksumSHA1": "POgkM3GrjRFw6H3sw95YNEs552A=",
+			"path": "github.com/hashicorp/vault/helper/jsonutil",
+			"revision": "85d7ffea83a62f6c9cacfbce37948044bfed2b1d",
+			"revisionTime": "2018-06-14T04:06:19Z"
 		},
 		{
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
@@ -601,6 +637,12 @@
 			"revisionTime": "2016-02-20T08:48:02Z"
 		},
 		{
+			"checksumSHA1": "6JP37UqrI0H80Gpk0Y2P+KXgn5M=",
+			"path": "github.com/ryanuber/go-glob",
+			"revision": "256dc444b735e061061cf46c809487313d5b0065",
+			"revisionTime": "2017-01-28T01:21:29Z"
+		},
+		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
 			"path": "github.com/satori/go.uuid",
 			"revision": "5bf94b69c6b68ee1b541973bb8e1144db23a194b",
@@ -731,6 +773,12 @@
 			"path": "golang.org/x/net/html/atom",
 			"revision": "feeb485667d1fdabe727840fe00adc22431bc86e",
 			"revisionTime": "2017-05-02T17:39:58Z"
+		},
+		{
+			"checksumSHA1": "pCY4YtdNKVBYRbNvODjx8hj0hIs=",
+			"path": "golang.org/x/net/http/httpguts",
+			"revision": "db08ff08e8622530d9ed3a0e8ac279f6d4c02196",
+			"revisionTime": "2018-06-11T16:35:41Z"
 		},
 		{
 			"checksumSHA1": "VrzPJyWI6disCgYuVEQzkjqUsJk=",

--- a/src/backend/vendor/vendor.json
+++ b/src/backend/vendor/vendor.json
@@ -313,6 +313,12 @@
 			"revisionTime": "2016-05-03T14:34:40Z"
 		},
 		{
+			"checksumSHA1": "J47ySO1q0gcnmoMnir1q1loKzCk=",
+			"path": "github.com/hashicorp/go-sockaddr",
+			"revision": "6d291a969b86c4b633730bfc6b8b9d64c3aafed9",
+			"revisionTime": "2018-03-20T11:50:54Z"
+		},
+		{
 			"checksumSHA1": "o3XZZdOnSnwQSpYw215QV75ZDeI=",
 			"path": "github.com/hashicorp/hcl",
 			"revision": "a4b07c25de5ff55ad3b8936cea69a79a3d95a855",
@@ -395,6 +401,12 @@
 			"path": "github.com/hashicorp/vault/helper/parseutil",
 			"revision": "bd0b7f1861c90d162d3d461e79a93cf0f331cac4",
 			"revisionTime": "2018-06-15T13:09:27Z"
+		},
+		{
+			"checksumSHA1": "iwXQDzHqTFsjJW2ehYae0oLo2Ts=",
+			"path": "github.com/hashicorp/vault/helper/strutil",
+			"revision": "069ae7b87df7665c620d95ea561b24e6ff346b1f",
+			"revisionTime": "2018-06-20T03:07:56Z"
 		},
 		{
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",

--- a/src/backend/vendor/vendor.json
+++ b/src/backend/vendor/vendor.json
@@ -301,6 +301,12 @@
 			"revisionTime": "2016-12-16T18:43:04Z"
 		},
 		{
+			"checksumSHA1": "s6mKR1dSKP04+A3kwSsFr/PvsOU=",
+			"path": "github.com/hashicorp/go-retryablehttp",
+			"revision": "3b087ef2d313afe6c55b2f511d20db04ca767075",
+			"revisionTime": "2018-05-31T21:13:21Z"
+		},
+		{
 			"checksumSHA1": "A1PcINvF3UiwHRKn8UcgARgvGRs=",
 			"path": "github.com/hashicorp/go-rootcerts",
 			"revision": "6bb64b370b90e7ef1fa532be9e591a81c3493e00",
@@ -383,6 +389,12 @@
 			"path": "github.com/hashicorp/vault/helper/jsonutil",
 			"revision": "85d7ffea83a62f6c9cacfbce37948044bfed2b1d",
 			"revisionTime": "2018-06-14T04:06:19Z"
+		},
+		{
+			"checksumSHA1": "zPHu2orsbQqIuiuQ/8elJIUR2Po=",
+			"path": "github.com/hashicorp/vault/helper/parseutil",
+			"revision": "bd0b7f1861c90d162d3d461e79a93cf0f331cac4",
+			"revisionTime": "2018-06-15T13:09:27Z"
 		},
 		{
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
@@ -529,10 +541,10 @@
 			"revisionTime": "2016-11-07T13:59:01Z"
 		},
 		{
-			"checksumSHA1": "11S7rNUzdp9JDgZOwfw00/MR2+4=",
+			"checksumSHA1": "mNIK6LfMGR+IzGogT1PNvJysmdQ=",
 			"path": "github.com/nats-io/go-nats",
-			"revision": "2485387d6ede89c1c8c3445cd1935fd41a2e9ee9",
-			"revisionTime": "2018-03-17T20:41:12Z"
+			"revision": "4cf007b2f724143321da6c887060853c8a855696",
+			"revisionTime": "2018-06-12T15:49:07Z"
 		},
 		{
 			"checksumSHA1": "Q2c9uTEIGhSIddv5pntYdFNtUdk=",
@@ -781,6 +793,18 @@
 			"revisionTime": "2018-06-11T16:35:41Z"
 		},
 		{
+			"checksumSHA1": "NNo0AcF8P5+b/140t0Wox/HFkkw=",
+			"path": "golang.org/x/net/http2",
+			"revision": "db08ff08e8622530d9ed3a0e8ac279f6d4c02196",
+			"revisionTime": "2018-06-11T16:35:41Z"
+		},
+		{
+			"checksumSHA1": "leSW9aM30mATlWs/eeqhQQh/3eo=",
+			"path": "golang.org/x/net/http2/hpack",
+			"revision": "db08ff08e8622530d9ed3a0e8ac279f6d4c02196",
+			"revisionTime": "2018-06-11T16:35:41Z"
+		},
+		{
 			"checksumSHA1": "VrzPJyWI6disCgYuVEQzkjqUsJk=",
 			"path": "golang.org/x/net/idna",
 			"revision": "feeb485667d1fdabe727840fe00adc22431bc86e",
@@ -901,6 +925,12 @@
 			"revisionTime": "2017-04-25T18:31:26Z"
 		},
 		{
+			"checksumSHA1": "HoCvrd3hEhsFeBOdEw7cbcfyk50=",
+			"path": "golang.org/x/time/rate",
+			"revision": "fbb02b2291d28baffd63558aa44b4b56f178d650",
+			"revisionTime": "2018-04-12T16:56:04Z"
+		},
+		{
 			"checksumSHA1": "6IzzHO9p32aHJhMYMwijccDUIVA=",
 			"path": "gopkg.in/alexcesaro/quotedprintable.v3",
 			"revision": "2caba252f4dc53eaf6b553000885530023f54623",
@@ -1003,10 +1033,10 @@
 			"revisionTime": "2015-01-07T22:02:07Z"
 		},
 		{
-			"checksumSHA1": "RDJpJQwkF012L6m/2BJizyOksNw=",
+			"checksumSHA1": "ZSWoOPUNRr5+3dhkLK3C4cZAQPk=",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "eb3733d160e74a9c7e442f435eb3bea458e1d19f",
-			"revisionTime": "2017-08-12T16:00:11Z"
+			"revision": "5420a8b6744d3b0345ab293f6fcba19c978f1183",
+			"revisionTime": "2018-03-28T19:50:20Z"
 		}
 	],
 	"rootPath": "github.com/CaliOpen/Caliopen/src/backend"

--- a/src/backend/workers/go.remoteIDs/cache.go
+++ b/src/backend/workers/go.remoteIDs/cache.go
@@ -26,7 +26,7 @@ func (p *Poller) updateCache() (added, removed, updated map[string]bool, err err
 	active := make(map[string]bool)
 	const defaultInterval = "15"
 
-	remotes, err := p.Store.RetrieveAllRemotes()
+	remotes, err := p.Store.RetrieveAllRemotes(false)
 	if err != nil {
 		logrus.WithError(err).Warn("[updateCache] failed to retrieve remote identities")
 		return


### PR DESCRIPTION
Configuration file for go-api and imap-worker have been modified to enable/disable usage of a vault serve to store remote identities' credentials.  
If `use_vault=true`, a vault server must be up and running for stack to start. Otherwise, credentials are store **in clear** in cassandra table.