### PR TITLE
Feature/backend/index sharding part1

### DIFF
--- a/src/backend/brokers/go.emails/email.go
+++ b/src/backend/brokers/go.emails/email.go
@@ -206,6 +206,13 @@ func (b *EmailBroker) SaveIndexSentEmail(ack *DeliveryAck) error {
 			}
 		}
 	}
+	// Retrieve user informations
+	user, err := b.Store.RetrieveUser(ack.EmailMessage.Message.User_id.String())
+	if err != nil {
+		return err
+	}
+	user_info := &UserInfo{User_id: user.UserId.String(), Shard_id: user.ShardId}
+
 	// update caliopen message status
 	fields := make(map[string]interface{})
 
@@ -219,7 +226,7 @@ func (b *EmailBroker) SaveIndexSentEmail(ack *DeliveryAck) error {
 	if err != nil {
 		log.WithError(err).Warn("[Email Broker] Store.UpdateMessage operation failed")
 	}
-	err = b.Index.UpdateMessage(ack.EmailMessage.Message, fields)
+	err = b.Index.UpdateMessage(user_info, ack.EmailMessage.Message, fields)
 	if err != nil {
 		log.WithError(err).Warn("[Email Broker] Index.UpdateMessage operation failed")
 	}

--- a/src/backend/components/py.pi/caliopen_pi/features/contact.py
+++ b/src/backend/components/py.pi/caliopen_pi/features/contact.py
@@ -39,7 +39,7 @@ class ContactFeature(object):
 
     def _compute_histogram(self, email):
         """Get an histogram for a contact email and compute basic infos."""
-        histo = ParticipantHistogram(self.user.user_id, 'day')
+        histo = ParticipantHistogram(self.user, 'day')
         data = histo.find_by_address(email)
         log.info('Got email {0} histogram result {1}'.format(email, data))
         if data:

--- a/src/backend/components/py.pi/caliopen_pi/features/histogram.py
+++ b/src/backend/components/py.pi/caliopen_pi/features/histogram.py
@@ -11,10 +11,10 @@ from caliopen_storage.helpers.connection import get_index_connection
 class ParticipantHistogram(object):
     """Date histogram for a participant in user messages index."""
 
-    def __init__(self, user_id, resolution='day'):
+    def __init__(self, user, resolution='day'):
         """Instanciate a date histrogram for an user."""
         self.esclient = get_index_connection()
-        self.user_id = user_id
+        self.user = user
         self.resolution = resolution
 
     def _format_results(self, results):
@@ -23,8 +23,9 @@ class ParticipantHistogram(object):
                  x['doc_count']) for x in results]
 
     def _do_query(self, value, term):
