### PR TITLE
disable the send button on quick draft when body is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Disable the send button on quick draft when empty (thanks Sebbaz).
+
 ### Fixed
 
 - BSOD when changing identity in draft when no recipients (thanks peha)

--- a/src/frontend/web_application/src/modules/draftMessage/components/DraftMessage/presenter.jsx
+++ b/src/frontend/web_application/src/modules/draftMessage/components/DraftMessage/presenter.jsx
@@ -541,7 +541,7 @@ class DraftMessage extends Component {
 
     const encryptionEnabled = isEncrypted && encryptionStatus === STATUS_DECRYPTED;
 
-    const canSend = this.getCanSend();
+    const canSend = this.getCanSend() && this.state.draftMessage.body.length > 0;
 
     return (
       <div className={classnames(className, 'm-draft-message-quick')} ref={ref}>


### PR DESCRIPTION
https://feedback.caliopen.org/t/erreur-lors-dun-envoi-de-message-vide-comme-une-bouteille-a-la-mer/688