### PR TITLE
Feature/backend/notify remote fetch failures

### DIFF
--- a/src/backend/defs/go-objects/identities.go
+++ b/src/backend/defs/go-objects/identities.go
@@ -58,7 +58,7 @@ type (
 		Credentials Credentials       `cql:"credentials"        json:"credentials,omitempty"                            patch:"user"`
 		DisplayName string            `cql:"display_name"       json:"display_name"                                     patch:"user"`
 		Infos       map[string]string `cql:"infos"              json:"infos"                                            patch:"user"`
-		LastCheck   time.Time         `cql:"last_check"         json:"last_check"           formatter:"RFC3339Milli"`
+		LastCheck   time.Time         `cql:"last_check"         json:"last_check,omitempty"                 formatter:"RFC3339Milli"`
 		RemoteId    UUID              `cql:"remote_id"          json:"remote_id"`
 		Status      string            `cql:"status"             json:"status"                                           patch:"user"` // for example : active, inactive, deleted
 		Type        string            `cql:"type"               json:"type"                                             patch:"user"` // for example : imap, twitter…

--- a/src/backend/protocols/go.imap/config.go
+++ b/src/backend/protocols/go.imap/config.go
@@ -26,3 +26,5 @@ type (
 		Urls []string `mapstructure:"urls"`
 	}
 )
+
+const failuresThreshold = 1 // how many hours to wait before disabling a faulty remote.

--- a/src/backend/protocols/go.imap/config.go
+++ b/src/backend/protocols/go.imap/config.go
@@ -27,4 +27,4 @@ type (
 	}
 )
 
-const failuresThreshold = 1 // how many hours to wait before disabling a faulty remote.
+const failuresThreshold = 48 // how many hours to wait before disabling a faulty remote.

--- a/src/backend/protocols/go.imap/fetcher.go
+++ b/src/backend/protocols/go.imap/fetcher.go
@@ -311,5 +311,5 @@ func (f *Fetcher) disableRemoteIdentity(rId *RemoteIdentity) {
 }
 
 func (f Fetcher) emitNotification() {
-
+	//TODO
 }


### PR DESCRIPTION
API will set remote_identity.status=inactive if fetching failed for more than 48hours. (without emitting a notification for now).