### PR TITLE
remove caliopen_go service

### DIFF
--- a/devtools/docker-compose.yml
+++ b/devtools/docker-compose.yml
@@ -8,12 +8,6 @@ volumes:
     driver: local
 
 services:
-  caliopen_go:
-    image: public-registry.caliopen.org/caliopen_go
-    build:
-      context: ../src/backend
-      dockerfile: Dockerfile.caliopen-go
-
   # Proxy API
   proxy-api:
     image: nginx
@@ -133,7 +127,7 @@ services:
       - elasticsearch:elasticsearch
       - object-store:minio
       - nats:nats
-      - inbucket:inbucket
+      - inbucket:smtp
     ports:
       - "2525:2525"
     volumes:


### PR DESCRIPTION
caliopen_go actually not a service but a base image for go containers
it is already build by drone and pulled by docker directly on registry

+ remove "image" property. the only purpose was to simplified image name build on dev environment
this can be misunderstood because the property is mainly used to pull latest images from docker hub
also this might bring some conflicts in the eventual publish of Caliopen images on docker hub