-        search = dsl.Search(using=self.esclient, index=self.user_id,
+        search = dsl.Search(using=self.esclient, index=self.user.shard_id,
                             doc_type='indexed_message')
+        search.filter(user_id=self.user.user_id)
         term_query = dsl.Q('term', **{term: value})
         search = search.query('nested', path='participants',
                               score_mode='avg',

--- a/src/backend/configs/caliopen.yaml
+++ b/src/backend/configs/caliopen.yaml
@@ -13,6 +13,27 @@ delivery_agent:
 elasticsearch:
     url: http://elasticsearch:9200
     mappings_version: v6
+    shards:
+        - e0a91650-dc36-4acf-a6a9-6c3d338d056b
+        - 6830c383-620f-4467-aa27-b8435029f1d2
+        - deca327e-0627-475f-bd7d-0bf56d349a1c
+        - e07958d5-e243-4f6e-bf10-22718db3e2dc
+        - 99c3b422-cfce-429c-b54a-d6269064dbab
+        - f0dd30de-dec3-4d38-a897-cb7315fe5bff
+        - 921ebf4a-6b63-42e8-aeca-9ed6019d4886
+        - fe10e264-723e-4134-b4c3-0f689018acf2
+        - b50f2f78-3837-44b4-899e-ffe10dcd83ab
+        - a3f991b9-7c32-4c31-9a9a-4a79a86c35f0
+        - e569474b-9d23-4291-908c-22acfc66223a
+        - 1088208f-158f-4e55-a183-8d30272cf6be
+        - a09e8223-5477-405c-af1c-dd9568a5bd77
+        - d931548e-5622-420f-8f19-0eb68e909f69
+        - 4faae137-5938-42d3-bf1a-8e1a4e1868e1
+        - 06f73b88-3317-45f4-9b48-3fffd8e43482
+        - 53bf2c57-967d-47b8-98f1-dfb3394184f8
+        - 0301a1b0-f65e-4912-be67-35daa162db4c
+        - 9f6e6c42-ddbd-48a7-9ed8-8b162a82baa0
+        - 2ffa0b75-3375-4f9e-8241-3d21a5ccea2b
 
 cassandra:
     keyspace: caliopen

--- a/src/backend/configs/caliopen.yaml.template
+++ b/src/backend/configs/caliopen.yaml.template
@@ -5,6 +5,12 @@ elasticsearch:
     mappings_version: v5
     url:
         - http://es.dev.caliopen.org:9200
+    shards:
+        - e0a91650-dc36-4acf-a6a9-6c3d338d056b
+        - 6830c383-620f-4467-aa27-b8435029f1d2
+        - deca327e-0627-475f-bd7d-0bf56d349a1c
+        - e07958d5-e243-4f6e-bf10-22718db3e2dc
+        - 99c3b422-cfce-429c-b54a-d6269064dbab
 
 cassandra:
     keyspace: caliopen

--- a/src/backend/defs/go-objects/search.go
+++ b/src/backend/defs/go-objects/search.go
@@ -13,6 +13,7 @@ type IndexSearch struct {
 	Limit   int                 `json:"limit"`
 	Offset  int                 `json:"offset"`
 	Terms   map[string][]string `json:"terms"`
+	Shard_id   string           `json:"shard_id"`
 	User_id UUID                `json:"user_id"`
 	DocType string              `json:"doc_type"`
 	ILrange [2]int8             `json:"il_range"`

--- a/src/backend/defs/go-objects/search.go
+++ b/src/backend/defs/go-objects/search.go
@@ -43,8 +43,9 @@ type IndexHit struct {
 }
 
 func (is *IndexSearch) FilterQuery(service *elastic.SearchService, withIL bool) *elastic.SearchService {
-
 	q := elastic.NewBoolQuery()
+	// Strictly filter on user_id
+	q = q.Filter(elastic.NewTermQuery("user_id", is.User_id))
 	for name, values := range is.Terms {
 		for _, value := range values {
 			q = q.Filter(elastic.NewTermQuery(name, value))

--- a/src/backend/defs/go-objects/user.go
+++ b/src/backend/defs/go-objects/user.go
@@ -14,6 +14,12 @@ import (
 	"time"
 )
 
+// Struct to operate on user objects
+type UserInfo struct {
+	User_id  string
+	Shard_id string
+}
+
 type User struct {
 	ContactId        UUID              `cql:"contact_id"               json:"contact_id"`
 	DateInsert       time.Time         `cql:"date_insert"              json:"date_insert"                              formatter:"RFC3339Milli"`
@@ -29,6 +35,7 @@ type User struct {
 	*PrivacyFeatures `cql:"privacy_features"         json:"privacy_features"`
 	RecoveryEmail    string `cql:"recovery_email"            json:"recovery_email"`
 	UserId           UUID   `cql:"user_id"                  json:"user_id"              elastic:"omit"      formatter:"rfc4122"`
+	ShardId          string `cql:"shard_id"          json:"shard_id"`
 }
 
 // payload for triggering a password reset procedure for an end-user.
@@ -47,6 +54,7 @@ type Auth_cache struct {
 	X             big.Int   `json:"x"`
 	Y             big.Int   `json:"y"`
 	Key_id        string    `json:"key_id"`
+	Shard_id      string    `json:"shard_id"`
 }
 
 // data stored into cache as long as a reset password request is pending for an user
@@ -193,14 +201,14 @@ func (user *User) NewEmpty() interface{} {
 //bespoke unmarshaller to workaround the expires_at field that is not RFC in cache (tz is missing, thanks python)
 func (ac *Auth_cache) UnmarshalJSON(b []byte) error {
 	var temp struct {
-		Access_token  string `json:"access_token"`
-		Expires_in    int    `json:"expires_in"`
-		Expires_at    string `json:"expires_at"`
-		Refresh_token string `json:"refresh_token"`
-		Curve		  string    `json:"curve"`
-		X             big.Int 	`json:"x"`
-		Y             big.Int   `json:"y"`
-		Key_id        string    `json:"key_id"`
+		Access_token  string  `json:"access_token"`
+		Expires_in    int     `json:"expires_in"`
+		Expires_at    string  `json:"expires_at"`
+		Refresh_token string  `json:"refresh_token"`
+		Curve         string  `json:"curve"`
+		X             big.Int `json:"x"`
+		Y             big.Int `json:"y"`
+		Key_id        string  `json:"key_id"`
 	}
 	if err := json.Unmarshal(b, &temp); err != nil {
 		return err

--- a/src/backend/defs/go-objects/user.go
+++ b/src/backend/defs/go-objects/user.go
@@ -209,6 +209,7 @@ func (ac *Auth_cache) UnmarshalJSON(b []byte) error {
 		X             big.Int `json:"x"`
 		Y             big.Int `json:"y"`
 		Key_id        string  `json:"key_id"`
+		Shard_id      string  `json:"shard_id"`
 	}
 	if err := json.Unmarshal(b, &temp); err != nil {
 		return err
@@ -225,5 +226,6 @@ func (ac *Auth_cache) UnmarshalJSON(b []byte) error {
 	ac.X = temp.X
 	ac.Y = temp.Y
 	ac.Curve = temp.Curve
+	ac.Shard_id = temp.Shard_id
 	return nil
 }

--- a/src/backend/interfaces/NATS/py.client/caliopen_nats/delivery.py
+++ b/src/backend/interfaces/NATS/py.client/caliopen_nats/delivery.py
@@ -33,7 +33,7 @@ class UserMessageDelivery(object):
         message = qualifier.process_inbound(raw)
 
         # store and index message
-        obj = Message(self.user)
+        obj = Message(user=self.user)
         obj.unmarshall_dict(message.to_native())
         obj.user_id = uuid.UUID(self.user.user_id)
         obj.message_id = uuid.uuid4()

--- a/src/backend/interfaces/REST/go.server/middlewares/authentication.go
+++ b/src/backend/interfaces/REST/go.server/middlewares/authentication.go
@@ -110,6 +110,7 @@ func BasicAuthFromCache(cache backends.APICache, realm string) gin.HandlerFunc {
 		//save user_id in context for future retreival
 		c.Set("user_id", user_id)
 		c.Set("access_token", "tokens::"+cache_key)
+		c.Set("shard_id", auth.Shard_id)
 	}
 }
 

--- a/src/backend/interfaces/REST/go.server/operations/contacts/contacts.go
+++ b/src/backend/interfaces/REST/go.server/operations/contacts/contacts.go
@@ -146,6 +146,8 @@ func PatchContact(ctx *gin.Context) {
 		ctx.Abort()
 		return
 	}
+	shard_id := ctx.MustGet("shard_id").(string)
+	user_info := &UserInfo{User_id: userId, Shard_id: shard_id}
 
 	contactId, err := operations.NormalizeUUIDstring(ctx.Param("contactID"))
 	if err != nil {
@@ -165,7 +167,7 @@ func PatchContact(ctx *gin.Context) {
 	}
 
 	// call REST facility with payload
-	err = caliopen.Facilities.RESTfacility.PatchContact(patch, userId, contactId)
+	err = caliopen.Facilities.RESTfacility.PatchContact(user_info, patch, userId, contactId)
 	if err != nil {
 		if Cerr, ok := err.(CaliopenError); ok {
 			returnedErr := new(swgErr.CompositeError)

--- a/src/backend/interfaces/REST/go.server/operations/messages/actions.go
+++ b/src/backend/interfaces/REST/go.server/operations/messages/actions.go
@@ -5,6 +5,7 @@
 package messages
 
 import (
+	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/middlewares"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.main"
@@ -22,6 +23,8 @@ type REST_order struct {
 // POST …/:message_id/actions
 func Actions(ctx *gin.Context) {
 	user_id := ctx.MustGet("user_id").(string)
+	shard_id := ctx.MustGet("shard_id").(string)
+	user_info := &UserInfo{User_id: user_id, Shard_id: shard_id}
 	msg_id, err := operations.NormalizeUUIDstring(ctx.Param("message_id"))
 	if err != nil {
 		e := swgErr.New(http.StatusUnprocessableEntity, err.Error())
@@ -50,7 +53,7 @@ func Actions(ctx *gin.Context) {
 				}
 			}
 		case "set_read":
-			err := caliopen.Facilities.RESTfacility.SetMessageUnread(user_id, msg_id, false)
+			err := caliopen.Facilities.RESTfacility.SetMessageUnread(user_info, msg_id, false)
 			if err != nil {
 				e := swgErr.New(http.StatusFailedDependency, err.Error())
 				http_middleware.ServeError(ctx.Writer, ctx.Request, e)
@@ -59,7 +62,7 @@ func Actions(ctx *gin.Context) {
 				ctx.Status(http.StatusNoContent)
 			}
 		case "set_unread":
-			err := caliopen.Facilities.RESTfacility.SetMessageUnread(user_id, msg_id, true)
+			err := caliopen.Facilities.RESTfacility.SetMessageUnread(user_info, msg_id, true)
 			if err != nil {
 				e := swgErr.New(http.StatusFailedDependency, err.Error())
 				http_middleware.ServeError(ctx.Writer, ctx.Request, e)

--- a/src/backend/interfaces/REST/go.server/operations/messages/attachments.go
+++ b/src/backend/interfaces/REST/go.server/operations/messages/attachments.go
@@ -54,7 +54,7 @@ func UploadAttachment(ctx *gin.Context) {
 	}
 	resp := struct {
 		TempId string `json:"temp_id"`
-	}{tempId}
+	}{attchmtUrl}
 	ctx.JSON(http.StatusOK, resp)
 }
 

--- a/src/backend/interfaces/REST/go.server/operations/messages/attachments.go
+++ b/src/backend/interfaces/REST/go.server/operations/messages/attachments.go
@@ -21,6 +21,8 @@ import (
 // POST …/:message_id/attachments
 func UploadAttachment(ctx *gin.Context) {
 	user_id := ctx.MustGet("user_id").(string)
+	shard_id := ctx.MustGet("shard_id").(string)
+	user := &UserInfo{User_id: user_id, Shard_id: shard_id}
 	msg_id, err := operations.NormalizeUUIDstring(ctx.Param("message_id"))
 	if err != nil {
 		e := swgErr.New(http.StatusUnprocessableEntity, err.Error())
@@ -38,7 +40,7 @@ func UploadAttachment(ctx *gin.Context) {
 
 	filename := header.Filename
 	content_type := header.Header["Content-Type"][0]
-	tempId, err := caliopen.Facilities.RESTfacility.AddAttachment(user_id, msg_id, filename, content_type, file)
+	attchmtUrl, err := caliopen.Facilities.RESTfacility.AddAttachment(user, msg_id, filename, content_type, file)
 	if err != nil {
 		var e error
 		if err.Error() == "not found" {
@@ -59,6 +61,8 @@ func UploadAttachment(ctx *gin.Context) {
 // DELETE …/:message_id/attachments/:attachment_id
 func DeleteAttachment(ctx *gin.Context) {
 	user_id := ctx.MustGet("user_id").(string)
+	shard_id := ctx.MustGet("shard_id").(string)
+	user := &UserInfo{User_id: user_id, Shard_id: shard_id}
 	msg_id, err := operations.NormalizeUUIDstring(ctx.Param("message_id"))
 	if err != nil {
 		e := swgErr.New(http.StatusUnprocessableEntity, err.Error())
@@ -73,7 +77,7 @@ func DeleteAttachment(ctx *gin.Context) {
 		ctx.Abort()
 		return
 	}
-	caliopenErr := caliopen.Facilities.RESTfacility.DeleteAttachment(user_id, msg_id, attch_id)
+	caliopenErr := caliopen.Facilities.RESTfacility.DeleteAttachment(user, msg_id, attch_id)
 	if caliopenErr != nil {
 		returnedErr := new(swgErr.CompositeError)
 		if caliopenErr.Error() == "message not found" ||
@@ -84,8 +88,6 @@ func DeleteAttachment(ctx *gin.Context) {
 			returnedErr = swgErr.CompositeValidationError(caliopenErr, caliopenErr.Cause())
 		}
 		http_middleware.ServeError(ctx.Writer, ctx.Request, returnedErr)
-		ctx.Abort()
-		return
 	}
 	ctx.Status(http.StatusOK)
 }

--- a/src/backend/interfaces/REST/go.server/operations/messages/messages.go
+++ b/src/backend/interfaces/REST/go.server/operations/messages/messages.go
@@ -32,6 +32,7 @@ func GetMessagesList(ctx *gin.Context) {
 	var user_UUID UUID
 
 	user_uuid_str := ctx.MustGet("user_id").(string)
+	shard_id := ctx.MustGet("shard_id").(string)
 	user_uuid, _ := uuid.FromString(user_uuid_str)
 	user_UUID.UnmarshalBinary(user_uuid.Bytes())
 
@@ -67,6 +68,7 @@ func GetMessagesList(ctx *gin.Context) {
 	}
 
 	filter := IndexSearch{
+		Shard_id: shard_id,
 		User_id: user_UUID,
 		Terms:   map[string][]string(query_values),
 		Limit:   limit,
@@ -116,6 +118,8 @@ func GetMessagesList(ctx *gin.Context) {
 // GET …/messages/:message_id
 func GetMessage(ctx *gin.Context) {
 	user_id := ctx.MustGet("user_id").(string)
+	shard_id := ctx.MustGet("shard_id").(string)
+	user_info := &UserInfo{User_id: user_id, Shard_id: shard_id}
 	msg_id, err := operations.NormalizeUUIDstring(ctx.Param("message_id"))
 	if err != nil {
 		e := swgErr.New(http.StatusUnprocessableEntity, err.Error())
@@ -123,7 +127,7 @@ func GetMessage(ctx *gin.Context) {
 		ctx.Abort()
 		return
 	}
-	msg, err := caliopen.Facilities.RESTfacility.GetMessage(user_id, msg_id)
+	msg, err := caliopen.Facilities.RESTfacility.GetMessage(user_info, msg_id)
 	if err != nil {
 		e := swgErr.New(http.StatusFailedDependency, err.Error())
 		http_middleware.ServeError(ctx.Writer, ctx.Request, e)

--- a/src/backend/interfaces/REST/go.server/operations/tags/tags.go
+++ b/src/backend/interfaces/REST/go.server/operations/tags/tags.go
@@ -234,6 +234,13 @@ func PatchResourceWithTags(ctx *gin.Context) {
 			return
 		}
 	}
+	shard_id, ok := ctx.Get("shard_id")
+	if !ok {
+		e := swgErr.New(http.StatusBadRequest, "shard_id is missing in context")
+		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
+		ctx.Abort()
+		return
+	}
 
 	// parse payload and ensure it is a patch for tags property only
 	patch, err = ioutil.ReadAll(ctx.Request.Body)
@@ -295,7 +302,8 @@ func PatchResourceWithTags(ctx *gin.Context) {
 		return
 	}
 
-	e := caliopen.Facilities.RESTfacility.UpdateResourceTags(userID, resourceID, resourceType, patch)
+	user_info := &UserInfo{User_id: userID, Shard_id: shard_id.(string)}
+	e := caliopen.Facilities.RESTfacility.UpdateResourceTags(user_info, resourceID, resourceType, patch)
 	if e != nil {
 		returnedErr := new(swgErr.CompositeError)
 		if e.Code() == DbCaliopenErr && e.Cause().Error() == "not found" {

--- a/src/backend/interfaces/REST/py.server/caliopen_api/message/message.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/message/message.py
@@ -73,7 +73,7 @@ class Message(Api):
         message_id = self.request.swagger_data["message_id"]
         patch = self.request.json
 
-        message = ObjectMessage(self.user.user_id, message_id=message_id)
+        message = ObjectMessage(user=self.user, message_id=message_id)
         try:
             message.patch_draft(self.user, patch, db=True, index=True,
                                 with_validation=True)
@@ -85,7 +85,7 @@ class Message(Api):
     @view(renderer='json', permission='authenticated')
     def delete(self):
         message_id = self.request.swagger_data["message_id"]
-        message = ObjectMessage(self.user.user_id, message_id=message_id)
+        message = ObjectMessage(user=self.user, message_id=message_id)
 
         try:
             message.get_db()

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/contact.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/contact.py
@@ -61,7 +61,7 @@ class Contact(Api):
             log.error("unable to extract contact_id: {}".format(exc))
             raise ValidationError(exc)
 
-        contact = ContactObject(self.user.user_id, contact_id=contact_id)
+        contact = ContactObject(user=self.user, contact_id=contact_id)
         try:
             contact.get_db()
             contact.unmarshall_db()
@@ -106,7 +106,7 @@ class Contact(Api):
         contact_id = self.request.swagger_data["contact_id"]
         patch = self.request.json
 
-        contact = ContactObject(self.user.user_id, contact_id=contact_id)
+        contact = ContactObject(user=self.user, contact_id=contact_id)
         try:
             contact.apply_patch(patch, db=True, index=True,
                                 with_validation=True)
@@ -118,7 +118,7 @@ class Contact(Api):
     @view(renderer='json', permission='authenticated')
     def delete(self):
         contact_id = self.request.swagger_data["contact_id"]
-        contact = ContactObject(self.user.user_id, contact_id=contact_id)
+        contact = ContactObject(user=self.user, contact_id=contact_id)
 
         try:
             contact.delete()

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/settings.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/settings.py
@@ -31,7 +31,7 @@ class SettingsAPI(Api):
     @view(renderer='json', permission='authenticated')
     def get(self):
         """Return user settings."""
-        objects = ObjectSettings.list_db(self.user.user_id)
+        objects = ObjectSettings.list_db(self.user)
         settings = [x.marshall_dict() for x in objects]
         return settings[0]
 
@@ -49,7 +49,7 @@ class SettingsAPI(Api):
         """
         patch = self.request.json
 
-        settings = ObjectSettings(self.user.user_id)
+        settings = ObjectSettings(self.user)
         error = settings.apply_patch(patch, db=True)
         if error is not None:
             raise MergePatchError(error)

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
@@ -115,6 +115,7 @@ class AuthenticationAPI(Api):
         tokens = {'access_token': access_token,
                   'refresh_token': refresh_token,
                   'expires_in': ttl,  # TODO : remove this value
+                  'shard_id': user.shard_id,
                   'expires_at': expires_at.isoformat()}
         cache_key = '{}-{}'.format(user.user_id, device.device_id)
         session_data = tokens.copy()
@@ -128,6 +129,8 @@ class AuthenticationAPI(Api):
 
         self.request.cache.set(cache_key, session_data)
 
+        self.request.cache.set(user.user_id, tokens)
+        tokens.pop('shard_id')
         return {'user_id': user.user_id,
                 'username': user.name,
                 'tokens': tokens,

--- a/src/backend/main/go.backends/ContactsInterfaces.go
+++ b/src/backend/main/go.backends/ContactsInterfaces.go
@@ -19,7 +19,7 @@ type ContactStorage interface {
 
 type ContactIndex interface {
 	CreateContact(contact *Contact) error
-	UpdateContact(contact *Contact, fields map[string]interface{}) error // 'fields' are the struct fields names that have been modified
 	DeleteContact(contact *Contact) error
+	UpdateContact(user *UserInfo, contact *Contact, fields map[string]interface{}) error
 	FilterContacts(search IndexSearch) (Contacts []*Contact, totalFound int64, err error)
 }

--- a/src/backend/main/go.backends/LDAInterfaces.go
+++ b/src/backend/main/go.backends/LDAInterfaces.go
@@ -31,10 +31,11 @@ type LDAStore interface {
 
 	RetrieveUserIdentity(userId, identityId string, withCredentials bool) (*UserIdentity, error)
 	UpdateUserIdentity(userIdentity *UserIdentity, fields map[string]interface{}) error
+	RetrieveUser(user_id string) (user *User, err error)
 }
 
 type LDAIndex interface {
 	Close()
-	CreateMessage(msg *Message) error
-	UpdateMessage(msg *Message, fields map[string]interface{}) error // 'fields' are the struct fields names that have been modified
+	CreateMessage(user *UserInfo, msg *Message) error
+	UpdateMessage(user *UserInfo, msg *Message, fields map[string]interface{}) error
 }

--- a/src/backend/main/go.backends/MessagesInterfaces.go
+++ b/src/backend/main/go.backends/MessagesInterfaces.go
@@ -14,9 +14,9 @@ type MessageStorage interface {
 }
 
 type MessageIndex interface {
-	SetMessageUnread(user_id, message_id string, status bool) error
-	CreateMessage(msg *Message) error
-	UpdateMessage(msg *Message, fields map[string]interface{}) error // 'fields' are the struct fields names that have been modified
+	SetMessageUnread(user *UserInfo, message_id string, status bool) error
+	CreateMessage(user *UserInfo, msg *Message) error
+	UpdateMessage(user *UserInfo, msg *Message, fields map[string]interface{}) error
 	FilterMessages(search IndexSearch) (messages []*Message, totalFound int64, err error)
 	GetMessagesRange(search IndexSearch) (messages []*Message, totalFound int64, err error)
 }

--- a/src/backend/main/go.backends/NotificationsInterfaces.go
+++ b/src/backend/main/go.backends/NotificationsInterfaces.go
@@ -19,5 +19,5 @@ type NotificationsStore interface {
 }
 
 type NotificationsIndex interface {
-	CreateMessage(msg *Message) error
+	CreateMessage(user *UserInfo, msg *Message) error
 }

--- a/src/backend/main/go.backends/index/elasticsearch/contacts.go
+++ b/src/backend/main/go.backends/index/elasticsearch/contacts.go
@@ -33,7 +33,7 @@ func (es *ElasticSearchBackend) CreateContact(contact *Contact) error {
 	return nil
 }
 
-func (es *ElasticSearchBackend) UpdateContact(contact *Contact, fields map[string]interface{}) error {
+func (es *ElasticSearchBackend) UpdateContact(user *UserInfo, contact *Contact, fields map[string]interface{}) error {
 
 	//get json field name for each field to modify
 	jsonFields := map[string]interface{}{}
@@ -45,9 +45,8 @@ func (es *ElasticSearchBackend) UpdateContact(contact *Contact, fields map[strin
 		split := strings.Split(jsonField, ",")
 		jsonFields[split[0]] = value
 	}
-
-	update, err := es.Client.Update().Index(contact.UserId.String()).Type(ContactIndexType).Id(contact.ContactId.String()).
-		Doc(jsonFields).
+	update, err := es.Client.Update().Index(user.Shard_id).Type(ContactIndexType).Id(contact.ContactId.String()).
+		Doc(fields).
 		Refresh("wait_for").
 		Do(context.TODO())
 	if err != nil {

--- a/src/backend/main/go.backends/index/elasticsearch/messages.go
+++ b/src/backend/main/go.backends/index/elasticsearch/messages.go
@@ -74,10 +74,10 @@ func (es *ElasticSearchBackend) SetMessageUnread(user *objects.UserInfo, message
 	return
 }
 
-// XXX chamal: need UserInfo filtering
-func (es *ElasticSearchBackend) FilterMessages(filter IndexSearch) (messages []*Message, totalFound int64, err error) {
-	search := es.Client.Search().Index(filter.User_id.String()).Type(MessageIndexType)
-	search = filter.FilterQuery(search, true).Sort("date_sort", false)
+func (es *ElasticSearchBackend) FilterMessages(filter objects.IndexSearch) (messages []*objects.Message, totalFound int64, err error) {
+
+	search := es.Client.Search().Index(filter.Shard_id).Type(objects.MessageIndexType)
+	search = filter.FilterQuery(search, true).Sort("date_insert", false)
 
 	if filter.Offset > 0 {
 		search = search.From(filter.Offset)

--- a/src/backend/main/go.main/facilities/Notifications/email.go
+++ b/src/backend/main/go.main/facilities/Notifications/email.go
@@ -77,7 +77,8 @@ func (notif *Notifier) SendEmailAdminToUser(user *User, email *Message) error {
 		log.WithError(err).Warn("[EmailNotifiers]: SendEmailAdminToUser failed to store draft")
 		return err
 	}
-	err = notif.index.CreateMessage(email)
+	user_info := &UserInfo{User_id: user.UserId.String(), Shard_id: user.ShardId}
+	err = notif.index.CreateMessage(user_info, email)
 	if err != nil {
 		log.WithError(err).Warn("[EmailNotifiers]: SendEmailAdminToUser failed to index draft")
 		return err

--- a/src/backend/main/go.main/facilities/REST/RESTfacility.go
+++ b/src/backend/main/go.main/facilities/REST/RESTfacility.go
@@ -28,8 +28,8 @@ type (
 		CreateContact(contact *Contact) error
 		RetrieveContacts(filter IndexSearch) (contacts []*Contact, totalFound int64, err error)
 		RetrieveContact(userID, contactID string) (*Contact, error)
-		UpdateContact(contact, oldContact *Contact, update map[string]interface{}) error
-		PatchContact(patch []byte, userID, contactID string) error
+		UpdateContact(user *UserInfo, contact, oldContact *Contact, update map[string]interface{}) error
+		PatchContact(user *UserInfo, patch []byte, userID, contactID string) error
 		DeleteContact(userID, contactID string) error
 		//identities
 		RetrieveContactIdentities(user_id, contact_id string) (identities []ContactIdentity, err error)
@@ -50,8 +50,8 @@ type (
 		GetRawMessage(raw_message_id string) (message []byte, err error)
 		//attachments
 		AddAttachment(user *UserInfo, message_id, filename, content_type string, file io.Reader) (attachmentURL string, err error)
-		DeleteAttachment(user *UserInfo, message_id string, attchmtIndex int) error
-		OpenAttachment(user_id, message_id string, attchmtIndex int) (contentType string, size int, content io.Reader, err error)
+		DeleteAttachment(user *UserInfo, message_id string, attchmt_id string) CaliopenError
+		OpenAttachment(user_id, message_id string, attchmtIndex string) (meta map[string]string, content io.Reader, err error)
 		//tags
 		RetrieveUserTags(user_id string) (tags []Tag, err CaliopenError)
 		CreateTag(tag *Tag) CaliopenError

--- a/src/backend/main/go.main/facilities/REST/RESTfacility.go
+++ b/src/backend/main/go.main/facilities/REST/RESTfacility.go
@@ -44,14 +44,14 @@ type (
 		//messages
 		GetMessagesList(filter IndexSearch) (messages []*Message, totalFound int64, err error)
 		GetMessagesRange(filter IndexSearch) (messages []*Message, totalFound int64, err error)
-		GetMessage(user_id, message_id string) (message *Message, err error)
+		GetMessage(user *UserInfo, message_id string) (message *Message, err error)
 		SendDraft(user_id, msg_id string) (msg *Message, err error)
-		SetMessageUnread(user_id, message_id string, status bool) error
+		SetMessageUnread(user *UserInfo, message_id string, status bool) error
 		GetRawMessage(raw_message_id string) (message []byte, err error)
 		//attachments
-		AddAttachment(user_id, message_id, filename, content_type string, file io.Reader) (tempId string, err error)
-		DeleteAttachment(user_id, message_id, attchmt_id string) CaliopenError
-		OpenAttachment(user_id, message_id, attchmtIndex string) (meta map[string]string, content io.Reader, err error)
+		AddAttachment(user *UserInfo, message_id, filename, content_type string, file io.Reader) (attachmentURL string, err error)
+		DeleteAttachment(user *UserInfo, message_id string, attchmtIndex int) error
+		OpenAttachment(user_id, message_id string, attchmtIndex int) (contentType string, size int, content io.Reader, err error)
 		//tags
 		RetrieveUserTags(user_id string) (tags []Tag, err CaliopenError)
 		CreateTag(tag *Tag) CaliopenError
@@ -59,7 +59,7 @@ type (
 		UpdateTag(tag *Tag) CaliopenError
 		PatchTag(patch []byte, user_id, tag_name string) CaliopenError
 		DeleteTag(user_id, tag_name string) CaliopenError
-		UpdateResourceTags(userID, resourceID, resourceType string, patch []byte) CaliopenError
+		UpdateResourceTags(user *UserInfo, resourceID, resourceType string, patch []byte) CaliopenError
 		//search
 		Search(IndexSearch) (result *IndexResult, err error)
 		//users

--- a/src/backend/main/go.main/facilities/REST/attachment.go
+++ b/src/backend/main/go.main/facilities/REST/attachment.go
@@ -15,9 +15,9 @@ import (
 	"strconv"
 )
 
-func (rest *RESTfacility) AddAttachment(user_id, message_id, filename, content_type string, file io.Reader) (tempId string, err error) {
+func (rest *RESTfacility) AddAttachment(user *UserInfo, message_id, filename, content_type string, file io.Reader) (attachmentPath string, err error) {
 	//check if message_id belongs to user and is a draft
-	msg, err := rest.store.RetrieveMessage(user_id, message_id)
+	msg, err := rest.store.RetrieveMessage(user.User_id, message_id)
 	if err != nil {
 		return "", err
 	}
@@ -55,7 +55,7 @@ func (rest *RESTfacility) AddAttachment(user_id, message_id, filename, content_t
 		return "", err
 	}
 	//update index
-	err = rest.index.UpdateMessage(msg, fields)
+	err = rest.index.UpdateMessage(user, msg, fields)
 	if err != nil {
 		//roll-back attachment storage before returning the error
 		fields["Attachments"] = msg.Attachments[:len(msg.Attachments)-1]
@@ -67,9 +67,9 @@ func (rest *RESTfacility) AddAttachment(user_id, message_id, filename, content_t
 	return
 }
 
-func (rest *RESTfacility) DeleteAttachment(user_id, message_id, attchmt_id string) CaliopenError {
+func (rest *RESTfacility) DeleteAttachment(user *UserInfo, message_id string, attchmtIndex int) error {
 	//check if message_id belongs to user and is a draft and index is consistent
-	msg, err := rest.store.RetrieveMessage(user_id, message_id)
+	msg, err := rest.store.RetrieveMessage(user.User_id, message_id)
 	if err != nil {
 		var msg string
 		if err.Error() == "not found" {
@@ -95,7 +95,7 @@ func (rest *RESTfacility) DeleteAttachment(user_id, message_id, attchmt_id strin
 				return WrapCaliopenErr(err, DbCaliopenErr, "")
 			}
 			//update index
-			err = rest.index.UpdateMessage(msg, fields)
+			err = rest.index.UpdateMessage(user, msg, fields)
 
 			//remove temporary file from object store
 			err = rest.store.DeleteAttachment(attachment.URL)

--- a/src/backend/main/go.main/facilities/REST/attachment.go
+++ b/src/backend/main/go.main/facilities/REST/attachment.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 )
 
-func (rest *RESTfacility) AddAttachment(user *UserInfo, message_id, filename, content_type string, file io.Reader) (attachmentPath string, err error) {
+func (rest *RESTfacility) AddAttachment(user *UserInfo, message_id, filename, content_type string, file io.Reader) (tempId string, err error) {
 	//check if message_id belongs to user and is a draft
 	msg, err := rest.store.RetrieveMessage(user.User_id, message_id)
 	if err != nil {
@@ -67,7 +67,7 @@ func (rest *RESTfacility) AddAttachment(user *UserInfo, message_id, filename, co
 	return
 }
 
-func (rest *RESTfacility) DeleteAttachment(user *UserInfo, message_id string, attchmtIndex int) error {
+func (rest *RESTfacility) DeleteAttachment(user *UserInfo, message_id string, attchmt_id string) CaliopenError {
 	//check if message_id belongs to user and is a draft and index is consistent
 	msg, err := rest.store.RetrieveMessage(user.User_id, message_id)
 	if err != nil {

--- a/src/backend/main/go.main/facilities/REST/contacts.go
+++ b/src/backend/main/go.main/facilities/REST/contacts.go
@@ -92,7 +92,7 @@ func (rest *RESTfacility) RetrieveContact(userID, contactID string) (contact *Co
 // - retrieve the contact from db
 // - UpdateWithPatch()
 // - then UpdateContact() to save updated contact to stores & index if everything went good.
-func (rest *RESTfacility) PatchContact(patch []byte, userID, contactID string) error {
+func (rest *RESTfacility) PatchContact(user *UserInfo, patch []byte, userID, contactID string) error {
 
 	current_contact, err := rest.RetrieveContact(userID, contactID)
 	if err != nil {
@@ -144,7 +144,7 @@ func (rest *RESTfacility) PatchContact(patch []byte, userID, contactID string) e
 	}
 
 	// save updated resource
-	err = rest.UpdateContact(newContact.(*Contact), current_contact, modifiedFields)
+	err = rest.UpdateContact(user, newContact.(*Contact), current_contact, modifiedFields)
 	if err != nil {
 		return WrapCaliopenErrf(err, FailDependencyCaliopenErr, "[RESTfacility] PatchContact failed with UpdateContact error : %s", err)
 	}
@@ -179,14 +179,14 @@ func (rest *RESTfacility) launchKeyDiscovery(current_contact *Contact, updatedFi
 }
 
 // UpdateContact updates a contact in store & index with payload
-func (rest *RESTfacility) UpdateContact(contact, oldContact *Contact, modifiedFields map[string]interface{}) error {
+func (rest *RESTfacility) UpdateContact(user *UserInfo, contact, oldContact *Contact, modifiedFields map[string]interface{}) error {
 
 	err := rest.store.UpdateContact(contact, oldContact, modifiedFields)
 	if err != nil {
 		return err
 	}
 
-	err = rest.index.UpdateContact(contact, modifiedFields)
+	err = rest.index.UpdateContact(user, contact, modifiedFields)
 	if err != nil {
 		return err
 	}

--- a/src/backend/main/go.main/facilities/REST/message.go
+++ b/src/backend/main/go.main/facilities/REST/message.go
@@ -9,14 +9,14 @@ import (
 	m "github.com/CaliOpen/Caliopen/src/backend/main/go.main/messages"
 )
 
-func (rest *RESTfacility) SetMessageUnread(user_id, message_id string, status bool) (err error) {
+func (rest *RESTfacility) SetMessageUnread(user *UserInfo, message_id string, status bool) (err error) {
 
-	err = rest.store.SetMessageUnread(user_id, message_id, status)
+	err = rest.store.SetMessageUnread(user.User_id, message_id, status)
 	if err != nil {
 		return err
 	}
 
-	err = rest.index.SetMessageUnread(user_id, message_id, status)
+	err = rest.index.SetMessageUnread(user, message_id, status)
 	return err
 }
 
@@ -57,8 +57,8 @@ func (rest *RESTfacility) GetMessagesRange(filter IndexSearch) (messages []*Mess
 }
 
 //return a sanitized message, ready for display in front interface
-func (rest *RESTfacility) GetMessage(user_id, msg_id string) (msg *Message, err error) {
-	msg, err = rest.store.RetrieveMessage(user_id, msg_id)
+func (rest *RESTfacility) GetMessage(user *UserInfo, msg_id string) (msg *Message, err error) {
+	msg, err = rest.store.RetrieveMessage(user.User_id, msg_id)
 	if err != nil {
 		return nil, err
 	}

--- a/src/backend/main/py.main/caliopen_main/common/objects/base.py
+++ b/src/backend/main/py.main/caliopen_main/common/objects/base.py
@@ -299,12 +299,12 @@ class ObjectUser(ObjectStorable):
         return self_dict
 
     @classmethod
-    def list_db(cls, user_id):
+    def list_db(cls, user):
         """List all objects that belong to an user."""
-        models = cls._model_class.filter(user_id=user_id)
+        models = cls._model_class.filter(user_id=user.user_id)
         objects = []
         for model in models:
-            obj = cls(user_id)
+            obj = cls(user)
             obj._db = model
             obj.unmarshall_db()
             objects.append(obj)

--- a/src/backend/main/py.main/caliopen_main/contact/store/contact_index.py
+++ b/src/backend/main/py.main/caliopen_main/contact/store/contact_index.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 from elasticsearch_dsl import Mapping, Nested, Text, Keyword, Date, Boolean, \
-    InnerObjectWrapper, Integer
+    InnerObjectWrapper
 from caliopen_storage.store.model import BaseIndexDocument
 from caliopen_main.pi.objects import PIIndexModel
 
@@ -75,6 +75,9 @@ class IndexedContact(BaseIndexDocument):
 
     doc_type = 'indexed_contact'
 
+    user_id = Keyword()
+    contact_id = Keyword()
+
     additional_name = Keyword()
     addresses = Nested(doc_class=IndexedPostalAddress)
     avatar = Keyword()
@@ -109,6 +112,10 @@ class IndexedContact(BaseIndexDocument):
         """Create elasticsearch indexed_contacts mapping object for an user."""
         m = Mapping(cls.doc_type)
         m.meta('_all', enabled=True)
+
+        m.field('user_id', 'keyword')
+        m.field('contact_id', 'keyword')
+
         m.field('additional_name', 'text', fields={
             "normalized": {"type": "text", "analyzer": "text_analyzer"}
         })

--- a/src/backend/main/py.main/caliopen_main/message/objects/message.py
+++ b/src/backend/main/py.main/caliopen_main/message/objects/message.py
@@ -296,7 +296,7 @@ class Message(ObjectIndexable):
         if res.hits:
             for x in res.hits:
                 try:
-                    obj = cls(user.user_id, message_id=x.meta.id)
+                    obj = cls(user, message_id=x.meta.id)
                     obj.get_db()
                     obj.unmarshall_db()
                     messages.append(obj)

--- a/src/backend/main/py.main/caliopen_main/message/store/message.py
+++ b/src/backend/main/py.main/caliopen_main/message/store/message.py
@@ -38,7 +38,6 @@ class Message(BaseModel, IndexedModelMixin):
     is_draft = columns.Boolean()
     is_unread = columns.Boolean()
     is_received = columns.Boolean(default=False)
-
     parent_id = columns.UUID()
     participants = columns.List(columns.UserDefinedType(Participant))
     privacy_features = columns.Map(columns.Text(), columns.Text())

--- a/src/backend/main/py.main/caliopen_main/message/store/message_index.py
+++ b/src/backend/main/py.main/caliopen_main/message/store/message_index.py
@@ -17,6 +17,9 @@ class IndexedMessage(BaseIndexDocument):
 
     doc_type = 'indexed_message'
 
+    user_id = Keyword()
+    message_id = Keyword()
+
     attachments = Nested(doc_class=IndexedMessageAttachment)
     body_html = Text()
     body_plain = Text()
@@ -31,7 +34,6 @@ class IndexedMessage(BaseIndexDocument):
     is_draft = Boolean()
     is_unread = Boolean()
     is_received = Boolean()
-    message_id = Keyword()
     parent_id = Keyword()
     participants = Nested(doc_class=IndexedParticipant)
     privacy_features = Nested()
@@ -52,6 +54,7 @@ class IndexedMessage(BaseIndexDocument):
         """Generate the mapping definition for indexed messages"""
         m = Mapping(cls.doc_type)
         m.meta('_all', enabled=True)
+        m.field('user_id', 'keyword')
         # attachments
         m.field('attachments', Nested(doc_class=IndexedMessageAttachment,
                                       include_in_all=True,

--- a/src/backend/main/py.main/caliopen_main/user/core/setups.py
+++ b/src/backend/main/py.main/caliopen_main/user/core/setups.py
@@ -20,17 +20,22 @@ def setup_index(user):
     url = Configuration('global').get('elasticsearch.url')
     client = Elasticsearch(url)
 
+    shard_id = user.shard_id
     # Creates a versioned index with our custom analyzers, tokenizers, etc.
-    log.debug('Creating index for user {}'.format(user.user_id))
     m_version = Configuration('global').get('elasticsearch.mappings_version')
     if m_version == "":
-        log.warn('Empty mappings_version for {}'.format(user.user_id))
+        raise Exception('Invalid mapping version for shard {0}'.
+                        format(shard_id))
+
+    alias_name = shard_id
+    index_name = "{0}_{1}".format(shard_id, m_version)
+
+    if client.indices.exists(index_name):
+        log.debug("Index for shard {0} already exists".format(shard_id))
         return
-
-    index_name = user.user_id + "_" + m_version
-    alias_name = user.user_id
-
     try:
+        log.info('Creating index {0} for shard {1}'.
+                 format(index_name, shard_id))
         client.indices.create(
             index=index_name,
             body={
@@ -76,8 +81,8 @@ def setup_index(user):
     try:
         client.indices.put_alias(index=index_name, name=alias_name)
     except Exception as exc:
-        log.warn("failed to create alias {} : {}".format(alias_name, exc))
-        return
+        raise Exception("failed to create alias {0} : {1}".
+                        format(alias_name, exc))
 
     # PUT mappings for each type, if any
     for name, kls in core_registry.items():
@@ -85,8 +90,8 @@ def setup_index(user):
                 hasattr(kls._model_class, 'user_id'):
             idx_kls = kls._index_class()
             if hasattr(idx_kls, "build_mapping"):
-                log.debug('Init index for {}'.format(idx_kls))
-                idx_kls.create_mapping(user.user_id)
+                log.debug('Init index mapping for {}'.format(idx_kls))
+                idx_kls.create_mapping(index_name)
 
 
 def setup_system_tags(user):

--- a/src/backend/main/py.main/caliopen_main/user/core/setups.py
+++ b/src/backend/main/py.main/caliopen_main/user/core/setups.py
@@ -120,7 +120,7 @@ def setup_settings(user, settings):
             settings.notification_delay_disappear,
     }
 
-    obj = ObjectSettings(user.user_id)
+    obj = ObjectSettings(user)
     obj.unmarshall_dict(settings)
     obj.marshall_db()
     obj.save_db()

--- a/src/backend/main/py.main/caliopen_main/user/core/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/core/user.py
@@ -41,20 +41,6 @@ def generate_user_shard_id(user_id):
     return user_id.hex
 
 
-class LocalIdentity(BaseCore):
-    """User local identity core class."""
-
-    _model_class = ModelLocalIdentity
-    _pkey_name = 'identifier'
-
-
-class RemoteIdentity(BaseUserCore):
-    """User remote identity core class."""
-
-    _model_class = ModelRemoteIdentity
-    _pkey_name = 'identifier'
-
-
 class Tag(BaseUserCore):
     """Tag core object."""
 

--- a/src/backend/main/py.main/caliopen_main/user/core/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/core/user.py
@@ -36,9 +36,13 @@ from .setups import (setup_index, setup_system_tags,
 log = logging.getLogger(__name__)
 
 
-def generate_user_shard_id(user_id):
-    """Generate an uniform shard_id for an user."""
-    return user_id.hex
+def allocate_user_shard(user_id):
+    """Find allocation to a shard for an user."""
+    shards = Configuration('global').get('elasticsearch.shards')
+    if not shards:
+        raise Exception('No shards configured for index')
+    shard_idx = int(user_id.hex, 16) % len(shards)
+    return shards[shard_idx]
 
 
 class Tag(BaseUserCore):
@@ -254,7 +258,7 @@ class User(BaseCore):
             pi.comportment = 0
             pi.context = 0
             pi.version = 0
-            shard_id = generate_user_shard_id(user_id)
+            shard_id = allocate_user_shard(user_id)
 
             core = super(User, cls).create(user_id=user_id,
                                            name=new_user.name,

--- a/src/backend/main/py.main/caliopen_main/user/store/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/store/user.py
@@ -51,7 +51,6 @@ class User(BaseModel):
     contact_id = columns.UUID()
     main_user_id = columns.UUID()
     recovery_email = columns.Text(required=True)
-    local_identities = columns.List(columns.Text())
     shard_id = columns.Text()
 
     privacy_features = columns.Map(columns.Text(), columns.Text())

--- a/src/backend/main/py.main/caliopen_main/user/store/user.py
+++ b/src/backend/main/py.main/caliopen_main/user/store/user.py
@@ -51,6 +51,8 @@ class User(BaseModel):
     contact_id = columns.UUID()
     main_user_id = columns.UUID()
     recovery_email = columns.Text(required=True)
+    local_identities = columns.List(columns.Text())
+    shard_id = columns.Text()
 
     privacy_features = columns.Map(columns.Text(), columns.Text())
     pi = columns.UserDefinedType(PIModel)

--- a/src/backend/main/py.storage/caliopen_storage/store/model.py
+++ b/src/backend/main/py.storage/caliopen_storage/store/model.py
@@ -67,17 +67,18 @@ class BaseIndexDocument(DocType):
         return Elasticsearch(cls.__url__)
 
     @classmethod
-    def create_mapping(cls, user_id):
+    def create_mapping(cls, index_name):
         """Create and save elasticsearch mapping for the cls.doc_type."""
 
         if hasattr(cls, 'build_mapping'):
             log.info('Create index {} mapping for doc_type {}'.
-                     format(user_id, cls.doc_type))
+                     format(index_name, cls.doc_type))
             try:
-                cls.build_mapping().save(using=cls.client(), index=user_id)
+                cls.build_mapping().save(using=cls.client(), index=index_name)
             except Exception as exc:
-                log.error(
-                    "failed to put mapping for {} : {}".format(user_id, exc))
+                log.error("failed to put mapping for {} : {}".
+                          format(index_name, exc))
+                raise exc
 
 
 class BaseUserType(UserType):

--- a/src/backend/tools/go.CLI/cmd/gocaliopen/cli_cmds/root.go
+++ b/src/backend/tools/go.CLI/cmd/gocaliopen/cli_cmds/root.go
@@ -165,7 +165,6 @@ func getStoreFacility() (Store *store.CassandraBackend, err error) {
 			Keyspace:     apiConf.BackendConfig.Settings.Keyspace,
 			Consistency:  gocql.Consistency(apiConf.BackendConfig.Settings.Consistency),
 			SizeLimit:    apiConf.BackendConfig.Settings.SizeLimit,
-			UseVault:     apiConf.BackendConfig.Settings.UseVault,
 			WithObjStore: true,
 			UseVault:     apiConf.BackendConfig.Settings.UseVault,
 			HVaultConfig: vault.HVaultConfig{


### PR DESCRIPTION
The current design 1 index per user is totally wrong and will not permit to scale correctly.

This PR fix this design. When creating an user we choose for him a shard (choosen from configuration entries). Many users will share a same index, we loose strict isolation of data and we must ensure qhen querying index that the filter on user_id is stricly apply.

Current alpha platform is down due to this design.