### PR TITLE
Feature/backend/import contact dedup

### DIFF
--- a/src/backend/main/py.main/caliopen_main/common/helpers/normalize.py
+++ b/src/backend/main/py.main/caliopen_main/common/helpers/normalize.py
@@ -8,7 +8,12 @@ log = logging.getLogger(__name__)
 
 
 def clean_email_address(addr):
-    """Clean an email address for user resolve."""
+    """
+    Clean an email address for user resolve.
+
+    Return a tuple (normalized_value, real_value)
+    Normalization is : lowercase the real email value and keep + in local part
+    """
     real_name, email = parseaddr(addr.replace('\r', ''))
     err_msg = 'Invalid email address {}'.format(addr)
     if not email or '@' not in email:
@@ -18,13 +23,11 @@ def clean_email_address(addr):
     if '@' in domain:
         log.error(err_msg)
         return ("", "")
-    if '+' in name:
-        try:
-            name, ext = name.split('+', 1)
-        except Exception as exc:
-            log.info(exc)
+
     # unicode everywhere
     return (u'%s@%s' % (name, domain), email)
 
+
 def clean_twitter_address(addr):
+    """Clean a twitter address."""
     return addr.strip('@').lower()

--- a/src/backend/main/py.main/caliopen_main/contact/parameters.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parameters.py
@@ -153,6 +153,13 @@ class NewPhone(Model):
     type = StringType(choices=PHONE_TYPES, default='other')
     uri = StringType()
 
+    @property
+    def best_value(self):
+        """Output the best value for duplicate/merge processing."""
+        if self.normalized_number:
+            return self.normalized_number
+        return self.number
+
     class Options:
         serialize_when_none = False
 
@@ -211,6 +218,18 @@ class NewContact(Model):
     phones = ListType(ModelType(NewPhone), default=lambda: [])
     privacy_features = DictType(StringType(), default=lambda: {})
     tags = ListType(StringType(), default=lambda: [])
+
+    @property
+    def all_identifiers(self):
+        """Return all distinct identifiers for this contact."""
+        for email in self.emails:
+            yield ('email', email.address)
+        for im in self.ims:
+            yield ('im', im.address)
+        for ident in self.identities:
+            yield (ident.type, ident.name)
+        for phone in self.phones:
+            yield ('phone', phone.best_value)
 
     class Options:
         serialize_when_none = False

--- a/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
@@ -242,6 +242,7 @@ class VcardContact(object):
         contact.emails, duplicates = self._deduplicate_list(emails, 'address')
         warnings['duplicate_email'] = duplicates
 
