### PR TITLE
Feature/backend/send pgp mail

### DIFF
--- a/devtools/docker-compose.yml
+++ b/devtools/docker-compose.yml
@@ -128,6 +128,7 @@ services:
       - object-store:minio
       - nats:nats
       - inbucket:smtp
+      - imap_worker:imapworker
     ports:
       - "2525:2525"
     volumes:

--- a/devtools/docker-compose.yml
+++ b/devtools/docker-compose.yml
@@ -138,6 +138,7 @@ services:
     image: nats:0.9.6
     ports:
       - "4222:4222"
+      - "8222:8222"
 
   # NATS Message Handler
   mq_worker:
@@ -213,3 +214,4 @@ services:
     image: jhillyerd/inbucket
     ports:
       - "8888:9000"
+      - "2500:2500"

--- a/src/backend/brokers/go.emails/broker.go
+++ b/src/backend/brokers/go.emails/broker.go
@@ -15,6 +15,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/gocql/gocql"
 	"github.com/nats-io/go-nats"
+	"math/rand"
+	"time"
 )
 
 type (
@@ -67,6 +69,9 @@ var (
 
 func Initialize(conf LDAConfig) (broker *EmailBroker, connectors EmailBrokerConnectors, err error) {
 	var e error
+
+	rand.Seed(time.Now().UnixNano())
+
 	broker = &EmailBroker{}
 	broker.Config = conf
 	switch conf.StoreName {

--- a/src/backend/brokers/go.emails/email.go
+++ b/src/backend/brokers/go.emails/email.go
@@ -99,7 +99,7 @@ func (b *EmailBroker) MarshalEmail(msg *Message) (em *EmailMessage, err error) {
 	crypt_method, ok := features["message_encryption_method"]
 	if ok {
 		if crypt_method == "pgp" {
-			err := b.MarshalEncryptedEmail(msg, em, addr_fields)
+			err := b.MarshalPGPEmail(msg, em, addr_fields)
 			if err != nil {
 				return &EmailMessage{}, err
 			}

--- a/src/backend/brokers/go.emails/email.go
+++ b/src/backend/brokers/go.emails/email.go
@@ -99,7 +99,7 @@ func (b *EmailBroker) MarshalEmail(msg *Message) (em *EmailMessage, err error) {
 	crypt_method, ok := features["message_encryption_method"]
 	if ok {
 		if crypt_method == "pgp" {
-			err := b.MarshalEncryptedEmail(msg, em)
+			err := b.MarshalEncryptedEmail(msg, em, addr_fields)
 			if err != nil {
 				return &EmailMessage{}, err
 			}

--- a/src/backend/brokers/go.emails/email.go
+++ b/src/backend/brokers/go.emails/email.go
@@ -73,22 +73,23 @@ func (b *EmailBroker) MarshalEmail(msg *Message) (em *EmailMessage, err error) {
 	m := gomail.NewMessage()
 	addr_fields := newAddressesFields()
 	for _, participant := range msg.Participants {
+		address := m.FormatAddress(participant.Address, participant.Label)
 		switch participant.Type {
 		case ParticipantFrom:
-			addr_fields["From"] = append(addr_fields["From"], m.FormatAddress(participant.Address, participant.Label))
+			addr_fields["From"] = append(addr_fields["From"], address)
 			em.Email.SmtpMailFrom = append(em.Email.SmtpMailFrom, participant.Address) //TODO: handle multisender to conform to RFC5322#3.6.2 (coupled with sender field)
 		case ParticipantReplyTo:
-			addr_fields["Reply-To"] = append(addr_fields["Reply-To"], m.FormatAddress(participant.Address, participant.Label))
+			addr_fields["Reply-To"] = append(addr_fields["Reply-To"], address)
 		case ParticipantTo:
-			addr_fields["To"] = append(addr_fields["To"], m.FormatAddress(participant.Address, participant.Label))
+			addr_fields["To"] = append(addr_fields["To"], address)
 			em.Email.SmtpRcpTo = append(em.Email.SmtpRcpTo, participant.Address)
 		case ParticipantCC:
-			addr_fields["Cc"] = append(addr_fields["Cc"], m.FormatAddress(participant.Address, participant.Label))
+			addr_fields["Cc"] = append(addr_fields["Cc"], address)
 			em.Email.SmtpRcpTo = append(em.Email.SmtpRcpTo, participant.Address)
 		case ParticipantBcc:
 			em.Email.SmtpRcpTo = append(em.Email.SmtpRcpTo, participant.Address)
 		case ParticipantSender:
-			addr_fields["Sender"] = append(addr_fields["Sender"], m.FormatAddress(participant.Address, participant.Label))
+			addr_fields["Sender"] = append(addr_fields["Sender"], address)
 			em.Email.SmtpMailFrom = append(em.Email.SmtpMailFrom, participant.Address) //TODO: handle multisender to conform to RFC5322#3.6.2 (coupled with sender field)
 		}
 	}

--- a/src/backend/brokers/go.emails/encrypt.go
+++ b/src/backend/brokers/go.emails/encrypt.go
@@ -7,8 +7,6 @@ package email_broker
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/base64"
 	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
 	log "github.com/Sirupsen/logrus"
 	"github.com/emersion/go-message"
@@ -39,15 +37,6 @@ func RandomString(n int) string {
 //                / "," / "-" / "." / "/" / ":" / "=" / "?"
 func (b *EmailBroker) NewBoundary() string {
 	return RandomString(42)
-}
-
-func (b *EmailBroker) NewMessageId(uuid []byte) string {
-	// sha256 internal message id to form external message id
-	hasher := sha256.New()
-	hasher.Write(uuid)
-	sha := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
-	messageId := sha + "@" + b.Config.PrimaryMailHost // should be the default domain in case there are multiple 'from' addresses
-	return messageId
 }
 
 //Marshal an encrypted email

--- a/src/backend/brokers/go.emails/encrypt.go
+++ b/src/backend/brokers/go.emails/encrypt.go
@@ -25,23 +25,18 @@ func randomString(n int) string {
 	return string(b)
 }
 
-// NewBoundary return a mail boundary according to RFC format
-//
-// Return a MIME boudary as specified in RFC 1341 (7.2.1)
+// NewBoundary return a mail boundary according to RFC 1341 (7.2.1).
 //
 // boundary := 0*69<bchars> bcharsnospace
-//
 // bchars := bcharsnospace / " "
-//
-// bcharsnospace :=    DIGIT / ALPHA / "'" / "(" / ")" / "+"  /
-// "_"
+// bcharsnospace :=    DIGIT / ALPHA / "'" / "(" / ")" / "+"  / "_"
 //                / "," / "-" / "." / "/" / ":" / "=" / "?"
 func (b *EmailBroker) NewBoundary() string {
 	return randomString(42)
 }
 
-//Marshal an encrypted email
-func (b *EmailBroker) MarshalEncryptedEmail(msg *Message, em *EmailMessage, addresses map[string][]string) (err error) {
+// MarshalEncryptedEmail build an encrypted PGP/MIME email according to RFC 3156.
+func (b *EmailBroker) MarshalPGPEmail(msg *Message, em *EmailMessage, addresses map[string][]string) (err error) {
 
 	mainHeader := make(message.Header)
 	params := map[string]string{"boundary": b.NewBoundary(), "protocol": "application/pgp-encrypted"}

--- a/src/backend/brokers/go.emails/encrypt.go
+++ b/src/backend/brokers/go.emails/encrypt.go
@@ -120,9 +120,7 @@ func formatBody(msg *Message, mainHeader message.Header) (bytes.Buffer, error) {
 	entityVersion := &message.Entity{Header: part1, Body: part1Body}
 	entityBody := &message.Entity{Header: part2, Body: part2Body}
 
-	entities := make([]*message.Entity, 2)
-	entities[0] = entityVersion
-	entities[1] = entityBody
+	entities := []*message.Entity{entityVersion, entityBody}
 
 	mp, err := message.NewMultipart(mainHeader, entities)
 	if err != nil {

--- a/src/backend/brokers/go.emails/encrypt.go
+++ b/src/backend/brokers/go.emails/encrypt.go
@@ -1,4 +1,4 @@
-// Copyleft (ɔ) 2017 The Caliopen contributors.
+// Copyleft (ɔ) 2019 The Caliopen contributors.
 // Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
 // license (AGPL) that can be found in the LICENSE file.
 

--- a/src/backend/brokers/go.emails/encrypt.go
+++ b/src/backend/brokers/go.emails/encrypt.go
@@ -1,0 +1,129 @@
+// Copyleft (ɔ) 2017 The Caliopen contributors.
+// Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+// license (AGPL) that can be found in the LICENSE file.
+
+// package email_broker handles codec/decodec between external emails and Caliopen message format
+package email_broker
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
+	log "github.com/Sirupsen/logrus"
+	"github.com/emersion/go-message"
+	"net/mail"
+	"strings"
+	"time"
+)
+
+// TODO
+func (b *EmailBroker) NewBoundary() string {
+	return "abcdef"
+}
+
+func (b *EmailBroker) NewMessageId(uuid []byte) string {
+	// sha256 internal message id to form external message id
+	hasher := sha256.New()
+	hasher.Write(uuid)
+	sha := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+	messageId := sha + "@" + b.Config.PrimaryMailHost // should be the default domain in case there are multiple 'from' addresses
+	return messageId
+}
+
+//Marshal an encrypted email
+func (b *EmailBroker) MarshalEncryptedEmail(msg *Message, em *EmailMessage) (err error) {
+
+	mainHeader := make(message.Header)
+	params := map[string]string{"boundary": b.NewBoundary(), "protocol": "application/pgp-encrypted"}
+	mainHeader.Set("Subject", msg.Subject)
+	mainHeader.Set("Date", time.Now().Format(time.RFC1123Z))
+	mainHeader.SetContentType("multipart/encrypted", params)
+	mainHeader.Set("X-Mailer", "Caliopen-"+b.Config.AppVersion)
+
+	addr_fields := formatAddressList(msg)
+	for field, addrs := range addr_fields {
+		if len(addrs) > 0 {
+			mainHeader.Set(field, strings.Join(addrs, ","))
+		}
+	}
+
+	// References headers
+	mainHeader.Set("Message-ID", "<"+b.NewMessageId(em.Message.Message_id.Bytes())+">")
+
+	// Formatted multipart body
+	body, err := formatBody(msg, mainHeader)
+	if err != nil {
+		return err
+	}
+	em.Email.Raw = body
+	log.Debug("Raw encrypted mail", em.Email.Raw)
+
+	json_rep, _ := EmailToJsonRep(em.Email.Raw.String())
+	em.Email_json = &json_rep
+	return
+}
+
+// Format a participant into a mail.Address
+func formatAddress(participant Participant) *mail.Address {
+	addr := &mail.Address{Name: participant.Label, Address: participant.Address}
+	return addr
+}
+
+// Create mail.Address listes indexed by participant type
+func formatAddressList(msg *Message) map[string][]string {
+	// Create address headers
+	addr_fields := newAddressesFields()
+	for _, participant := range msg.Participants {
+		address := formatAddress(participant)
+		switch participant.Type {
+		case ParticipantFrom:
+			addr_fields["From"] = append(addr_fields["From"], address.String())
+		case ParticipantReplyTo:
+			addr_fields["Reply-To"] = append(addr_fields["Reply-To"], address.String())
+		case ParticipantTo:
+			addr_fields["To"] = append(addr_fields["To"], address.String())
+		case ParticipantCC:
+			addr_fields["Cc"] = append(addr_fields["Cc"], address.String())
+		case ParticipantSender:
+			addr_fields["Sender"] = append(addr_fields["Sender"], address.String())
+		}
+	}
+	return addr_fields
+}
+
+func formatBody(msg *Message, mainHeader message.Header) (bytes.Buffer, error) {
+	// Create part to include into multipart/[encrypted/signed]
+	var body bytes.Buffer
+	part1 := make(message.Header)
+	part1.SetContentType("application/pgp-encrypted", nil)
+	part1.SetContentDescription("PGP/MIME version identification")
+	part1Body := bytes.NewBuffer([]byte("Version: 1\n"))
+
+	part2 := make(message.Header)
+	part2Params := map[string]string{"name": "encrypted.asc"}
+	dispoParams := map[string]string{"filename": "encrypted.asc"}
+
+	part2.SetContentType("application/octet-stream", part2Params)
+	part2.SetContentDescription("Caliopen PGP encrypted message")
+	part2.SetContentDisposition("inline", dispoParams)
+	part2Body := bytes.NewBuffer([]byte(msg.Body_plain))
+
+	entityVersion := &message.Entity{Header: part1, Body: part1Body}
+	entityBody := &message.Entity{Header: part2, Body: part2Body}
+
+	entities := make([]*message.Entity, 2)
+	entities[0] = entityVersion
+	entities[1] = entityBody
+
+	mp, err := message.NewMultipart(mainHeader, entities)
+	if err != nil {
+		return body, err
+	}
+
+	err = mp.WriteTo(&body)
+	if err != nil {
+		return body, err
+	}
+	return body, nil
+}

--- a/src/backend/brokers/go.emails/encrypt.go
+++ b/src/backend/brokers/go.emails/encrypt.go
@@ -26,6 +26,8 @@ func RandomString(n int) string {
 	return string(b)
 }
 
+// NewBoundary return a mail boundary according to RFC format
+//
 // Return a MIME boudary as specified in RFC 1341 (7.2.1)
 //
 // boundary := 0*69<bchars> bcharsnospace

--- a/src/backend/brokers/go.emails/encrypt.go
+++ b/src/backend/brokers/go.emails/encrypt.go
@@ -12,14 +12,33 @@ import (
 	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
 	log "github.com/Sirupsen/logrus"
 	"github.com/emersion/go-message"
+	"math/rand"
 	"net/mail"
 	"strings"
 	"time"
 )
 
-// TODO
+var boundaryChars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+:=?")
+
+func RandomString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = boundaryChars[rand.Intn(len(boundaryChars))]
+	}
+	return string(b)
+}
+
+// Return a MIME boudary as specified in RFC 1341 (7.2.1)
+//
+// boundary := 0*69<bchars> bcharsnospace
+//
+// bchars := bcharsnospace / " "
+//
+// bcharsnospace :=    DIGIT / ALPHA / "'" / "(" / ")" / "+"  /
+// "_"
+//                / "," / "-" / "." / "/" / ":" / "=" / "?"
 func (b *EmailBroker) NewBoundary() string {
-	return "abcdef"
+	return RandomString(42)
 }
 
 func (b *EmailBroker) NewMessageId(uuid []byte) string {
@@ -70,7 +89,7 @@ func formatAddress(participant Participant) *mail.Address {
 	return addr
 }
 
-// Create mail.Address listes indexed by participant type
+// Create mail.Address list indexed by participant type
 func formatAddressList(msg *Message) map[string][]string {
 	// Create address headers
 	addr_fields := newAddressesFields()

--- a/src/backend/configs/lmtp.yaml
+++ b/src/backend/configs/lmtp.yaml
@@ -17,7 +17,7 @@ AppConfig:
     max_clients: 1000
   #submit is the MTA to connect to for final delivery (postfix for example)
   submit_address: smtp
-  submit_port: 10025
+  submit_port: 2500
   submit_user:
   submit_password:
   submit_workers: 2                                      # number of concurrent connexions to submit MTA
@@ -59,7 +59,7 @@ LDAConfig:
   log_received_mails: true
 
   # outbound
-  out_topic: outboundSMTP                                # NATS topic to listen to
+  out_topic: outboundIMAP                                # NATS topic to listen to
   nats_listeners: 2                                      # number of concurrent nats listeners
 
   # notifications

--- a/src/backend/configs/lmtp.yaml
+++ b/src/backend/configs/lmtp.yaml
@@ -59,7 +59,7 @@ LDAConfig:
   log_received_mails: true
 
   # outbound
-  out_topic: outboundIMAP                                # NATS topic to listen to
+  out_topic: outboundSMTP                                # NATS topic to listen to
   nats_listeners: 2                                      # number of concurrent nats listeners
 
   # notifications

--- a/src/backend/vendor/vendor.json
+++ b/src/backend/vendor/vendor.json
@@ -115,10 +115,28 @@
 			"versionExact": "v1"
 		},
 		{
+			"checksumSHA1": "lyRS2uliigRHMWOJ29mqp1R/SrI=",
+			"path": "github.com/emersion/go-message",
+			"revision": "63ac8399c1e4c07ca2a233b0fa6d205694c7bdbe",
+			"revisionTime": "2018-09-28T09:20:03Z"
+		},
+		{
+			"checksumSHA1": "bhmH93s2Kh2GMDG4YyzmV2S3za0=",
+			"path": "github.com/emersion/go-message/charset",
+			"revision": "63ac8399c1e4c07ca2a233b0fa6d205694c7bdbe",
+			"revisionTime": "2018-09-28T09:20:03Z"
+		},
+		{
 			"checksumSHA1": "VGdrJ5SV27dfTYVafzkH03uotLA=",
 			"path": "github.com/emersion/go-sasl",
 			"revision": "7e096a0a6197b89989e8cc31016daa67c8c62051",
 			"revisionTime": "2016-11-16T18:30:48Z"
+		},
+		{
+			"checksumSHA1": "BX9blgbaHp0hnLTAxqNwVZgWra4=",
+			"path": "github.com/emersion/go-textwrapper",
+			"revision": "d0e65e56babe3f687ff94c1d764ca0e6aa7723ee",
+			"revisionTime": "2016-06-06T18:21:33Z"
 		},
 		{
 			"checksumSHA1": "x2Km0Qy3WgJJnV19Zv25VwTJcBM=",

--- a/src/backend/vendor/vendor.json
+++ b/src/backend/vendor/vendor.json
@@ -625,12 +625,6 @@
 			"revisionTime": "2017-12-22T15:26:07Z"
 		},
 		{
-			"checksumSHA1": "Ws2pqY93XGkFXIFmyH0W6ItaI/k=",
-			"path": "github.com/minio/go-homedir",
-			"revision": "4d76aabb80b22bad8695d3904e943f1fb5e6199f",
-			"revisionTime": "2016-02-15T11:55:11Z"
-		},
-		{
 			"checksumSHA1": "kfdP7wldRywc6JygjJ3uGW1Hg3A=",
 			"path": "github.com/minio/minio-go",
 			"revision": "f50615fec83bed70e5370e890c71c966c96e190d",


### PR DESCRIPTION
This change permit to send correctly formed an encrypted mail using PGP method (RFC 3156)

The body will not be stored in index after message is marshalled into it's  mail envelope