### PR TITLE
Clickable links in messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.18.2] 2019-04-26
 
+### Added
+
+- Activate links in plain text messages.
+
 ### Fixed
 
 - signup does not authenticate and crash

--- a/src/frontend/web_application/package.json
+++ b/src/frontend/web_application/package.json
@@ -68,6 +68,7 @@
     "iron": "^4.0.5",
     "jquery": "^3.3.1",
     "jssha": "^2.3.1",
+    "linkifyjs": "^2.1.8",
     "locale": "^0.1.0",
     "lodash.debounce": "^4.0.8",
     "lodash.intersection": "^4.4.0",

--- a/src/frontend/web_application/src/scenes/Discussion/components/InstantMessage/index.jsx
+++ b/src/frontend/web_application/src/scenes/Discussion/components/InstantMessage/index.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Moment from 'react-moment';
 import classNames from 'classnames';
+import Linkify from 'linkifyjs/react';
 import { withI18n, Trans } from '@lingui/react';
 import { withScrollTarget } from '../../../../modules/scroll';
 import { withPush } from '../../../../modules/routing';
@@ -187,7 +188,11 @@ class InstantMessage extends PureComponent {
           isLocked ?
             <LockedMessage encryptionStatus={encryptionStatus} />
             :
-            <TextBlock className="m-instant-message__content" nowrap={false}>{message.body}</TextBlock>
+            <TextBlock className="m-instant-message__content" nowrap={false}>
+              <Linkify>
+                {message.body}
+              </Linkify>
+            </TextBlock>
         }
       </article>
     );

--- a/src/frontend/web_application/src/scenes/Discussion/components/MailMessage/index.jsx
+++ b/src/frontend/web_application/src/scenes/Discussion/components/MailMessage/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Moment from 'react-moment';
 import { Trans, withI18n } from '@lingui/react';
 import classnames from 'classnames';
+import Linkify from 'linkifyjs/react';
 import { withScrollTarget } from '../../../../modules/scroll';
 import { withPush } from '../../../../modules/routing';
 import { ParticipantLabel } from '../../../../modules/message';
@@ -77,7 +78,7 @@ class MailMessage extends Component {
     }
 
     return (
-      <TextBlock nowrap={false}><pre className="s-mail-message__content">{message.body}</pre></TextBlock>
+      <TextBlock nowrap={false}><Linkify tagName="pre" className="s-mail-message__content">{message.body}</Linkify></TextBlock>
     );
   }
 

--- a/src/frontend/web_application/yarn.lock
+++ b/src/frontend/web_application/yarn.lock
@@ -9215,6 +9215,15 @@ lie@~3.1.0:
   dependencies:
     immediate "~3.0.5"
 
+linkifyjs@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-2.1.8.tgz#2bee2272674dc196cce3740b8436c43df2162f9c"
+  integrity sha512-j3QpiEr4UYzN5foKhrr9Sr06VI9vSlI4HisDWt+7Mq+TWDwpJ6H/LLpogYsXcyUIJLVhGblXXdUnblHsVNMPpg==
+  optionalDependencies:
+    jquery "^3.3.1"
+    react "^16.4.2"
+    react-dom "^16.4.2"
+
 load-bmfont@^1.2.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.4.0.tgz#75f17070b14a8c785fe7f5bee2e6fd4f98093b6b"
@@ -12492,7 +12501,7 @@ react-document-title@^2.0.3:
     prop-types "^15.5.6"
     react-side-effect "^1.0.2"
 
-react-dom@^16.8.6:
+react-dom@^16.4.2, react-dom@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
   integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
@@ -12653,7 +12662,7 @@ react-visibility-sensor@^5.0.2:
   dependencies:
     prop-types "^15.6.2"
 
-react@^16.8.6:
+react@^16.4.2, react@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==


### PR DESCRIPTION
This simple proposal uses ~https://github.com/alexcorvi/anchorme.js/tree/gh-pages/src~ linkifyjs to add clickable links to plain text messages. 

Could be used to make custom intern `mailto` links with some additions.