### PR TITLE
Strip hardcoded values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - signup does not authenticate and crash
+- hardcoded references to "alpha.caliopen.org" in client
 
 ## [0.18.1] 2019-04-26
 

--- a/src/frontend/web_application/config/client.default.js
+++ b/src/frontend/web_application/config/client.default.js
@@ -1,5 +1,4 @@
 const { version } = require('../package.json');
-const { maxBodySize } = require('./server.default.js');
 
 const siteId = process.env.CALIOPEN_PIWIK_SITE_ID && JSON.parse(process.env.CALIOPEN_PIWIK_SITE_ID);
 
@@ -11,5 +10,4 @@ module.exports = {
   piwik: {
     siteId: (siteId === false) ? false : siteId || 6,
   },
-  maxBodySize,
 };

--- a/src/frontend/web_application/server/ssr/ssr-middleware.js
+++ b/src/frontend/web_application/server/ssr/ssr-middleware.js
@@ -48,7 +48,6 @@ export default (req, res) => {
       ...initialStateSettings,
       settings: getDefaultSettings(getUserLocales()[0]),
     },
-    instanceConfig: getConfig(),
   };
 
   const store = configureStore(initialState);

--- a/src/frontend/web_application/server/ssr/ssr-middleware.js
+++ b/src/frontend/web_application/server/ssr/ssr-middleware.js
@@ -15,7 +15,9 @@ import { initialState as initialStateSettings } from '../../src/store/modules/se
  */
 function getMarkup({ store, context, location }) {
   try {
-    const { protocol, hostname, port } = getConfig();
+    const {
+      protocol, hostname, port, maxBodySize,
+    } = getConfig();
     const config = { protocol, hostname, port };
     const markup = ReactDOMServer.renderToString(React.createElement(Bootstrap, {
       context, location, store, config,
@@ -25,7 +27,7 @@ function getMarkup({ store, context, location }) {
 
     return [
       { key: '</title>', value: `${documentTitle}</title>` },
-      { key: '</head>', value: `<script>window.__STORE__ = ${serialize(initialState)};</script></head>` },
+      { key: '</head>', value: `<script>window.__STORE__ = ${serialize(initialState)};window.__INSTANCE_CONFIG__ = ${serialize({ hostname, maxBodySize })}</script></head>` },
       { key: '%MARKUP%', value: markup },
     ].reduce((str, current) => str.replace(current.key, current.value), template);
   } catch (e) {
@@ -46,6 +48,7 @@ export default (req, res) => {
       ...initialStateSettings,
       settings: getDefaultSettings(getUserLocales()[0]),
     },
+    instanceConfig: getConfig(),
   };
 
   const store = configureStore(initialState);

--- a/src/frontend/web_application/src/components/PageTitle/index.jsx
+++ b/src/frontend/web_application/src/components/PageTitle/index.jsx
@@ -1,11 +1,14 @@
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
 import { userSelector } from '../../modules/user';
+import { getConfig } from '../../services/config';
+
 import Presenter from './presenter';
 
+const { hostname } = getConfig();
 const mapStateToProps = createSelector(
   [userSelector],
-  user => ({ user })
+  user => ({ user, hostname })
 );
 
 export default connect(mapStateToProps)(Presenter);

--- a/src/frontend/web_application/src/components/PageTitle/presenter.jsx
+++ b/src/frontend/web_application/src/components/PageTitle/presenter.jsx
@@ -10,17 +10,21 @@ class PageTitle extends PureComponent {
     // FIXME always undefined
     currentTab: PropTypes.shape({}),
     title: PropTypes.string,
+    hostname: PropTypes.string,
   };
 
   static defaultProps = {
     title: '',
+    hostname: 'unknown',
     currentTab: undefined,
     user: undefined,
   };
 
   render() {
-    const { user, title, currentTab } = this.props;
-    const userName = user ? `${user.name}@alpha.caliopen.org - ` : '';
+    const {
+      user, title, currentTab, hostname,
+    } = this.props;
+    const userName = user ? `${user.name}@${hostname} - ` : '';
     const currentTabLabel = currentTab ? `${currentTab.routeConfig.tab.renderLabel()} - ` : '';
     const pageTitle = title ? `${title} - ` : currentTabLabel;
     const documentTitle = `${pageTitle}${userName}${DEFAULT_DOCUMENT_TITLE}`;

--- a/src/frontend/web_application/src/scenes/Signup/components/SignupForm/presenter.jsx
+++ b/src/frontend/web_application/src/scenes/Signup/components/SignupForm/presenter.jsx
@@ -5,6 +5,8 @@ import {
   Spinner, Link, Label, Subtitle, PasswordStrength, FieldErrors, TextBlock, Modal, Button,
   TextFieldGroup, CheckboxFieldGroup, FormGrid, FormRow, FormColumn,
 } from '../../../../components';
+import { getConfig } from '../../../../services/config';
+
 import './style.scss';
 
 function generateStateFromProps(props) {
@@ -174,6 +176,7 @@ class SignupForm extends Component {
     const {
       form, errors = {}, i18n, isValidating,
     } = this.props;
+    const { hostname } = getConfig();
 
     return (
       <div className="s-signup">
@@ -200,7 +203,7 @@ class SignupForm extends Component {
                   onBlur={this.handleInputBlur}
                 />
                 <TextBlock className="s-signup__user">
-                  <span className="s-signup__username">{this.state.formValues.username}</span>@alpha.caliopen.org
+                  <span className="s-signup__username">{this.state.formValues.username}</span>@{hostname}
                 </TextBlock>
               </FormColumn>
             </FormRow>

--- a/src/frontend/web_application/src/services/config.js
+++ b/src/frontend/web_application/src/services/config.js
@@ -1,6 +1,7 @@
 import merge from 'lodash.merge';
 
-let config = CALIOPEN_OPTIONS;
+// eslint-disable-next-line no-underscore-dangle
+let config = BUILD_TARGET === 'browser' && typeof window !== 'undefined' ? { ...window.__INSTANCE_CONFIG__, ...CALIOPEN_OPTIONS } : CALIOPEN_OPTIONS;
 
 const initConfig = (cfg) => { config = merge(config, cfg); };
 const getConfig = () => config;


### PR DESCRIPTION
Pass env vars to client, strip "alpha.caliopen.org" from client code. One ref remains in tests, but has no incidence on client.