### PR TITLE
Feature/backend/user status

### DIFF
--- a/src/backend/defs/go-objects/user.go
+++ b/src/backend/defs/go-objects/user.go
@@ -61,6 +61,7 @@ type Auth_cache struct {
 	Y             big.Int   `json:"y"`
 	Key_id        string    `json:"key_id"`
 	Shard_id      string    `json:"shard_id"`
+	User_status   string    `json:"user_status"`
 }
 
 // unmarshal a map[string]interface{} that must owns all Contact's fields
@@ -209,6 +210,7 @@ func (ac *Auth_cache) UnmarshalJSON(b []byte) error {
 		Y             big.Int `json:"y"`
 		Key_id        string  `json:"key_id"`
 		Shard_id      string  `json:"shard_id"`
+		User_status   string  `json:"user_status"`
 	}
 	if err := json.Unmarshal(b, &temp); err != nil {
 		return err
@@ -226,5 +228,6 @@ func (ac *Auth_cache) UnmarshalJSON(b []byte) error {
 	ac.Y = temp.Y
 	ac.Curve = temp.Curve
 	ac.Shard_id = temp.Shard_id
+	ac.User_status = temp.User_status
 	return nil
 }

--- a/src/backend/interfaces/REST/go.server/middlewares/authentication.go
+++ b/src/backend/interfaces/REST/go.server/middlewares/authentication.go
@@ -89,6 +89,10 @@ func BasicAuthFromCache(cache backends.APICache, realm string) gin.HandlerFunc {
 			kickUnauthorizedRequest(c, realm)
 			return
 		}
+		if auth.User_status == "maintenance" || auth.User_status == "locked" {
+			c.AbortWithError(401, errors.New("User status does not permit operations"))
+		}
+		log.Println("User status", auth.User_status)
 
 		if device_sign := c.Request.Header.Get("X-Caliopen-Device-Signature"); device_sign != "" {
 			query := getSignedQuery(c)

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/authentication.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/authentication.py
@@ -66,6 +66,9 @@ class AuthenticatedUser(object):
             raise AuthenticationError
         if infos.get('access_token') != token:
             raise AuthenticationError
+        if infos.get('user_status', 'unknown') in ['locked', 'maintenance']:
+            raise AuthenticationError('Status {} does not permit operations'.
+                                      format(infos.get('user_status')))
 
         if self.request.headers.get('X-Caliopen-Device-Signature', None):
             valid = self._validate_signature(self.request, device_id, infos)

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
@@ -141,7 +141,6 @@ class AuthenticationAPI(Api):
 
         self.request.cache.set(cache_key, session_data)
 
-        self.request.cache.set(user.user_id, tokens)
         tokens.pop('shard_id')
         return {'user_id': user.user_id,
                 'username': user.name,

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
@@ -62,6 +62,9 @@ def make_user_device_tokens(request, user, device, key, ttl=86400):
         status = previous.get('user_status', 'unknown')
         log.info('Found current user device entry {} : {}'.
                  format(cache_key, status))
+        if status in ['locked', 'maintenance']:
+            raise AuthenticationError('Status {} does not permit operations'.
+                                      format(status))
 
     access_token = create_token()
     refresh_token = create_token(80)

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
@@ -75,8 +75,10 @@ def make_user_device_tokens(request, user, device, key):
               'y': key.y,
               'curve': key.crv}
 
-    request.cache.set(cache_key, tokens)
-    return tokens
+    request.cache.setex(cache_key, ttl, tokens)
+    result = tokens.copy()
+    result.pop('shard_id')
+    return result
 
 
 @resource(path='',

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
@@ -80,7 +80,7 @@ def make_user_device_tokens(request, user, device, key, ttl=86400):
               'y': key.y,
               'curve': key.crv}
 
-    request.cache.setex(cache_key, ttl, tokens)
+    request.cache.set(cache_key, tokens)
     result = tokens.copy()
     result.pop('shard_id')
     return result
@@ -150,7 +150,6 @@ class AuthenticationAPI(Api):
             log.exception('Device login failed: {0}'.format(exc))
 
         tokens = make_user_device_tokens(self.request, user, device, key)
-        tokens.pop('shard_id')
         return {'user_id': user.user_id,
                 'username': user.name,
                 'tokens': tokens,

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
@@ -53,14 +53,19 @@ def patch_device_key(key, param):
     return False
 
 
-def make_user_device_tokens(request, user, device, key):
+def make_user_device_tokens(request, user, device, key, ttl=86400):
     """Return (key, tokens) informations for cache entry management."""
     cache_key = '{}-{}'.format(user.user_id, device.device_id)
+
+    previous = request.cache.get(cache_key)
+    if previous:
+        status = previous.get('user_status', 'unknown')
+        log.info('Found current user device entry {} : {}'.
+                 format(cache_key, status))
 
     access_token = create_token()
     refresh_token = create_token(80)
 
-    ttl = 86400
     expires_at = (datetime.datetime.utcnow() +
                   datetime.timedelta(seconds=ttl))
 

--- a/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
+++ b/src/backend/interfaces/REST/py.server/caliopen_api/user/user.py
@@ -65,7 +65,8 @@ def make_user_device_tokens(request, user, device, key):
               'refresh_token': refresh_token,
               'expires_in': ttl,  # TODO : remove this value
               'shard_id': user.shard_id,
-              'expires_at': expires_at.isoformat()}
+              'expires_at': expires_at.isoformat(),
+              'user_status': 'active'}
     cache_key = '{}-{}'.format(user.user_id, device.device_id)
     tokens.update({'key_id': str(key.key_id),
                    'x': key.x,

--- a/src/backend/tools/py.CLI/caliopen_cli/utils/user_token.py
+++ b/src/backend/tools/py.CLI/caliopen_cli/utils/user_token.py
@@ -1,0 +1,56 @@
+import logging
+import redis
+import json
+
+log = logging.getLogger(__name__)
+
+
+class UserToken(object):
+
+    """Utility class to deal with user token session in cache."""
+
+    _token_prefix = 'tokens::'
+
+    def __init__(self, redis_host, redis_port=6379):
+        self.client = redis.Redis(redis_host, redis_port)
+
+    def parse_session(self, session):
+        if '-' not in session:
+            return session, None
+        user_id, device_id = session.split('-')
+        return user_id, device_id
+
+    def list_user_sessions(self, user_id):
+        return self.client.keys('{}{}-*'.format(self._token_prefix, user_id))
+
+    def get_token(self, token):
+        infos = self.client.get(token)
+        if infos:
+            return json.loads(infos)
+        return {}
+
+    def delete_token(self, token):
+        return self.client.delete(token)
+
+    def get_user_status(self, user_id):
+        sessions = self.list_user_sessions(user_id)
+        for session in sessions:
+            token = self.get_token(session)
+            log.info('User session {} status is {}'.
+                     format(session, token.get('user_status')))
+
+    def _set_user_status(self, user_id, status):
+        sessions = self.list_user_sessions(user_id)
+        for session in sessions:
+            token = self.get_token(session)
+            if token.get('user_status') != status:
+                log.info('Updating user session {} status '.format(session))
+                token['user_status'] = status
+                self.client.set(session, json.dumps(token))
+        return True
+
+    def user_set_maintenance(self, user_id):
+        return self._set_user_status(user_id, 'maintenance')
+
+    def user_unset_maintenance(self, user_id):
+        return self._set_user_status(user_id, 'active')


### PR DESCRIPTION
We spoke about such functionality a lot with @sapiens-sapide 

I implemented it naively using a `user_status` value in redis cache user+device entry.

If value is `maintenance` or `locked` then APIv1 and APIv2 respond with a 401 message for the moment.

There is a class utility UserToken in caliopen_cli.utils namespace for POC around set / unset a maintenance status for an user (and manipulate sessions a bit).

A new device can bypass this situation for the moment. Don't get correct API from request.cache object to deal with user sessions.