### PR TITLE
Previous commit remove ability to detect pgp encryption

### DIFF
--- a/src/backend/components/py.pi/caliopen_pi/features/mail.py
+++ b/src/backend/components/py.pi/caliopen_pi/features/mail.py
@@ -116,9 +116,9 @@ class InboundMailFeature(object):
 
     def get_encryption_informations(self):
         """Get message encryption features."""
-        encrypted_parts = [x for x in self.message.attachments
-                           if 'pgp-encrypt' in x.content_type]
-        is_encrypted = True if encrypted_parts else False
+        is_encrypted = False
+        if 'encrypted' in self.message.extra_parameters:
+            is_encrypted = True
 
         # Maybe pgp/inline ?
         if not is_encrypted:

--- a/src/backend/components/py.pi/caliopen_pi/tests/fixtures/pgp_crypted_1.eml
+++ b/src/backend/components/py.pi/caliopen_pi/tests/fixtures/pgp_crypted_1.eml
@@ -1,0 +1,70 @@
+Message-ID: <1492761665.964.1.camel@gandi.net>
+Subject: crypted content
+From: Chamal <chamal@caliopen.org>
+To: Caliopen <contact@caliopen.org>
+Date: Fri, 21 Apr 2017 10:01:05 +0200
+Content-Type: multipart/encrypted; protocol="application/pgp-encrypted";
+        boundary="=-hf6zgIn8mtv3IPX/X7Tq"
+X-Mailer: Evolution 3.22.6 
+Mime-Version: 1.0
+X-Evolution-Identity: 1485870052.1665.0@tao
+X-Evolution-Fcc: folder://1485870052.1665.2%40tao/Sent
+X-Evolution-Transport: 1485870052.1665.10@tao
+X-Evolution-Source: 
+
+
+--=-hf6zgIn8mtv3IPX/X7Tq
+Content-Type: application/pgp-encrypted
+Content-Transfer-Encoding: 7bit
+
+Version: 1
+
+--=-hf6zgIn8mtv3IPX/X7Tq
+Content-Type: application/octet-stream; name="encrypted.asc"
+Content-Description: Ceci est une partie de message
+ =?ISO-8859-1?Q?num=E9riquement?= =?ISO-8859-1?Q?_sign=E9e?=
+Content-Transfer-Encoding: 7bit
+
+-----BEGIN PGP MESSAGE-----
+
+hQIMAxEK1/MMDKzXAQ/+KpNeJBR9o5etazFr16HO/vWAdDlkq3iIu7BOm0sAXYIJ
+ssjXN9cXY1LM1B70GeXvGeB4suqJBjrl6xbKCW0fMQsGovYQpyHJAOJCtModM6vM
+76OuuTcT0AdE40pgfscTdG3nCUV2T/w2IKg7TNLwEstRQ4BoA+RFPyar97Zq1Pyk
+74Wkwv1BT9jMejkpaQycqlV1eTF/JNbXa/hs5dcmirbH9PCoySQx+qFnp4w4ZHnx
+JDT/MpmK4M3w7FawyA2adUFKeBqXU9Oo2LBz9f9ZBtIPHeiV2iklEgQUqv/847dc
+OqB23fd+Jq8mXjmycLcwEsXjOL77dI+SCip4MheFvGjwSOUoIkIb6SbcnUq/hwsi
+xpLc3yeZDm4BCi/M0crmhMF8NEJYyu0Xg2Si+lWtWPHCtrXW+Lla226BcGNlV1Dx
+cpaeMlFF2MvADqTsxAD8F+km2mrf7RznobnX70TkH2wF80W+/KIKbc0R2ilyvyIm
+Y/MgttT593nUJgIm77cIzUjSMJHVfhYASS960Rv4cvKMIYcJQ41zJ1O693eB8gXM
+ebCU7Tg6gzZ1Fckgil0VQyRwY9cPERZQSrgcQOdZaw51jYzJNrRDXaaX8TuMnSTx
+xJkalCh8PEJ9mtLIvNPgw5cGNhttNkoGvPamEAXEHTNE7757qo5ku7w4X2u9t6uF
+AQwD08kNfkWMEY4BB/9N42dz6IwZ7GG/9Hj0Avcb5l8If1peNj/zOUXv88JBvMEL
+GukefhD2ez0R359ErrJk4Q+RhOOJYkrcPUShqm0SN7s50TVsms5/7T/OT0mxVsOR
+6nnm19DMGW32Kz819c8Gp+kVB7sFOldJpi/kyoXJsO/0HdnXaM4HyeF8csTFFvLf
+B2bZFNk5YgasiCbCys2M0Zv8MtmUXQc7y1xsHSvpgjM6Ftb2BQdfjNj+CUnJHpxc
+CfFtM8lmeVrjPFHqtyuofVEqQvHjKSKSfZH5LrYA6QJfL0Girfqm3x4fgCSAaHPQ
+87G7pcu5Ci2FDpQlHxPwnXHfbT/IKPNQrjB/nQ0E0ukBK5GRwm8AnqjK+cCcSaYo
+bcoNartPm8J3qPTC3Vdzw2OButC6wnXYrsbE1rADZ6PVByeXj7OtSX01fykHwgFj
+nEu4HEIMNTVtprZQ8UnMV95REM8yRteiNPfl+osK3Ae/PyZ/0go7bhYgfJh3qnIH
+NDzThiCy3/4YoBErejnLVQdpVTf2OFHEDpohwz76/4GhXouOiWkrSpjBWIwMnYC+
+F/ZEgXkUIja6l1K16ovNe03DiEb/dgZkF//BJsnIAzNqK8PzGawwxLkDrMKVVAjP
+TpdGSnwyDsjjFMYG4s7dWWo0miwPU5QLJIkqqyk2040YCV6rgebpfZ8RrIuZEERi
+uSFQtf+ghBWGJDuf49P+adf20HbNYFIi++TkG0fQ0RlcagRHYRahgytdQpUBz9GS
+afOnC9uPtIyBq6dNLsvAr1pIlBXsy14lSdAv67rtUtOzNoeww0BaiYpL6Ir3rrPg
+pQ34U3RZ44kH0QWq/9btVWPTxLobRc41pf/LmEo4MAvwwZeyvJH5mJQotaWDRtJu
+NYLzCYcqT5UqRn5dYq8k8UFzLwaynoSxdUSV0uozGsLj5yXf5Dm1x/L+FAX5STgZ
+95MntgS5fPjYABNPD9oVqfFdJmm9s27b3LgFgQBlx4kU+rqN/aAQdIltlUsA+zl1
+qkoRdhilQfqn7g35HRm/ysD9pK7GKQ+R1D+fQAebs451E50q3VIaB0lJRluRXabK
+vWhMk29emRPKg8OMRR7r9oIss9gg+fTVmyttNX5MZ5t+DKjGdlApMhLPahyxa/i/
+WWhRmZTLkVRqssD3blfPa1AR/XJIONcfFROwLyHy3LwQyMBcH8YcFC5oT3oDn3PR
+07gXHSK6N7Xv6R08NF1Q6Ag4d6IUT//KvUf5WqyZaB5adLEE/Fip8doDed6zv/Hw
+qSeSqgWm9Y2t+6sekZXJkMHaY0Mdiuu6ONntG7cs87rHHKG/paCcAMLLoKkpFuJM
+voKkjlafMq+HR59hY4fIgrOw2iydL1Ihb9YiMzl15zknpzQeQMNCElm3dZvWwsHU
+n3HYTc+JqTEXxpP7IiBpIbiy/EP5kIuKk9kapBgiDDzMiey3WbyyeqTH4luAh0Uv
+ofJivNiEJeCzCR6Gml1bgvRbJrimsgYF1iBAsY3m14onkCCnWaim9kqLUmB8mVec
+xsYUJuNtGEqS8W0++uBzW+tXKlq6hjdGkfeCp/oD6gbBGxq+Iho8qVRSRPJ90EOR
+IZX5mCJJzSYdP9ELwWFAObl7WtRea7Ed376B6a7maQ==
+=EKUR
+-----END PGP MESSAGE-----
+
+--=-hf6zgIn8mtv3IPX/X7Tq--