+        # TODO deduplicate using protocol and not only identity name
         identities = list(self.__parse_social_identities())
         if identities:
             contact.identities, duplicates = self._deduplicate_list(identities,
@@ -266,21 +267,6 @@ class VcardContact(object):
     def validate(self):
         """Validate contact parsed informations."""
         return self.contact.validate()
-
-    def all_identifiers(self):
-        """Return all distinct identifiers for this contact."""
-        for email in self.contact.emails:
-            yield ('email', email.address)
-        for im in self.contact.ims:
-            yield ('im', im.address)
-        for ident in self.contact.identities:
-            yield (ident.type, ident.name)
-        for phone in self.contact.phones:
-            if phone.normalized_number:
-                number = phone.normalized_number
-            else:
-                number = phone.number
-            yield ('phone', number)
 
 
 class VcardParserResult(object):
@@ -316,7 +302,7 @@ class VcardParser(object):
         for contact in contacts:
             result.sum_all_contacts += 1
             contact_conflict = 0
-            for ident in contact.all_identifiers():
+            for ident in contact.contact.all_identifiers:
                 if ident not in known_ids:
                     known_ids.append(ident)
                 else:

--- a/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
@@ -121,6 +121,11 @@ class VcardContact(object):
         """Parse a vcard contact."""
         self._vcard = vcard
         self.locale = default_locale
+        self.contact = None
+        self.warnings = {'duplicate_phone': 0, 'duplicate_email': 0,
+                         'duplicate_identity': 0, 'duplicate_im': 0}
+
+    def parse(self):
         self._parse()
 
     def _get_not_empty(self, prop):
@@ -214,8 +219,7 @@ class VcardContact(object):
                 self._meta[prop] = value
 
         # build list then dedup them
-        warnings = {'duplicate_phone': 0, 'duplicate_email': 0,
-                    'duplicate_identity': 0, 'duplicate_im': 0}
+        warnings = self.warnings
         phones = list(self.__parse_phones())
         normalized_phones = [x.normalized_number for x in phones
                              if x.normalized_number]
@@ -313,7 +317,9 @@ class VcardParser(object):
     def _parse(self):
         """Generator on vcards objects read from read file."""
         for vcard in self._vcards:
-            yield VcardContact(vcard, self.locale)
+            contact = VcardContact(vcard, self.locale)
+            contact.parse()
+            yield contact
 
 
 class VcardParserResult(object):

--- a/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
@@ -84,7 +84,9 @@ class VcardPhone(VcardParameter):
             normalized = phonenumbers.format_number(number, phone_format)
             if normalized:
                 phone.normalized_number = normalized
-        except:
+        except Exception as exc:
+            log.warning('Error during phone normalization {}: {}'.
+                        format(phone.number, exc))
             pass
         return phone
 
@@ -213,12 +215,12 @@ class VcardContact(object):
         # build list then dedup them
         warnings = {'duplicate_phone': 0, 'duplicate_email': 0,
                     'duplicate_identity': 0, 'duplicate_im': 0}
-        phones = self.__parse_phones()
+        phones = list(self.__parse_phones())
         normalized_phones = [x.normalized_number for x in phones
                              if x.normalized_number]
         distinct_numbers = []
         for phone in phones:
-            if phone.normalized_number in normalized_phones:
+            if phone.normalized_number not in normalized_phones:
                 if phone.normalized_number not in distinct_numbers:
                     distinct_numbers.append(phone.normalized_number)
                     contact.phones.append(phone)

--- a/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
@@ -94,9 +94,10 @@ class VcardPhone(VcardParameter):
 class VcardIdentity(VcardParameter):
 
     def _build(self):
-            social = NewSocialIdentity()
-            social.type = 'twitter'
-            social.name = self.param.value.lower().replace('@', '')
+        social = NewSocialIdentity()
+        social.type = 'twitter'
+        social.name = self.param.name.lower().replace('@', '')
+        return social
 
 
 class VcardAddress(VcardParameter):
@@ -233,22 +234,22 @@ class VcardContact(object):
                 else:
                     warnings['duplicate_phone'] += 1
 
-        emails = self.__parse_emails()
+        emails = list(self.__parse_emails())
         contact.emails, duplicates = self._deduplicate_list(emails, 'address')
         warnings['duplicate_email'] = duplicates
 
-        identities = self.__parse_social_identities()
-        if list(identities):
+        identities = list(self.__parse_social_identities())
+        if identities:
             contact.identities, duplicates = self._deduplicate_list(identities,
-                                                                    'value')
+                                                                    'name')
             warnings['duplicate_identity'] = duplicates
 
-        ims = self.__parse_impps()
+        ims = list(self.__parse_impps())
         contact.ims, duplicates = self._deduplicate_list(ims, 'address')
         warnings['duplicate_im'] = duplicates
 
-        contact.addresses = self.__parse_addresses()
-        contact.organizations = self.__parse_organizations()
+        contact.addresses = list(self.__parse_addresses())
+        contact.organizations = list(self.__parse_organizations())
         self.warnings = warnings
         self.contact = contact
 

--- a/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
+++ b/src/backend/main/py.main/caliopen_main/contact/parsers/vcard.py
@@ -283,6 +283,23 @@ class VcardContact(object):
             yield ('phone', number)
 
 
+class VcardParserResult(object):
+    """Result structure for a vcard parsing."""
+
+    def __init__(self):
+        self.sum_contacts = 0
+        self.sum_all_contacts = 0
+        self.sum_conflicts = 0
+        self.conflicts = []
+
+    def to_dict(self):
+        """Dict representation of this result."""
+        return {'sum_contacts': self.sum_contacts,
+                'sum_all_contacts': self.sum_all_contacts,
+                'sum_conflicts': self.sum_conflicts,
+                'conflicts': self.conflicts}
+
+
 class VcardParser(object):
     """Vcard format parser class."""
 
@@ -320,13 +337,3 @@ class VcardParser(object):
             contact = VcardContact(vcard, self.locale)
             contact.parse()
             yield contact
-
-
-class VcardParserResult(object):
-    """Result structure for a vcard parsing."""
-
-    def __init__(self):
-        self.sum_contacts = 0
-        self.sum_all_contacts = 0
-        self.sum_conflicts = 0
-        self.conflicts = []

