### PR TITLE
Fix chronological order in discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix chronological order of messages in discussion scene
 - Better responsiveness on small screens for timeline & discussion & logo
 - inversion en/fr for some translations
 

--- a/src/frontend/web_application/src/services/message/index.js
+++ b/src/frontend/web_application/src/services/message/index.js
@@ -1,4 +1,5 @@
-export const sortMessages = (messages, reversed = false) => messages.sort((a, b) => {
+// Array.prototype.sort() is destructive, hence we need a copy of messages array.
+export const sortMessages = (messages, reversed = false) => [...messages].sort((a, b) => {
   if (reversed) {
     return new Date(b.date_sort) - new Date(a.date_sort);
   }


### PR DESCRIPTION
Copy messages array to prevent accidental discussion reversal.