--- a/src/backend/components/py.pi/caliopen_pi/tests/test_features.py
+++ b/src/backend/components/py.pi/caliopen_pi/tests/test_features.py
@@ -63,3 +63,14 @@ class TestEncyption(unittest.TestCase):
         featurer.process(user, param, ([]))
         feats = param.privacy_features
         self.assertEqual(feats.get('transport_signed'), True)
+
+    def test_encrypted_message(self):
+        mail = load_mail('pgp_crypted_1.eml')
+        message = MailMessage(mail)
+        param = NewMessage()
+        user = FakeUser()
+        featurer = InboundMailFeature(message, {})
+        featurer.process(user, param, ([]))
+        feats = param.privacy_features
+        self.assertEqual(feats.get('message_encrypted'), True)
+        self.assertEqual(feats.get('message_encryption_method'), 'pgp')

--- a/src/backend/main/py.main/caliopen_main/tests/parsers/test_mail.py
+++ b/src/backend/main/py.main/caliopen_main/tests/parsers/test_mail.py
@@ -53,6 +53,7 @@ class TestMailFormat(unittest.TestCase):
         self.assertEqual(len(mail.attachments), 1)
         self.assertEqual(mail.subject, 'crypted content')
         self.assertTrue(isinstance(mail.date, datetime))
+        self.assertTrue(mail.extra_parameters.get('encrypted', None), 'pgp')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add an _extra_parameters dict to MailMessage parser, when detecting a part of `application/pgp-encrypted` content-type do not produce an attachement but set `encryption` _extra_parameters key to related encryption type.
