### PR TITLE
Feature/backend/cli copy command

### DIFF
--- a/src/backend/tools/py.CLI/caliopen_cli/cli.py
+++ b/src/backend/tools/py.CLI/caliopen_cli/cli.py
@@ -67,6 +67,8 @@ def main(args=sys.argv):
     sp_copy = subparsers.add_parser('copy')
     sp_copy.set_defaults(func=copy_model)
     sp_copy.add_argument('-m', dest='model', help='model to dump')
+    sp_copy.add_argument('--where', dest='where', help='where condition')
+    sp_copy.add_argument('--fetch-size', dest='fetch_size', default=100)
 
     sp_dump_index = subparsers.add_parser('dump_index')
     sp_dump_index.set_defaults(func=dump_indexes)

--- a/src/backend/tools/py.CLI/caliopen_cli/cli.py
+++ b/src/backend/tools/py.CLI/caliopen_cli/cli.py
@@ -15,7 +15,7 @@ from caliopen_cli.commands import (shell, import_email, setup, create_user,
                                    import_vcard, dump_model, dump_indexes,
                                    inject_email, basic_compute, migrate_index,
                                    import_reserved_names, resync_index,
-                                   resync_shard_index)
+                                   resync_shard_index, copy_model)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -63,6 +63,10 @@ def main(args=sys.argv):
     sp_dump.set_defaults(func=dump_model)
     sp_dump.add_argument('-m', dest='model', help='model to dump')
     sp_dump.add_argument('-o', dest='output_path', help='output path')
+
+    sp_copy = subparsers.add_parser('copy')
+    sp_copy.set_defaults(func=copy_model)
+    sp_copy.add_argument('-m', dest='model', help='model to dump')
 
     sp_dump_index = subparsers.add_parser('dump_index')
     sp_dump_index.set_defaults(func=dump_indexes)

--- a/src/backend/tools/py.CLI/caliopen_cli/commands/__init__.py
+++ b/src/backend/tools/py.CLI/caliopen_cli/commands/__init__.py
@@ -11,3 +11,4 @@ from .compute import basic_compute
 from .reserved_names import import_reserved_names
 from .resync_index import resync_index
 from .resync_shard_index import resync_shard_index
+from .copy_model import copy_model

--- a/src/backend/tools/py.CLI/caliopen_cli/commands/copy_model.py
+++ b/src/backend/tools/py.CLI/caliopen_cli/commands/copy_model.py
@@ -1,0 +1,37 @@
+
+import sys
+
+from cassandra.cluster import Cluster
+from cassandra.query import SimpleStatement
+from cassandra.query import dict_factory
+
+from caliopen_storage.config import Configuration
+
+
+def copy_model(**kwargs):
+    conf = Configuration('global').configuration
+    cluster_source = Cluster(conf['cassandra']['hosts'])
+    source = cluster_source.connect(conf['cassandra']['keyspace'])
+    source.row_factory = dict_factory
+    cluster_dest = Cluster(conf['new_cassandra']['hosts'])
+    dest = cluster_dest.connect(conf['new_cassandra']['keyspace'])
+
+    table = kwargs['model'].lower()
+    query = "SELECT * from {0}".format(table)
+    statement = SimpleStatement(query, fetch_size=100)
+    insert_query = "INSERT INTO {0} ({1}) VALUES ({2})"
+    cpt = 0
+    insert = None
+    for row in source.execute(statement):
+        if cpt == 0:
+            columns = row.keys()
+            binds = ['?' for x in range(0, len(columns))]
+            insert_str = insert_query.format(table,
+                                             ','.join(columns),
+                                             ','.join(binds))
+            insert = dest.prepare(insert_str)
+        bound = insert.bind(row.values())
+        dest.execute(bound)
+        cpt += 1
+    print('Copy of {} records from {}'.format(cpt, table))
+    return cpt

--- a/src/backend/tools/py.CLI/caliopen_cli/commands/copy_model.py
+++ b/src/backend/tools/py.CLI/caliopen_cli/commands/copy_model.py
@@ -17,8 +17,11 @@ def copy_model(**kwargs):
     dest = cluster_dest.connect(conf['new_cassandra']['keyspace'])
 
     table = kwargs['model'].lower()
-    query = "SELECT * from {0}".format(table)
-    statement = SimpleStatement(query, fetch_size=100)
+    fetch_size = kwargs.get('fetch_size', 100)
+    query = "SELECT * FROM {0}".format(table)
+    if 'where' in kwargs and kwargs['where']:
+        query = "{0} WHERE {1} ALLOW FILTERING".format(query, kwargs['where'])
+    statement = SimpleStatement(query, fetch_size=fetch_size)
     insert_query = "INSERT INTO {0} ({1}) VALUES ({2})"
     cpt = 0
     insert = None


### PR DESCRIPTION
Add a `copy -m <model_name>` command to Caliopen CLI.

It take data from `cassandra` configuration entry and copy all into a `new_cassandra` configuration entry.

```
cassandra:
    keyspace: caliopen
    hosts:
        - 'cassandra.dev.caliopen.org'
    consistency_level: 1
    protocol_version: 3

new_cassandra:
    keyspace: caliopen2
    hosts:
        - 'cassandra.dev.caliopen.org'
    consistency_level: 1
    protocol_version: 3
```