--- a/src/backend/main/py.main/caliopen_main/message/parsers/mail.py
+++ b/src/backend/main/py.main/caliopen_main/message/parsers/mail.py
@@ -28,7 +28,8 @@ from caliopen_main.common.interfaces import (IAttachmentParser, IMessageParser,
 
 log = logging.getLogger(__name__)
 
-TEXT_CONTENT_TYPE = ['text', 'xml', 'vnd', 'xhtml', 'json' , 'msword']
+TEXT_CONTENT_TYPE = ['text', 'xml', 'vnd', 'xhtml', 'json', 'msword']
+
 
 class MailAttachment(object):
     """Mail part structure."""
@@ -229,11 +230,10 @@ class MailMessage(object):
         ref_ids = [address[1] for address in ref_addr] if ref_addr else []
         mid = clean_email_address(ext_id)[1] if ext_id else None
         if not mid:
-            log.error('Unable to find correct message_id {}'.format(ext_id))
+            log.warning('Unable to find correct message_id {}'.format(ext_id))
             mid = ext_id
         pid = clean_email_address(parent_id)[1] if parent_id else None
         if not pid:
-            log.error('Unable to find correct parent_id {}'.format(parent_id))
             pid = parent_id
         return {
             'message_id': mid,

--- a/src/backend/main/py.main/caliopen_main/tests/fixtures/vcard/dedup.vcf
+++ b/src/backend/main/py.main/caliopen_main/tests/fixtures/vcard/dedup.vcf
@@ -1,0 +1,51 @@
+BEGIN:VCARD
+VERSION:3.0
+FN:First contact
+N:First;Contact;;;
+X-EVOLUTION-FILE-AS:Contact\, First
+EMAIL;TYPE=OTHER:contact1@caliopen.org
+UID:pas-id-58AF0A5A00000000
+REV:2017-02-23T16:14:18Z(1)
+END:VCARD
+
+BEGIN:VCARD
+VERSION:3.0
+FN:Second contact
+N:Second;Contact;;;
+X-EVOLUTION-FILE-AS:Contact\, Second
+EMAIL;TYPE=OTHER:contact2@caliopen.org
+UID:pas-id-58AF0A5A00000000
+REV:2017-02-23T16:14:18Z(1)
+END:VCARD
+
+BEGIN:VCARD
+VERSION:3.0
+FN:Third contact
+N:Third;Contact;;;
+X-EVOLUTION-FILE-AS:Contact\, Third
+EMAIL;TYPE=OTHER:contact3@caliopen.org
+EMAIL;TYPE=OTHER:duplicate-email@caliopen.org
+UID:pas-id-58AF0A5A00000000
+REV:2017-02-23T16:14:18Z(1)
+END:VCARD
+
+BEGIN:VCARD
+VERSION:3.0
+FN:Third bis contact
+N:Third bis;Contact;;;
+X-EVOLUTION-FILE-AS:Contact\, Third bis
+EMAIL;TYPE=OTHER:contact3@caliopen.org
+EMAIL;TYPE=OTHER:duplicate-email@caliopen.org
+UID:pas-id-58AF0A5A00000000
+REV:2017-02-23T16:14:18Z(1)
+END:VCARD
+
+BEGIN:VCARD
+VERSION:3.0
+FN:Second bis contact
+N:Second bis;Contact;;;
+X-EVOLUTION-FILE-AS:Contact\, Second bis
+EMAIL;TYPE=OTHER:contact2@caliopen.org
+UID:pas-id-58AF0A5A00000000
+REV:2017-02-23T16:14:18Z(1)
+END:VCARD

--- a/src/backend/main/py.main/caliopen_main/tests/fixtures/vcard/full.vcf
+++ b/src/backend/main/py.main/caliopen_main/tests/fixtures/vcard/full.vcf
@@ -1,0 +1,17 @@
+BEGIN:VCARD
+VERSION:3.0
+FN:Complete contact
+N:contact;Complete;;;
+ADR;TYPE=WORK:;;63-65 Boulevard Massena;Paris;;75013;France
+ADR;TYPE=PERSONAL:;;1 bis rue du test;Paris;;75020;France
+X-EVOLUTION-FILE-AS:Complete\, contact
+EMAIL;TYPE=OTHER:contact@caliopen.org
+EMAIL;TYPE=PERSONAL:personal@caliopen.org
+IM;TYPE=OTHER:contact@caliopen.org
+TEL:+33 123456789
+TEL:0123456789
+X-TWITTER:@__someone
+ORG:some organization
+UID:pas-id-58AF0A5A00000000
+REV:2017-02-23T16:14:18Z(1)
+END:VCARD

--- a/src/backend/main/py.main/caliopen_main/tests/parsers/test_vcard.py
+++ b/src/backend/main/py.main/caliopen_main/tests/parsers/test_vcard.py
@@ -75,6 +75,7 @@ class TestVcardFormat(unittest.TestCase):
         self.assertTrue(len(list(contact.identities)) > 0)
         self.assertTrue(len(list(contact.organizations)) > 0)
         self.assertTrue(len(list(contact.addresses)) > 0)
+        self.assertTrue(len(list(contact.all_identifiers)) > 0)
 
 
 class TestVcardDedup(unittest.TestCase):

--- a/src/backend/main/py.main/caliopen_main/tests/parsers/test_vcard.py
+++ b/src/backend/main/py.main/caliopen_main/tests/parsers/test_vcard.py
@@ -16,9 +16,9 @@ else:
 
 Configuration.load(conf_file, 'global')
 
-#from caliopen_main.interfaces import IMessageParser
+
 from caliopen_main.contact.parameters import NewContact
-from caliopen_main.contact.parsers import VcardContact
+from caliopen_main.contact.parsers import VcardContact, VcardParser
 
 
 def load_vcard(filename):
@@ -43,7 +43,7 @@ class TestVcardFormat(unittest.TestCase):
         contact = parse_vcard(vcard)
         self.assertIsNotNone(contact.family_name)
         self.assertIsNotNone(contact.given_name)
-    
+
     def test_address_vcard(self):
         data = load_vcard('vcard1.vcf')
         vcard = vobject.readOne(data)
@@ -64,6 +64,26 @@ class TestVcardFormat(unittest.TestCase):
         contact = parse_vcard(vcard)
         for i in contact.ims:
             self.assertIsNotNone(i.type)
+
+
+class TestVcardDedup(unittest.TestCase):
+
+    def test_duplicate(self):
+        data = load_vcard('dedup.vcf')
+        parser = VcardParser(data)
+        parser.parse()
+        self.assertEqual(parser.result.sum_conflicts, 3)
+        self.assertEqual(parser.result.sum_contacts, len(parser.contacts))
+        self.assertEqual(parser.result.sum_all_contacts, 5)
+
+    def test_no_duplicate(self):
+        data = load_vcard('multi.vcf')
+        parser = VcardParser(data)
+        parser.parse()
+        self.assertEqual(parser.result.sum_conflicts, 0)
+        self.assertEqual(parser.result.sum_contacts,
+                         parser.result.sum_all_contacts)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/backend/main/py.main/caliopen_main/tests/parsers/test_vcard.py
+++ b/src/backend/main/py.main/caliopen_main/tests/parsers/test_vcard.py
@@ -32,6 +32,7 @@ def load_vcard(filename):
 
 def parse_vcard(vcard, locale=None):
     contact = VcardContact(vcard, locale)
+    contact.parse()
     return contact.contact
 
 

--- a/src/backend/main/py.main/caliopen_main/tests/parsers/test_vcard.py
+++ b/src/backend/main/py.main/caliopen_main/tests/parsers/test_vcard.py
@@ -30,8 +30,8 @@ def load_vcard(filename):
     return data
 
 
-def parse_vcard(vcard):
-    contact = VcardContact(vcard)
+def parse_vcard(vcard, locale=None):
+    contact = VcardContact(vcard, locale)
     return contact.contact
 
 
@@ -64,6 +64,16 @@ class TestVcardFormat(unittest.TestCase):
         contact = parse_vcard(vcard)
         for i in contact.ims:
             self.assertIsNotNone(i.type)
+
+    def test_complete(self):
+        data = load_vcard('full.vcf')
+        vcard = vobject.readOne(data)
+        contact = parse_vcard(vcard, 'FR')
+        self.assertTrue(len(list(contact.emails)) > 0)
+        self.assertTrue(len(list(contact.phones)) > 0)
+        self.assertTrue(len(list(contact.identities)) > 0)
+        self.assertTrue(len(list(contact.organizations)) > 0)
+        self.assertTrue(len(list(contact.addresses)) > 0)
 
 
 class TestVcardDedup(unittest.TestCase):


### PR DESCRIPTION
We must deduplicate and filter contact informations when importing a vcard file.

Start building a logic around a dry run mode to report problems before they occurs.