### PR TITLE
Feature/backend/uri to contact resolution route

### DIFF
--- a/src/backend/configs/swagger.json
+++ b/src/backend/configs/swagger.json
@@ -3571,6 +3571,13 @@
             "type": "integer",
             "required": false,
             "description": "number of pages to skip from the response"
+          },
+          {
+            "name": "uri",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "description": "return contact that has this uri embedded, if any"
           }
         ],
         "produces": [

--- a/src/backend/defs/rest-api/paths/contactsV2.yaml
+++ b/src/backend/defs/rest-api/paths/contactsV2.yaml
@@ -29,6 +29,11 @@ contacts:
       type: integer
       required: false
       description: number of pages to skip from the response
+    - name: uri
+      in: query
+      type: string
+      required: false
+      description: return contact that has this uri embedded, if any
     produces:
     - application/json
     responses:

--- a/src/backend/main/go.main/facilities/REST/RESTfacility.go
+++ b/src/backend/main/go.main/facilities/REST/RESTfacility.go
@@ -33,6 +33,7 @@ type (
 		PatchContact(user *UserInfo, patch []byte, contactID string) error
 		DeleteContact(user *UserInfo, contactID string) error
 		ContactExists(userID, contactID string) bool
+		LookupContactByUri(userID, uri string) ([]*Contact, int64, error)
 		//identities
 		RetrieveContactIdentities(user_id, contact_id string) (identities []ContactIdentity, err error)
 		RetrieveLocalIdentities(user_id string) (identities []UserIdentity, err error)

--- a/src/backend/main/go.main/facilities/REST/contacts.go
+++ b/src/backend/main/go.main/facilities/REST/contacts.go
@@ -70,6 +70,28 @@ func (rest *RESTfacility) RetrieveContact(userID, contactID string) (contact *Co
 	return rest.store.RetrieveContact(userID, contactID)
 }
 
+func (rest *RESTfacility) LookupContactByUri(userID, uri string) (contacts []*Contact, totalFound int64, err error) {
+	contacts = []*Contact{}
+	uri = strings.ToLower(uri)
+	uriSplit := strings.SplitN(uri, ":", 2)
+	if len(uriSplit) != 2 {
+		err = fmt.Errorf("[LookupContactByUri] uri malformed : %s => %v", uri, uriSplit)
+		log.WithError(err)
+		return
+	}
+	ids, err := rest.store.LookupContactsByIdentifier(userID, uriSplit[1], uriSplit[0])
+	if err != nil {
+		return
+	}
+	for _, contactId := range ids {
+		c := Contact{}
+		c.ContactId = UUID(uuid.FromStringOrNil(contactId))
+		contacts = append(contacts, &c)
+		totalFound++
+	}
+	return
+}
+
 // RetrieveUserContact returns the contact entry belonging to user.
 // This is the contact that is auto-created for user and can't be deleted.
 func (rest *RESTfacility) RetrieveUserContact(userID string) (contact *Contact, err error) {


### PR DESCRIPTION
Allow frontend to add a query param on route `GET …/contacts` to lookup contact by uri. Examples : 
- to lookup if an email belongs to a contact : `GET …/contacts?uri=email%3Astan%40mailden.net`
- to lookup a twitter account : `GET …/contacts?uri=twitter%3Acaliopen`