### PR TITLE
use multi-stage build in frontend Dockerfile

### DIFF
--- a/src/frontend/web_application/Dockerfile
+++ b/src/frontend/web_application/Dockerfile
@@ -3,13 +3,25 @@
 # Author: Caliopen
 # Date: 2016-01-05
 
-FROM node:8
+FROM node:8 as builder
 MAINTAINER Caliopen
 
 ADD . /srv/caliopen/frontend/
 WORKDIR /srv/caliopen/frontend/
 RUN yarn install
 RUN yarn run release
+
+FROM node:8-alpine
+MAINTAINER Caliopen
+
+WORKDIR /srv/caliopen/frontend/
+COPY --from=builder /srv/caliopen/frontend/dist ./dist
+COPY --from=builder /srv/caliopen/frontend/bin ./bin
+COPY --from=builder /srv/caliopen/frontend/public ./public
+COPY --from=builder /srv/caliopen/frontend/package.json .
+COPY --from=builder /srv/caliopen/frontend/yarn.lock .
+ENV NODE_ENV=production
+RUN yarn install
 
 EXPOSE 4000
 


### PR DESCRIPTION
it reduces frontend image size from about 1GB

```
caliopen_frontend       latest              f1c2fa38cdd4        About a minute ago   659MB
devtools_frontend       latest              cba2ad8dd586        2 months ago         1.61GB
```