### PR TITLE
Fix/backend/tweet duplicate

### DIFF
--- a/src/backend/brokers/go.twitter/broker.go
+++ b/src/backend/brokers/go.twitter/broker.go
@@ -7,15 +7,11 @@
 package twitter_broker
 
 import (
-	"errors"
 	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.backends"
-	"github.com/CaliOpen/Caliopen/src/backend/main/go.backends/index/elasticsearch"
-	"github.com/CaliOpen/Caliopen/src/backend/main/go.backends/store/cassandra"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.main/facilities/Notifications"
 	"github.com/CaliOpen/go-twitter/twitter"
 	log "github.com/Sirupsen/logrus"
-	"github.com/gocql/gocql"
 	"github.com/nats-io/go-nats"
 )
 
@@ -67,92 +63,13 @@ type (
 	}
 )
 
-func Initialize(conf BrokerConfig) (broker *TwitterBroker, err error) {
-	var e error
+func Initialize(conf BrokerConfig, store backends.LDAStore, index backends.LDAIndex, natsConn *nats.Conn, notifier *Notifications.Notifier) (broker *TwitterBroker, err error) {
 	broker = new(TwitterBroker)
 	broker.Config = conf
-	switch conf.StoreName {
-	case "cassandra":
-		c := store.CassandraConfig{
-			Hosts:       conf.StoreConfig.Hosts,
-			Keyspace:    conf.StoreConfig.Keyspace,
-			Consistency: gocql.Consistency(conf.StoreConfig.Consistency),
-			SizeLimit:   conf.StoreConfig.SizeLimit,
-			UseVault:    conf.StoreConfig.UseVault,
-		}
-		if conf.StoreConfig.ObjectStore == "s3" {
-			c.WithObjStore = true
-			c.Endpoint = conf.StoreConfig.OSSConfig.Endpoint
-			c.AccessKey = conf.StoreConfig.OSSConfig.AccessKey
-			c.SecretKey = conf.StoreConfig.OSSConfig.SecretKey
-			c.RawMsgBucket = conf.StoreConfig.OSSConfig.Buckets["raw_messages"]
-			c.AttachmentBucket = conf.StoreConfig.OSSConfig.Buckets["temporary_attachments"]
-			c.Location = conf.StoreConfig.OSSConfig.Location
-		}
-		if conf.StoreConfig.UseVault {
-			c.HVaultConfig.Url = conf.StoreConfig.VaultConfig.Url
-			c.HVaultConfig.Username = conf.StoreConfig.VaultConfig.Username
-			c.HVaultConfig.Password = conf.StoreConfig.VaultConfig.Password
-		}
-		b, e := store.InitializeCassandraBackend(c)
-		if e != nil {
-			err = e
-			log.WithError(err).Warnf("[EmailBroker] initialization of %s backend failed", conf.StoreName)
-			return
-		}
-
-		broker.Store = backends.LDAStore(b) // type conversion to LDA interface
-	default:
-		log.Warnf("[TwitterBroker] unknown store backend: %s", conf.StoreName)
-		err = errors.New("[TwitterBroker] unknown store backend")
-		return
-	}
-
-	switch conf.LDAConfig.IndexName {
-	case "elasticsearch":
-		c := index.ElasticSearchConfig{
-			Urls: conf.LDAConfig.IndexConfig.Urls,
-		}
-		i, e := index.InitializeElasticSearchIndex(c)
-		if e != nil {
-			err = e
-			log.WithError(err).Warnf("[EmailBroker] initialization of %s backend failed", conf.IndexName)
-			return
-		}
-
-		broker.Index = backends.LDAIndex(i) // type conversion to LDA interface
-	default:
-		log.Warnf("[TwitterBroker] unknown index backend: %s", conf.LDAConfig.IndexName)
-		err = errors.New("[TwitterBroker] unknown index backend")
-		return
-	}
-
-	broker.NatsConn, e = nats.Connect(conf.NatsURL)
-	if e != nil {
-		err = e
-		log.WithError(err).Warn("[EmailBroker] initalization of NATS connexion failed")
-		return
-	}
-	caliopenConfig := CaliopenConfig{
-		NotifierConfig: conf.LDAConfig.NotifierConfig,
-		NatsConfig: NatsConfig{
-			Url: conf.NatsURL,
-		},
-		RESTstoreConfig: RESTstoreConfig{
-			BackendName:  conf.StoreName,
-			Consistency:  conf.StoreConfig.Consistency,
-			Hosts:        conf.StoreConfig.Hosts,
-			Keyspace:     conf.StoreConfig.Keyspace,
-			OSSConfig:    conf.StoreConfig.OSSConfig,
-			ObjStoreType: conf.StoreConfig.ObjectStore,
-			SizeLimit:    conf.StoreConfig.SizeLimit,
-		},
-		RESTindexConfig: RESTIndexConfig{
-			Hosts:     conf.LDAConfig.IndexConfig.Urls,
-			IndexName: conf.LDAConfig.IndexName,
-		},
-	}
-	broker.Notifier = Notifications.NewNotificationsFacility(caliopenConfig, broker.NatsConn)
+	broker.Store = store
+	broker.Index = index
+	broker.NatsConn = natsConn
+	broker.Notifier = notifier
 	broker.Connectors = TwitterBrokerConnectors{
 		Egress: make(chan NatsCom, 5),
 	}

--- a/src/backend/defs/go-objects/search.go
+++ b/src/backend/defs/go-objects/search.go
@@ -8,15 +8,15 @@ import (
 	"gopkg.in/olivere/elastic.v5"
 )
 
-// params to pass to API to trigger an elasticsearch search
+// params to pass to API to trigger an elasticsearch filtering search
 type IndexSearch struct {
-	Limit   int                 `json:"limit"`
-	Offset  int                 `json:"offset"`
-	Terms   map[string][]string `json:"terms"`
-	Shard_id   string           `json:"shard_id"`
-	User_id UUID                `json:"user_id"`
-	DocType string              `json:"doc_type"`
-	ILrange [2]int8             `json:"il_range"`
+	Limit    int                 `json:"limit"`
+	Offset   int                 `json:"offset"`
+	Terms    map[string][]string `json:"terms"`
+	Shard_id string              `json:"shard_id"`
+	User_id  UUID                `json:"user_id"`
+	DocType  string              `json:"doc_type"`
+	ILrange  [2]int8             `json:"il_range"`
 }
 
 type IndexResult struct {

--- a/src/backend/main/go.backends/LDAInterfaces.go
+++ b/src/backend/main/go.backends/LDAInterfaces.go
@@ -42,4 +42,5 @@ type LDAIndex interface {
 	Close()
 	CreateMessage(user *UserInfo, msg *Message) error
 	UpdateMessage(user *UserInfo, msg *Message, fields map[string]interface{}) error
+	SeekMessageByExternalRef(userID, messageID string) (bool, error)
 }

--- a/src/backend/main/go.backends/index/elasticsearch/messages.go
+++ b/src/backend/main/go.backends/index/elasticsearch/messages.go
@@ -33,6 +33,7 @@ func (es *ElasticSearchBackend) CreateMessage(user *objects.UserInfo, msg *objec
 		log.WithError(err).Warn("backend Index: IndexMessage operation failed")
 		return err
 	}
+
 	log.Infof("New msg indexed with id %s", resp.Id)
 	return nil
 
@@ -172,6 +173,24 @@ func (es *ElasticSearchBackend) GetMessagesRange(filter objects.IndexSearch) (me
 	}
 	sort.Sort(objects.ByDateSortAsc(messages))
 	return messages, totalFound, nil
+}
+
+// return false if message not found or error
+func (es *ElasticSearchBackend) SeekMessageByExternalRef(userID, externalMessageID string) (bool, error) {
+	q := elastic.NewBoolQuery()
+	// Strictly filter on user_id and external ref.
+	q = q.Must(
+		elastic.NewTermQuery("user_id", userID),
+		elastic.NewNestedQuery("external_references", elastic.NewTermQuery("external_references.message_id", externalMessageID)),
+	)
+
+	result, err := es.Client.Search().Type(objects.MessageIndexType).Query(q).Do(context.TODO())
+	if err != nil {
+		return false, err
+	} else if result.TotalHits() > 0 {
+		return true, nil
+	}
+	return false, nil
 }
 
 func executeMessagesQuery(search *elastic.SearchService) (messages []*objects.Message, totalFound int64, err error) {

--- a/src/backend/main/go.backends/store/cassandra/cassandra.go
+++ b/src/backend/main/go.backends/store/cassandra/cassandra.go
@@ -67,12 +67,10 @@ func InitializeCassandraBackend(config CassandraConfig) (cb *CassandraBackend, e
 			return nil, err
 		}
 	}
-
 	return
 }
 
 func (cb *CassandraBackend) initialize(config CassandraConfig) (err error) {
-
 	cb.CassandraConfig = config
 	cb.Timeout = DefaultTimeout
 	// connect to the cluster
@@ -107,7 +105,7 @@ func (cb *CassandraBackend) Close() {
 // SessionQuery is a wrapper to cb.Session.Query(…………) that re-init a Session if it has been closed
 func (cb *CassandraBackend) SessionQuery(stmt string, values ...interface{}) *gocql.Query {
 	if cb.Session.Closed() {
-		err := cb.initialize(cb.CassandraConfig)
+		err := (*cb).initialize(cb.CassandraConfig)
 		if err != nil {
 			log.WithError(err).Warn("[CassandraBackend] SessionQuery failed to re-init a gocql Session")
 		}

--- a/src/backend/main/go.backends/store/cassandra/messages.go
+++ b/src/backend/main/go.backends/store/cassandra/messages.go
@@ -22,7 +22,6 @@ func (cb *CassandraBackend) CreateMessage(msg *Message) error {
 }
 
 func (cb *CassandraBackend) RetrieveMessage(user_id, msg_id string) (msg *Message, err error) {
-
 	msg = new(Message).NewEmpty().(*Message) // correctly initialize nested values
 	m := map[string]interface{}{}
 	q := cb.SessionQuery(`SELECT * FROM message WHERE user_id = ? and message_id = ?`, user_id, msg_id)

--- a/src/backend/main/go.main/facilities/REST/providers.go
+++ b/src/backend/main/go.main/facilities/REST/providers.go
@@ -118,8 +118,9 @@ func (rest *RESTfacility) CreateTwitterIdentity(requestToken, verifier string) (
 			"secret": accessSecret,
 		}
 		userIdentity.Infos = map[string]string{
-			"provider": "twitter",
-			"authtype": Oauth1,
+			"provider":  "twitter",
+			"authtype":  Oauth1,
+			"twitterid": twitterUser.IDStr,
 		}
 		// save identity
 		e := rest.CreateUserIdentity(userIdentity)

--- a/src/backend/protocols/go.twitter/accountworker.go
+++ b/src/backend/protocols/go.twitter/accountworker.go
@@ -55,10 +55,10 @@ const (
 
 // NewWorker create a worker dedicated to a specific twitter account.
 // A worker holds remote identity credentials and data, as well as user context connection to twitter API.
-func NewAccountWorker(userID, remoteID string, conf WorkerConfig) (accountWorker *AccountWorker, err error) {
+func NewAccountWorker(userID, remoteID string, worker Worker) (accountWorker *AccountWorker, err error) {
 	accountWorker = new(AccountWorker)
 	accountWorker.WorkerDesk = make(chan uint, 3)
-	b, e := broker.Initialize(conf.BrokerConfig)
+	b, e := broker.Initialize(worker.Conf.BrokerConfig, worker.Store, worker.Index, worker.NatsConn, worker.Notifier)
 	if e != nil {
 		err = fmt.Errorf("[TwitterWorker]NewAccountWorker failed to initialize a twitter broker : %s", e)
 		return nil, err
@@ -88,7 +88,7 @@ func NewAccountWorker(userID, remoteID string, conf WorkerConfig) (accountWorker
 		accountWorker.lastDMseen = "0"
 	}
 
-	authConf := oauth1.NewConfig(conf.TwitterAppKey, conf.TwitterAppSecret)
+	authConf := oauth1.NewConfig(worker.Conf.TwitterAppKey, worker.Conf.TwitterAppSecret)
 	token := oauth1.NewToken(accountWorker.userAccount.accessToken, accountWorker.userAccount.accessTokenSecret)
 	httpClient := authConf.Client(oauth1.NoContext, token)
 	if accountWorker.twitterClient = twitter.NewClient(httpClient); accountWorker.twitterClient == nil {

--- a/src/backend/protocols/go.twitter/accountworker.go
+++ b/src/backend/protocols/go.twitter/accountworker.go
@@ -239,7 +239,6 @@ func (worker *AccountWorker) PollDM() {
 	for _, event := range DMs.Events {
 		if worker.dmNotSeen(event) {
 			if worker.isDMunique(event.ID) {
-				log.Infof("dm %s is new", event.ID)
 				//lookup sender & recipient's screen_names because there are not embedded in event object
 				(*event.Message).SenderScreenName = worker.getAccountName(event.Message.SenderID)
 				(*event.Message).Target.RecipientScreenName = worker.getAccountName(event.Message.Target.RecipientID)


### PR DESCRIPTION
Prevent importing tweets twice by looking up external reference against tweets already fetched in database. Fix prevents sent tweet to appear twice and prevents re-importing tweets twice if user delete/create a Twitter account.
Should fix issue #1137 