### PR TITLE
Notifier must use nats Queue subscriber model

### DIFF
--- a/src/backend/configs/apiv2.yaml
+++ b/src/backend/configs/apiv2.yaml
@@ -32,6 +32,7 @@ ApiConfig:
         - http://elasticsearch:9200
   NatsConfig:
     url: nats://nats:4222
+    nats_queue: NotifierQueue
     outSMTP_topic: outboundSMTP       # topic's name for "send" draft order via SMTP
     outIMAP_topic: outboundIMAP       # topic's name for "send" draft order via remote SMTP+IMAP
     outTWITTER_topic: twitter_dm      # topics's name for "send" draft order via TWITTER

--- a/src/backend/defs/go-objects/configs.go
+++ b/src/backend/defs/go-objects/configs.go
@@ -43,6 +43,7 @@ type (
 	// NATS
 	NatsConfig struct {
 		Url              string `mapstructure:"url"`
+		NatsQueue        string `mapstructure:"nats_queue"`
 		OutSMTP_topic    string `mapstructure:"outSMTP_topic"`
 		OutIMAP_topic    string `mapstructure:"outIMAP_topic"`
 		OutTWITTER_topic string `mapstructure:"outTWITTER_topic"`

--- a/src/backend/interfaces/REST/go.server/api_server.go
+++ b/src/backend/interfaces/REST/go.server/api_server.go
@@ -82,6 +82,7 @@ type (
 
 	NatsConfig struct {
 		Url              string `mapstructure:"url"`
+		NatsQueue        string `mapstructure:"nats_queue"`
 		OutSMTP_topic    string `mapstructure:"outSMTP_topic"`
 		OutIMAP_topic    string `mapstructure:"outIMAP_topic"`
 		OutTWITTER_topic string `mapstructure:"outTWITTER_topic"`
@@ -130,6 +131,7 @@ func (server *REST_API) initialize(config APIConfig) error {
 		},
 		NatsConfig: obj.NatsConfig{
 			Url:              config.NatsConfig.Url,
+			NatsQueue:        config.NatsConfig.NatsQueue,
 			OutSMTP_topic:    config.NatsConfig.OutSMTP_topic,
 			OutIMAP_topic:    config.NatsConfig.OutIMAP_topic,
 			OutTWITTER_topic: config.NatsConfig.OutTWITTER_topic,

--- a/src/backend/main/go.main/facilities/Messaging/facility.go
+++ b/src/backend/main/go.main/facilities/Messaging/facility.go
@@ -44,7 +44,7 @@ func NewCaliopenMessaging(config CaliopenConfig, notifier *Notifications.Notifie
 	if config.NatsConfig.Users_topic == "" {
 		return nil, errors.New("[NewCaliopenMessaging] wont subscribe to empty topic")
 	}
-	userSub, err := cm.natsConn.Subscribe(config.NatsConfig.Users_topic, cm.HandleUserAction)
+	userSub, err := cm.natsConn.QueueSubscribe(config.NatsConfig.Users_topic, config.NatsConfig.NatsQueue, cm.HandleUserAction)
 	if err != nil {
 		log.WithError(err).Errorf("[NewCaliopenMessaging] failed to subscribe to %s topic on NATS", config.NatsConfig.Users_topic)
 		return nil, err


### PR DESCRIPTION
Subscriber model is a one to many and do not permit to scale apiv2 without processing notifications many time.