### PR TITLE
Fix/backend/update contacts index

### DIFF
--- a/src/backend/defs/go-objects/contact.go
+++ b/src/backend/defs/go-objects/contact.go
@@ -375,7 +375,7 @@ func (c *Contact) MarshalFrontEnd() ([]byte, error) {
 	return JSONMarshaller("frontend", c)
 }
 
-func (c *Contact) MarshelES() ([]byte, error) {
+func (c *Contact) MarshalES() ([]byte, error) {
 	return JSONMarshaller("elastic", c)
 }
 

--- a/src/backend/main/go.backends/index/elasticsearch/contacts.go
+++ b/src/backend/main/go.backends/index/elasticsearch/contacts.go
@@ -46,7 +46,7 @@ func (es *ElasticSearchBackend) UpdateContact(user *UserInfo, contact *Contact, 
 		jsonFields[split[0]] = value
 	}
 	update, err := es.Client.Update().Index(user.Shard_id).Type(ContactIndexType).Id(contact.ContactId.String()).
-		Doc(fields).
+		Doc(jsonFields).
 		Refresh("wait_for").
 		Do(context.TODO())
 	if err != nil {

--- a/src/backend/main/go.backends/index/elasticsearch/contacts.go
+++ b/src/backend/main/go.backends/index/elasticsearch/contacts.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (es *ElasticSearchBackend) CreateContact(contact *Contact) error {
-	es_contact, err := contact.MarshelES()
+	es_contact, err := contact.MarshalES()
 	if err != nil {
 		log.WithError(err).Warn("[ElasticSearchBackend] failed to parse contact to json : %s", string(es_contact))
 		return err


### PR DESCRIPTION
Fields in indexed_contacts documents where incorrectly renamed after a `Contact` update.  
This fix issue #1223 

The naming error last for months… **Contacts indexes should be rebuild**