### PR TITLE
Caliopen python dependencies are described in requirements.deps file

### DIFF
--- a/src/backend/components/py.pgp/setup.py
+++ b/src/backend/components/py.pgp/setup.py
@@ -14,6 +14,10 @@ with open(os.path.join(*([here] + name.split('.') + ['__init__.py']))) as v_file
 
 requires = ['dnsknife', 'PGpy']
 
+if (os.path.isfile('./requirements.deps')):
+    with open('./requirements.deps') as f_deps:
+        requires.extend(f_deps.read().split('\n'))
+
 setup(name=name,
       namespace_packages=[name],
       version=version,

--- a/src/backend/components/py.pi/requirements.deps
+++ b/src/backend/components/py.pi/requirements.deps
@@ -1,0 +1,1 @@
+caliopen_pgp

--- a/src/backend/components/py.pi/setup.py
+++ b/src/backend/components/py.pi/setup.py
@@ -19,8 +19,12 @@ requires = [
     'pgpy',
     'user-agents',
     'geoip2',
-    'caliopen_pgp',
 ]
+
+if (os.path.isfile('./requirements.deps')):
+    with open('./requirements.deps') as f_deps:
+        requires.extend(f_deps.read().split('\n'))
+
 
 extras_require = {
     'dev': [],

--- a/src/backend/interfaces/NATS/py.client/requirements.deps
+++ b/src/backend/interfaces/NATS/py.client/requirements.deps
@@ -1,0 +1,1 @@
+caliopen_main

--- a/src/backend/interfaces/NATS/py.client/setup.py
+++ b/src/backend/interfaces/NATS/py.client/setup.py
@@ -17,10 +17,12 @@ with open(os.path.join(*([here] + name.split('.') + ['__init__.py']))) as v_file
 
 requires = [
     'nats-client',
-    'tornado==4.2',
-    'caliopen_storage',
-    'caliopen_main'
-    ]
+    'tornado==4.2',]
+
+if (os.path.isfile('./requirements.deps')):
+    with open('./requirements.deps') as f_deps:
+        requires.extend(f_deps.read().split('\n'))
+
 
 tests_require = []
 if sys.version_info < (3, 3):

--- a/src/backend/interfaces/REST/py.server/requirements.deps
+++ b/src/backend/interfaces/REST/py.server/requirements.deps
@@ -1,0 +1,2 @@
+caliopen_storage
+caliopen_main

--- a/src/backend/interfaces/REST/py.server/setup.py
+++ b/src/backend/interfaces/REST/py.server/setup.py
@@ -18,8 +18,6 @@ with open(os.path.join(*([here] + name.split('.') + ['__init__.py']))) as v_file
 requires = [
     'pyramid',
     'pyramid_jinja2',
-    'caliopen_storage',
-    'caliopen_main',
     'pyramid_kvs',
     'waitress',
     'cornice==1.2.1',
@@ -29,6 +27,11 @@ requires = [
     'webcolors',
     'strict-rfc3339',
     'ecdsa']
+
+if (os.path.isfile('./requirements.deps')):
+    with open('./requirements.deps') as f_deps:
+        requires.extend(f_deps.read().split('\n'))
+
 
 tests_require = ['nose', 'coverage']
 if sys.version_info < (3, 3):

--- a/src/backend/main/py.main/requirements.deps
+++ b/src/backend/main/py.main/requirements.deps
@@ -1,0 +1,2 @@
+caliopen_storage
+caliopen_pi

--- a/src/backend/main/py.main/setup.py
+++ b/src/backend/main/py.main/setup.py
@@ -14,8 +14,6 @@ with open(os.path.join(*([here] + name.split('.') + ['__init__.py']))) as v_file
 
 requires = [
     'phonenumbers',
-    'caliopen_storage',
-    'caliopen_pi',
     'pytz',
     'zxcvbn_python',
     'validate_email',
@@ -25,6 +23,10 @@ requires = [
     'vobject',
     'minio',
 ]
+
+if (os.path.isfile('./requirements.deps')):
+    with open('./requirements.deps') as f_deps:
+        requires.extend(f_deps.read().split('\n'))
 
 extras_require = {
     'dev': [],

--- a/src/backend/tools/py.CLI/requirements.deps
+++ b/src/backend/tools/py.CLI/requirements.deps
@@ -1,0 +1,2 @@
+caliopen_pi
+caliopen_nats

--- a/src/backend/tools/py.CLI/setup.py
+++ b/src/backend/tools/py.CLI/setup.py
@@ -13,9 +13,11 @@ with open(os.path.join(*([here] + name.split('.') + ['__init__.py']))) as v_file
     version = re.compile(r".*__version__ = '(.*?)'", re.S).match(v_file.read()).group(1)
 
 requires = [
-    'caliopen_pi',
-    'caliopen_nats',
 ]
+
+if (os.path.isfile('./requirements.deps')):
+    with open('./requirements.deps') as f_deps:
+        requires.extend(f_deps.read().split('\n'))
 
 setup(name=name,
       namespace_packages=[name],


### PR DESCRIPTION
Drone pipeline startup need a simple information for detection.

Caliopen python package dependencies are stored in a requirements.deps file to be able to do such detection without installing packages