### PR TITLE
fix last message not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Better responsiveness on small screens for dropdowns
 - inversion en/fr for some translations
 - BSOD on draft view in case there is no author (for example after remote identity deletion)
+- Last messages not visible in case the discussion has been openned
 
 ## [0.16.0] 2019-02-25
 

--- a/src/frontend/web_application/src/modules/message/actions/requestDiscussion.js
+++ b/src/frontend/web_application/src/modules/message/actions/requestDiscussion.js
@@ -1,22 +1,17 @@
 import { tryCatchAxiosAction } from '../../../services/api-client';
 import { requestDiscussion as requestDiscussionBase } from '../../../store/modules/discussion';
 import { requestMessages as requestMessagesBase } from '../../../store/modules/message';
-import { createMessageCollectionStateSelector } from '../../../store/selectors/message';
-import { discussionSelector, discussionIdSelector } from '../../discussion';
-
-const messageCollectionSelector = createMessageCollectionStateSelector(() => 'discussion', discussionIdSelector);
+import { discussionSelector } from '../../discussion';
 
 export const requestDiscussion = ({ discussionId }) => async (dispatch, getState) => {
+  // the discussion can be outdated but not the message's collection
   const discussion = discussionSelector(getState(), { discussionId });
 
-  const coll = messageCollectionSelector(getState(), { discussionId });
   const results = await Promise.all([
     discussion ?
       { discussion } :
       tryCatchAxiosAction(() => dispatch(requestDiscussionBase({ discussionId }))),
-    coll && coll.messageIds && coll.messageIds.length > 0 ?
-      undefined :
-      dispatch(requestMessagesBase('discussion', discussionId, { discussion_id: discussionId })),
+    dispatch(requestMessagesBase('discussion', discussionId, { discussion_id: discussionId })),
   ]);
 
   return results[0];

--- a/src/frontend/web_application/src/scenes/Discussion/components/Message/index.js
+++ b/src/frontend/web_application/src/scenes/Discussion/components/Message/index.js
@@ -12,9 +12,11 @@ const onReply = ({ message }) => (dispatch) => {
   dispatch(reply({ internalId: message.discussion_id, message }));
 };
 
-const mapStateToProps = (state, { message }) => createSelector(
-  [messageEncryptionStatusSelector],
-  (messageEncryptionStatus) => {
+const messageSelector = (state, { message }) => message;
+
+const mapStateToProps = createSelector(
+  [messageEncryptionStatusSelector, messageSelector],
+  (messageEncryptionStatus, message) => {
     const encryptionStatus = messageEncryptionStatus[message.message_id];
 
     return {

--- a/src/frontend/web_application/src/scenes/Discussion/components/MessageList/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Discussion/components/MessageList/presenter.jsx
@@ -65,12 +65,11 @@ class MessageList extends Component {
       hash, scrollToTarget, user, settings,
     } = this.props;
 
-    const messageList = [];
-
-    return (messages.length > 0) && messages.reduce((acc, message) => {
-      if (message.protocol !== 'email' && messageList.length > 0
+    return messages.reduce((acc, message) => {
+      const result = [...acc];
+      if (message.protocol !== 'email' && acc.length > 0
         && this.findMessageBefore(message).protocol !== message.protocol) {
-        messageList.push(<ProtocolSwitch
+        result.push(<ProtocolSwitch
           newProtocol={message.protocol}
           pi={getAveragePIMessage({ message })}
           date={message.date}
@@ -79,7 +78,7 @@ class MessageList extends Component {
         />);
       }
 
-      messageList.push(<Message
+      result.push(<Message
         onMessageRead={onMessageRead}
         onMessageUnread={onMessageUnread}
         onMessageDelete={onMessageDelete}
@@ -90,8 +89,8 @@ class MessageList extends Component {
         settings={settings}
       />);
 
-      return messageList;
-    }, messageList);
+      return result;
+    }, []);
   }
 
   render() {


### PR DESCRIPTION
force fetch last messages

I forgot my own pattern: 
* `request<Resource>` force fetch to get up to date data and store it to redux (network first strategy)
* `get<Resource>` cache first strategy
* `fetch<Resource>`may be not related to redux (like password related requests)

Well, the best would be to write down this to a rfc.