### PR TITLE
fix bad props overwriting for remote.info

### DIFF
--- a/src/frontend/web_application/src/scenes/RemoteIdentitySettings/components/RemoteIdentityEmail/index.jsx
+++ b/src/frontend/web_application/src/scenes/RemoteIdentitySettings/components/RemoteIdentityEmail/index.jsx
@@ -17,7 +17,7 @@ function generateStateFromProps(props, prevState) {
     },
   } = props;
   const [serverHostname = '', serverPort = ''] = infos && infos.server ? infos.server.split(':') : [];
-  const active = status ? status === REMOTE_IDENTITY_STATUS[0] : prevState.remoteIdentity.status;
+  const active = status ? status === REMOTE_IDENTITY_STATUS[0] : prevState.remoteIdentity.active;
   const typeProtocol = type || prevState.remoteIdentity.type;
 
   return {
@@ -52,7 +52,7 @@ function getRemoteIdentityFromState(state, props) {
     ...remoteIdentity,
     display_name: displayName,
     infos: {
-      ...(remoteIdentity.server ? remoteIdentity.server : {}),
+      ...(remoteIdentity.infos ? remoteIdentity.infos : {}),
       server: `${serverHostname}:${serverPort}`,
     },
     credentials,


### PR DESCRIPTION
this caused identity to be polled as new every time an update was done

+ fix bad name to get the active value. previsouly a new remote wasn't enabled by default