### PR TITLE
Dead simple detection of pgp inline format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Simple detection of PGP inline message
+- Apiv2 create and delete contacts does not use user.shard_id
+- Better logging for apiv2 and mq-worker
+- Do not fail if ContactLookup raise a NotFound
+
 ## [0.18.2] 2019-04-26
 
 ### Fixed

--- a/src/backend/components/py.pi/caliopen_pi/features/mail.py
+++ b/src/backend/components/py.pi/caliopen_pi/features/mail.py
@@ -22,6 +22,9 @@ TLS_VERSION_PI = {
 }
 
 
+PGP_MESSAGE_HEADER = '\n-----BEGIN PGP MESSAGE-----'
+
+
 class InboundMailFeature(object):
     """Process a parsed mail message and extract available privacy features."""
 
@@ -116,6 +119,12 @@ class InboundMailFeature(object):
         encrypted_parts = [x for x in self.message.attachments
                            if 'pgp-encrypt' in x.content_type]
         is_encrypted = True if encrypted_parts else False
+
+        # Maybe pgp/inline ?
+        if not is_encrypted:
+            if self.message.body_plain.startswith(PGP_MESSAGE_HEADER):
+                is_encrypted = True
+
         return {'message_encrypted': is_encrypted,
                 'message_encryption_method': 'pgp' if is_encrypted else ''}
 


### PR DESCRIPTION
There is no RFC for this format but it sound the default format using Thunderbird PGP plugin.

This method is imperfect but for a simple mail with a PGP message in it's plain body we should detect correctly encrption.

Should fix #1309