### PR TITLE
Fix/better go images

### DIFF
--- a/src/backend/Dockerfile.go-api
+++ b/src/backend/Dockerfile.go-api
@@ -8,6 +8,9 @@ FROM public-registry.caliopen.org/caliopen_go as builder
 ADD . /go/src/github.com/CaliOpen/Caliopen/src/backend
 WORKDIR /go/src/github.com/CaliOpen/Caliopen/src/backend
 
+# Fetch dependencies needed for Caliopen GO apps
+RUN govendor sync -v
+
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/cmd/caliopen_rest
 
 FROM scratch

--- a/src/backend/Dockerfile.go-api
+++ b/src/backend/Dockerfile.go-api
@@ -16,6 +16,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' github
 FROM scratch
 MAINTAINER Caliopen
 
+# Add CA certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 COPY --from=builder /go/src/github.com/CaliOpen/Caliopen/src/backend/caliopen_rest /usr/local/bin/caliopen_rest
 
 WORKDIR  "/etc/caliopen"

--- a/src/backend/Dockerfile.go-lmtp
+++ b/src/backend/Dockerfile.go-lmtp
@@ -16,6 +16,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' github
 FROM scratch
 MAINTAINER Caliopen
 
+# Add CA certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 COPY --from=builder /go/src/github.com/CaliOpen/Caliopen/src/backend/caliopen_lmtpd /usr/local/bin/caliopen_lmtpd
 
 WORKDIR "/etc/caliopen"

--- a/src/backend/Dockerfile.go-lmtp
+++ b/src/backend/Dockerfile.go-lmtp
@@ -8,6 +8,9 @@ FROM public-registry.caliopen.org/caliopen_go as builder
 ADD . /go/src/github.com/CaliOpen/Caliopen/src/backend
 WORKDIR /go/src/github.com/CaliOpen/Caliopen/src/backend
 
+# Fetch dependencies needed for Caliopen GO apps
+RUN govendor sync -v
+
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' github.com/CaliOpen/Caliopen/src/backend/protocols/go.smtp/cmd/caliopen_lmtpd
 
 FROM scratch

--- a/src/backend/Dockerfile.identity-poller
+++ b/src/backend/Dockerfile.identity-poller
@@ -8,6 +8,9 @@ FROM public-registry.caliopen.org/caliopen_go as builder
 ADD . /go/src/github.com/CaliOpen/Caliopen/src/backend
 WORKDIR /go/src/github.com/CaliOpen/Caliopen/src/backend
 
+# Fetch dependencies needed for Caliopen GO apps
+RUN govendor sync -v
+
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' github.com/CaliOpen/Caliopen/src/backend/workers/go.remoteIDs/cmd/idpoller
 
 FROM scratch

--- a/src/backend/Dockerfile.identity-poller
+++ b/src/backend/Dockerfile.identity-poller
@@ -16,6 +16,9 @@ RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' gith
 FROM scratch
 MAINTAINER Caliopen
 
+# Add CA certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 COPY --from=builder /go/bin/idpoller /usr/local/bin/idpoller
 
 WORKDIR "/etc/caliopen"

--- a/src/backend/Dockerfile.imap-worker
+++ b/src/backend/Dockerfile.imap-worker
@@ -8,6 +8,9 @@ FROM public-registry.caliopen.org/caliopen_go as builder
 ADD . /go/src/github.com/CaliOpen/Caliopen/src/backend
 WORKDIR /go/src/github.com/CaliOpen/Caliopen/src/backend
 
+# Fetch dependencies needed for Caliopen GO apps
+RUN govendor sync -v
+
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' github.com/CaliOpen/Caliopen/src/backend/protocols/go.imap/cmd/imapworker
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' github.com/CaliOpen/Caliopen/src/backend/protocols/go.imap/cmd/imapctl
 

--- a/src/backend/Dockerfile.imap-worker
+++ b/src/backend/Dockerfile.imap-worker
@@ -17,6 +17,9 @@ RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' gith
 FROM scratch
 MAINTAINER Caliopen
 
+# Add CA certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 COPY --from=builder /go/bin/imapworker /usr/local/bin/imapworker
 COPY --from=builder /go/bin/imapctl /usr/local/bin/imapctl
 

--- a/src/backend/Dockerfile.twitter-worker
+++ b/src/backend/Dockerfile.twitter-worker
@@ -8,6 +8,9 @@ FROM public-registry.caliopen.org/caliopen_go as builder
 ADD . /go/src/github.com/CaliOpen/Caliopen/src/backend
 WORKDIR /go/src/github.com/CaliOpen/Caliopen/src/backend
 
+# Fetch dependencies needed for Caliopen GO apps
+RUN govendor sync -v
+
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' github.com/CaliOpen/Caliopen/src/backend/protocols/go.twitter/cmd/twitterworker
 
 FROM scratch

--- a/src/backend/Dockerfile.twitter-worker
+++ b/src/backend/Dockerfile.twitter-worker
@@ -16,6 +16,9 @@ RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' gith
 FROM scratch
 MAINTAINER Caliopen
 
+# Add CA certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 COPY --from=builder /go/bin/twitterworker /usr/local/bin/twitterworker
 
 WORKDIR "/etc/caliopen"


### PR DESCRIPTION
Force a govendor sync in all images to get new dependencies introduced during development

Add CA certificates from builder image to permit go binaries to do TLS connection correctly