### PR TITLE
Feature/backend/import contact v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - On quick reply, «Enter» will not send draft anymore, it must be CTRL+Enter.
 - Quick reply is now multilines.
 - Use message's excerpt in search results instead of garbled highlights
+- Move vcard file import route on apiv2 to use contact uniqueness and lookups principles
 
 ### Fixed
 

--- a/src/backend/configs/swagger.json
+++ b/src/backend/configs/swagger.json
@@ -7474,7 +7474,7 @@
         }
       }
     },
-    "/v1/imports": {
+    "/v2/imports": {
       "post": {
         "consumes": [
           "multipart/form-data"

--- a/src/backend/defs/rest-api/swagger-root.yaml
+++ b/src/backend/defs/rest-api/swagger-root.yaml
@@ -54,7 +54,7 @@ paths:
     "$ref": paths/contactsV2.yaml#/contacts_{contact_id}_publickeys_{pubkey_id}
   "/v2/contacts/{contact_id}/tags":
     "$ref": paths/contactsV2.yaml#/contacts_{contact_id}_tags
-  "/v1/imports":
+  "/v2/imports":
     "$ref": paths/imports.yaml#/imports
 ## messages/discussions ##
   "/v2/discussions":

--- a/src/backend/interfaces/REST/go.server/api_server.go
+++ b/src/backend/interfaces/REST/go.server/api_server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations/devices"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations/discussions"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations/identities"
+	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations/imports"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations/messages"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations/notifications"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations/participants"
@@ -270,6 +271,10 @@ func (server *REST_API) AddHandlers(api *gin.RouterGroup) {
 	dev.PATCH("/:deviceID", devices.PatchDevice)
 	dev.DELETE("/:deviceID", devices.DeleteDevice)
 	dev.POST("/:deviceID/actions", devices.Actions)
+
+	// imports
+	imp := api.Group(http_middleware.ImportsRoute, http_middleware.BasicAuthFromCache(caliopen.Facilities.Cache, "caliopen"))
+	imp.POST("", imports.ImportFile)
 
 	/** tags API **/
 	tag := api.Group(http_middleware.TagsRoute, http_middleware.BasicAuthFromCache(caliopen.Facilities.Cache, "caliopen"))

--- a/src/backend/interfaces/REST/go.server/middlewares/config.go
+++ b/src/backend/interfaces/REST/go.server/middlewares/config.go
@@ -6,4 +6,5 @@ const (
 	TagsRoute       = "/tags"
 	ContactsRoute   = "/contacts"
 	DevicesRoute    = "/devices"
+	ImportsRoute    = "/imports"
 )

--- a/src/backend/interfaces/REST/go.server/operations/contacts/contacts.go
+++ b/src/backend/interfaces/REST/go.server/operations/contacts/contacts.go
@@ -12,7 +12,6 @@ import (
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/middlewares"
 	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.main"
-	log "github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	swgErr "github.com/go-openapi/errors"
 	"github.com/satori/go.uuid"
@@ -243,41 +242,4 @@ func DeleteContact(ctx *gin.Context) {
 		return
 	}
 	ctx.Status(http.StatusNoContent)
-}
-
-// ImportFile handles POST /imports and do logic depending on file mime type
-func ImportFile(ctx *gin.Context) {
-	userId, err := operations.NormalizeUUIDstring(ctx.MustGet("user_id").(string))
-
-	if err != nil {
-		e := swgErr.New(http.StatusUnprocessableEntity, err.Error())
-		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
-		ctx.Abort()
-		return
-	}
-	shard_id := ctx.MustGet("shard_id").(string)
-	user_info := &UserInfo{User_id: userId, Shard_id: shard_id}
-
-	file, header, err := ctx.Request.FormFile("file")
-	if err != nil {
-		e := swgErr.New(http.StatusUnprocessableEntity, err.Error())
-		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
-		ctx.Abort()
-		return
-	}
-
-	filename := header.Filename
-	content_type := header.Header["Content-Type"][0]
-
-	log.Info("Importing file ", filename, " with content_type ", content_type)
-	err = caliopen.Facilities.RESTfacility.ImportVcardFile(user_info, file)
-	if err != nil {
-		var e error
-		e = swgErr.New(http.StatusInternalServerError, err.Error())
-		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
-		ctx.Abort()
-	} else {
-		ctx.Status(http.StatusOK)
-	}
-	return
 }

--- a/src/backend/interfaces/REST/go.server/operations/imports/import.go
+++ b/src/backend/interfaces/REST/go.server/operations/imports/import.go
@@ -1,0 +1,51 @@
+/*
+ * // Copyleft (ɔ) 2019 The Caliopen contributors.
+ * // Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+ * // license (AGPL) that can be found in the LICENSE file.
+ */
+
+package imports
+
+import (
+	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
+	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/middlewares"
+	"github.com/CaliOpen/Caliopen/src/backend/interfaces/REST/go.server/operations"
+	"github.com/CaliOpen/Caliopen/src/backend/main/go.main"
+	"github.com/gin-gonic/gin"
+	swgErr "github.com/go-openapi/errors"
+	"net/http"
+)
+
+// ImportFile handles POST /imports and do logic depending on file mime type
+func ImportFile(ctx *gin.Context) {
+	userId, err := operations.NormalizeUUIDstring(ctx.MustGet("user_id").(string))
+
+	if err != nil {
+		e := swgErr.New(http.StatusUnprocessableEntity, err.Error())
+		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
+		ctx.Abort()
+		return
+	}
+	shard_id := ctx.MustGet("shard_id").(string)
+	user_info := &UserInfo{User_id: userId, Shard_id: shard_id}
+
+	file, _, err := ctx.Request.FormFile("file")
+	if err != nil {
+		e := swgErr.New(http.StatusUnprocessableEntity, err.Error())
+		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
+		ctx.Abort()
+		return
+	}
+
+	// TODO manage import switch file content-type / name
+	err = caliopen.Facilities.RESTfacility.ImportVcardFile(user_info, file)
+	if err != nil {
+		var e error
+		e = swgErr.New(http.StatusInternalServerError, err.Error())
+		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
+		ctx.Abort()
+	} else {
+		ctx.Status(http.StatusOK)
+	}
+	return
+}

--- a/src/backend/interfaces/REST/go.server/operations/imports/import.go
+++ b/src/backend/interfaces/REST/go.server/operations/imports/import.go
@@ -41,7 +41,7 @@ func ImportFile(ctx *gin.Context) {
 	err = caliopen.Facilities.RESTfacility.ImportVcardFile(user_info, file)
 	if err != nil {
 		var e error
-		e = swgErr.New(http.StatusInternalServerError, err.Error())
+		e = swgErr.New(http.StatusUnprocessableEntity, err.Error())
 		http_middleware.ServeError(ctx.Writer, ctx.Request, e)
 		ctx.Abort()
 	} else {

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -129,8 +129,10 @@ func FromVcard(user *objects.UserInfo, card vcard.Card) (*objects.Contact, error
 	// check version
 	// TODO implement version 4.0 (rfc 6350)
 	version := card[vcard.FieldVersion]
-	if version != nil && version[0].Value == "4.0" {
-		return contact, errors.New("Not supported vcard version 4.0")
+	if version != nil {
+		if !(version[0].Value == "3.0" || version[0].Value == "4.0") {
+			return contact, errors.New("Only vcard format 3.0 and 4.0 are supported")
+		}
 	}
 
 	// emails

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -129,8 +129,8 @@ func FromVcard(user *objects.UserInfo, card vcard.Card) (*objects.Contact, error
 	// check version
 	// TODO implement version 4.0 (rfc 6350)
 	version := card[vcard.FieldVersion]
-	if version != nil && version[0].Value != "3.0" {
-		return contact, errors.New("Invalid vcard version")
+	if version != nil && version[0].Value == "4.0" {
+		return contact, errors.New("Not supported vcard version 4.0")
 	}
 
 	// emails

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -47,6 +47,19 @@ func parsePhone(field *vcard.Field) *objects.Phone {
 	return phone
 }
 
+func parseIm(field *vcard.Field) *objects.IM {
+	im := new(objects.IM)
+	uid := new(objects.UUID)
+	_ = uid.UnmarshalBinary(uuid.NewV4().Bytes())
+	im.IMId = *uid
+	im.Address = strings.ToLower(field.Value)
+	im.Label = field.Value
+	if field.Params["TYPE"] != nil {
+		im.Type = strings.ToLower(field.Params["TYPE"][0])
+	}
+	return im
+}
+
 func parseAddress(addr *vcard.Address) *objects.PostalAddress {
 	address := new(objects.PostalAddress)
 	uid := new(objects.UUID)
@@ -89,6 +102,15 @@ func (parser *ContactParser) AddVcard(card vcard.Card) error {
 		}
 	}
 	helpers.NormalizePhoneNumbers(contact)
+
+	ims := card[vcard.FieldIMPP]
+	if ims != nil {
+		contact.Ims = []objects.IM{}
+		for _, im := range ims {
+			i := parseIm(im)
+			contact.Ims = append(contact.Ims, *i)
+		}
+	}
 
 	// addresses
 	addrs := card.Addresses()

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -141,7 +141,9 @@ func FromVcard(user *objects.UserInfo, card vcard.Card) (*objects.Contact, error
 		contact.Emails = []objects.EmailContact{}
 		for _, email := range emails {
 			e := parseEmail(email)
-			contact.Emails = append(contact.Emails, *e)
+			if e.Address != "" {
+				contact.Emails = append(contact.Emails, *e)
+			}
 		}
 	}
 
@@ -151,7 +153,9 @@ func FromVcard(user *objects.UserInfo, card vcard.Card) (*objects.Contact, error
 		contact.Phones = []objects.Phone{}
 		for _, phone := range phones {
 			p := parsePhone(phone)
-			contact.Phones = append(contact.Phones, *p)
+			if p.Number != "" {
+				contact.Phones = append(contact.Phones, *p)
+			}
 		}
 	}
 	helpers.NormalizePhoneNumbers(contact)
@@ -161,7 +165,9 @@ func FromVcard(user *objects.UserInfo, card vcard.Card) (*objects.Contact, error
 		contact.Ims = []objects.IM{}
 		for _, im := range ims {
 			i := parseIm(im)
-			contact.Ims = append(contact.Ims, *i)
+			if i.Address != "" {
+				contact.Ims = append(contact.Ims, *i)
+			}
 		}
 	}
 

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -13,10 +13,11 @@ import (
 )
 
 type VcardParser interface {
-	ProcessVcard(objects.UUID, vcard.Card) (*objects.Contact, error)
+	AddVcard(vcard.Card) error
 }
 
 type ContactParser struct {
+	UserId   objects.UUID
 	Contacts []objects.Contact
 }
 
@@ -59,9 +60,9 @@ func parseAddress(addr *vcard.Address) *objects.PostalAddress {
 	return address
 }
 
-func (parser *ContactParser) ProcessVcard(user_id objects.UUID, card vcard.Card) (*objects.Contact, error) {
+func (parser *ContactParser) AddVcard(card vcard.Card) error {
 	contact := new(objects.Contact).NewEmpty().(*objects.Contact)
-	contact.UserId = user_id
+	contact.UserId = parser.UserId
 	contact.Title = card.PreferredValue(vcard.FieldFormattedName)
 	if card.Name() != nil {
 		contact.FamilyName = card.Name().FamilyName
@@ -114,6 +115,6 @@ func (parser *ContactParser) ProcessVcard(user_id objects.UUID, card vcard.Card)
 	if contact.Title == "" {
 		helpers.ComputeNewTitle(contact)
 	}
-
-	return contact, nil
+	parser.Contacts = append(parser.Contacts, *contact)
+	return nil
 }

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -98,7 +98,17 @@ func (parser *ContactParser) ProcessVcard(user_id objects.UUID, card vcard.Card)
 			contact.Addresses = append(contact.Addresses, *a)
 		}
 	}
-	// TODO fill Contact.Infos with UID/REV informations
+	infos := make(map[string]string)
+	if uid := card[vcard.FieldUID]; uid != nil {
+		infos["uid"] = uid[0].Value
+	}
+	if rev := card[vcard.FieldRevision]; rev != nil {
+		infos["revision"] = rev[0].Value
+	}
+	contact.Infos = make(map[string]string)
+	for k, v := range infos {
+		contact.Infos[k] = v
+	}
 
 	// Compute a title if none found
 	if contact.Title == "" {

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -1,0 +1,108 @@
+// Copyleft (ɔ) 2019 The Caliopen contributors.
+// Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+// license (AGPL) that can be found in the LICENSE file.
+
+package contact
+
+import (
+	"github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
+	"github.com/emersion/go-vcard"
+	"strings"
+)
+
+type ContactParser struct {
+	Contacts []objects.Contact
+}
+
+/*
+
+type (
+	Contact struct {
+		Locker          *sync.Mutex       `cql:"-"                  json:"-"`
+		AdditionalName  string            `cql:"additional_name"    json:"additional_name,omitempty"      patch:"user"`
+		Addresses       []PostalAddress   `cql:"addresses"          json:"addresses,omitempty"            patch:"user"`
+		Avatar          string            `cql:"avatar"             json:"avatar,omitempty"               patch:"user"`
+		ContactId       UUID              `cql:"contact_id"         json:"contact_id,omitempty"   elastic:"omit"`
+		DateInsert      time.Time         `cql:"date_insert"        json:"date_insert,omitempty"          formatter:"RFC3339Milli"`
+		DateUpdate      time.Time         `cql:"date_update"        json:"date_update,omitempty"          formatter:"RFC3339Milli"`
+		Deleted         time.Time         `cql:"deleted"            json:"deleted,omitempty"              formatter:"RFC3339Milli"`
+		Emails          []EmailContact    `cql:"emails"             json:"emails,omitempty"               patch:"user"`
+		FamilyName      string            `cql:"family_name"        json:"family_name,omitempty"          patch:"user"`
+		GivenName       string            `cql:"given_name"         json:"given_name,omitempty"           patch:"user"`
+		Groups          []string          `cql:"groups"             json:"groups,omitempty"               patch:"user"`
+		Identities      []SocialIdentity  `cql:"identities"         json:"identities,omitempty"           patch:"user"`
+		Ims             []IM              `cql:"ims"                json:"ims,omitempty"                  patch:"user"`
+		Infos           map[string]string `cql:"infos"              json:"infos,omitempty"                patch:"user"`
+		NamePrefix      string            `cql:"name_prefix"        json:"name_prefix,omitempty"          patch:"user"`
+		NameSuffix      string            `cql:"name_suffix"        json:"name_suffix,omitempty"          patch:"user"`
+		Organizations   []Organization    `cql:"organizations"      json:"organizations,omitempty"        patch:"user"`
+		Phones          []Phone           `cql:"phones"             json:"phones,omitempty"               patch:"user"`
+		PrivacyIndex    *PrivacyIndex     `cql:"pi"                 json:"pi,omitempty"`
+		PublicKeys      []PublicKey       `cql:"-"                  json:"public_keys,omitempty"          patch:"user"`
+		PrivacyFeatures *PrivacyFeatures  `cql:"privacy_features"   json:"privacy_features,omitempty"`
+		Tags            []string          `cql:"tagnames"           json:"tags,omitempty"                 patch:"system"`
+		Title           string            `cql:"title"              json:"title,omitempty"                patch:"user"`
+		UserId          UUID              `cql:"user_id"            json:"user_id,omitempty"`
+	}
+
+	// ContactByContactPoints is the model of a Cassandra table to lookup contacts by address/email/phone/etc.
+	ContactByContactPoints struct {
+		ContactID string `cql:"contact_id"`
+		Type      string `cql:"type"`
+		UserID    string `cql:"user_id"`
+		Value     string `cql:"value"`
+	}
+)
+
+*/
+
+func parseEmail(field *vcard.Field) *objects.EmailContact {
+	email := new(objects.EmailContact)
+	email.Address = strings.ToLower(field.Value)
+	if field.Params["TYPE"] != nil {
+		email.Type = strings.ToLower(field.Params["TYPE"][0])
+	}
+	// TODO complete struct filling
+	email.Label = field.Value
+	return email
+}
+
+func parseAddress(addr *vcard.Address) *objects.PostalAddress {
+	address := new(objects.PostalAddress)
+	address.City = addr.Locality
+	address.Country = addr.Country
+	address.Region = addr.Region
+	address.PostalCode = addr.PostalCode
+	address.Street = addr.StreetAddress
+	return address
+}
+
+func (parser *ContactParser) ProcessVcard(user_id objects.UUID, card vcard.Card) (*objects.Contact, error) {
+	contact := new(objects.Contact).NewEmpty().(*objects.Contact)
+	contact.UserId = user_id
+	contact.Title = card.PreferredValue(vcard.FieldFormattedName)
+	if card.Name() != nil {
+		contact.FamilyName = card.Name().FamilyName
+		contact.GivenName = card.Name().GivenName
+	}
+	emails := card[vcard.FieldEmail]
+	if emails != nil {
+		contact.Emails = []objects.EmailContact{}
+		for _, email := range emails {
+			e := parseEmail(email)
+			contact.Emails = append(contact.Emails, *e)
+		}
+	}
+	/*
+		phones := card[vcard.FieldPhone]
+		if phones != nil {
+			contact.Phones = []objects.PhoneContact{}
+			for _, phone := range phones {
+				p := parsePhone(phone)
+				contact.Phones = append(contact.Phones, *p)
+			}
+		}
+	*/
+	// TODO fill Contact.Infos with UID/REV informations
+	return contact, nil
+}

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -99,17 +99,20 @@ func (parser *ContactParser) AddVcard(card vcard.Card) error {
 			contact.Addresses = append(contact.Addresses, *a)
 		}
 	}
-	infos := make(map[string]string)
-	if uid := card[vcard.FieldUID]; uid != nil {
-		infos["uid"] = uid[0].Value
-	}
-	if rev := card[vcard.FieldRevision]; rev != nil {
-		infos["revision"] = rev[0].Value
-	}
-	contact.Infos = make(map[string]string)
-	for k, v := range infos {
-		contact.Infos[k] = v
-	}
+	/*
+		TODO: Need to change index mappings of contact.infos
+		infos := make(map[string]string)
+		if uid := card[vcard.FieldUID]; uid != nil {
+			infos["uid"] = uid[0].Value
+		}
+		if rev := card[vcard.FieldRevision]; rev != nil {
+			infos["revision"] = rev[0].Value
+		}
+		contact.Infos = make(map[string]string)
+		for k, v := range infos {
+			contact.Infos[k] = v
+		}
+	*/
 
 	// Compute a title if none found
 	if contact.Title == "" {

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -88,15 +88,15 @@ func parseKey(field *vcard.Field, contact *objects.Contact) (*objects.PublicKey,
 	if field.Params["ENCODING"] != nil && field.Params["ENCODING"][0] == "b" {
 		pubkey, err := base64.StdEncoding.DecodeString(field.Value)
 		if err != nil {
-			return key, err
+			return &objects.PublicKey{}, err
 		}
 		entity, err := readPgpKey(pubkey)
 		if err != nil {
-			return key, err
+			return &objects.PublicKey{}, err
 		}
 		err = key.UnmarshalPGPEntity("PGP key", entity, contact)
 	} else {
-		return key, errors.New("Unknow key encoding")
+		return &objects.PublicKey{}, errors.New("Unknow key encoding")
 	}
 	log.Info("Have parsed PGP key ", key.Fingerprint, " with algorithm ", key.Algorithm)
 	return key, err

--- a/src/backend/main/go.main/contact/contact.go
+++ b/src/backend/main/go.main/contact/contact.go
@@ -202,9 +202,5 @@ func FromVcard(user *objects.UserInfo, card vcard.Card) (*objects.Contact, error
 		}
 	*/
 
-	// Compute a title if none found
-	if contact.Title == "" {
-		helpers.ComputeNewTitle(contact)
-	}
 	return contact, nil
 }

--- a/src/backend/main/go.main/contact/contact_test.go
+++ b/src/backend/main/go.main/contact/contact_test.go
@@ -6,6 +6,27 @@ import (
 	"testing"
 )
 
+// https://en.wikipedia.org/wiki/VCard#vCard_2.1
+var testWikipediav2_1 = `BEGIN:VCARD
+VERSION:2.1
+N:Gump;Forrest;;Mr.
+FN:Forrest Gump
+ORG:Bubba Gump Shrimp Co.
+TITLE:Shrimp Man
+PHOTO;GIF:http://www.example.com/dir_photos/my_photo.gif
+TEL;WORK;VOICE:(111) 555-1212
+TEL;HOME;VOICE:(404) 555-1212
+ADR;WORK;PREF:;;100 Waters Edge;Baytown;LA;30314;United States of America
+LABEL;WORK;PREF;ENCODING=QUOTED-PRINTABLE;CHARSET=UTF-8:100 Waters Edge=0D=
+ =0ABaytown\, LA 30314=0D=0AUnited States of America
+ADR;HOME:;;42 Plantation St.;Baytown;LA;30314;United States of America
+LABEL;HOME;ENCODING=QUOTED-PRINTABLE;CHARSET=UTF-8:42 Plantation St.=0D=0A=
+ Baytown, LA 30314=0D=0AUnited States of America
+EMAIL:forrestgump@example.com
+REV:20080424T195243Z
+END:VCARD`
+
+// https://en.wikipedia.org/wiki/VCard#vCard_3.0
 var testWikipediav3 = `BEGIN:VCARD
 VERSION:3.0
 N:Gump;Forrest;;Mr.;
@@ -23,6 +44,7 @@ EMAIL:forrestgump@example.com
 REV:2008-04-24T19:52:43Z
 END:VCARD`
 
+// https://en.wikipedia.org/wiki/VCard#vCard_4.0
 var testWikipediav4 = `BEGIN:VCARD
 VERSION:4.0
 N:Gump;Forrest;;Mr.;
@@ -41,6 +63,14 @@ REV:20080424T195243Z
 x-qq:21588891
 END:VCARD`
 
+// Format 2.1 used for v3
+var testInvalidv3 = `begin:vcard
+fn:Emma
+email;internet:Emma@tomme.de.savoie
+version:3.0
+end:vcard
+`
+
 var validTests = []struct {
 	s string
 }{
@@ -48,7 +78,13 @@ var validTests = []struct {
 	{testWikipediav4},
 }
 
-func TestFromVcard(t *testing.T) {
+var invalidFormat = []struct {
+	s string
+}{
+	{testWikipediav2_1},
+}
+
+func TestFromVcardValid(t *testing.T) {
 	info := objects.UserInfo{User_id: "ede04443-b60f-4869-9040-20bd6b1e33c1"}
 	for _, test := range validTests {
 		r := strings.NewReader(test.s)
@@ -66,5 +102,37 @@ func TestFromVcard(t *testing.T) {
 		if len(contact.Phones) == 0 {
 			t.Error("No phone found in test vcard ")
 		}
+	}
+}
+
+func TestFromVcardInvalid(t *testing.T) {
+	info := objects.UserInfo{User_id: "ede04443-b60f-4869-9040-20bd6b1e33c1"}
+	for _, test := range invalidFormat {
+		r := strings.NewReader(test.s)
+		cards, err := ParseVcardFile(r)
+		if len(cards) != 1 {
+			t.Error("Expected only one vcard")
+		}
+		_, err = FromVcard(&info, cards[0])
+		if err == nil {
+			t.Error("Expecting not null error ")
+		}
+	}
+}
+
+// Test testInvalidv3 card
+func TestFromVcardInvalidEmailFormat(t *testing.T) {
+	info := objects.UserInfo{User_id: "ede04443-b60f-4869-9040-20bd6b1e33c1"}
+	r := strings.NewReader(testInvalidv3)
+	cards, err := ParseVcardFile(r)
+	if len(cards) != 1 {
+		t.Error("Expected only one vcard")
+	}
+	contact, err := FromVcard(&info, cards[0])
+	if err != nil {
+		t.Error("Expecting no error ")
+	}
+	if len(contact.Emails) > 0 {
+		t.Error("Expecting no email in invalid vcard")
 	}
 }

--- a/src/backend/main/go.main/contact/contact_test.go
+++ b/src/backend/main/go.main/contact/contact_test.go
@@ -54,14 +54,17 @@ func TestFromVcard(t *testing.T) {
 		r := strings.NewReader(test.s)
 		cards, err := ParseVcardFile(r)
 		if len(cards) != 1 {
-			t.Fatal("Expected only one vcard")
+			t.Error("Expected only one vcard")
 		}
 		contact, err := FromVcard(&info, cards[0])
 		if err != nil {
-			t.Fatal("Expecting null error ", err)
+			t.Error("Expecting null error ", err)
 		}
 		if len(contact.Emails) == 0 {
-			t.Fatal("No email found in test vcard ")
+			t.Error("No email found in test vcard ")
+		}
+		if len(contact.Phones) == 0 {
+			t.Error("No phone found in test vcard ")
 		}
 	}
 }

--- a/src/backend/main/go.main/contact/contact_test.go
+++ b/src/backend/main/go.main/contact/contact_test.go
@@ -1,0 +1,67 @@
+package contact
+
+import (
+	"github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
+	"strings"
+	"testing"
+)
+
+var testWikipediav3 = `BEGIN:VCARD
+VERSION:3.0
+N:Gump;Forrest;;Mr.;
+FN:Forrest Gump
+ORG:Bubba Gump Shrimp Co.
+TITLE:Shrimp Man
+PHOTO;VALUE=URI;TYPE=GIF:;http://www.example.com/dir_photos/my_photo.gif
+TEL;TYPE=WORK,VOICE:(111) 555-1212
+TEL;TYPE=HOME,VOICE:(404) 555-1212
+ADR;TYPE=WORK,PREF:;;100 Waters Edge;Baytown;LA;30314;United States of America
+LABEL;TYPE=WORK,PREF:100 Waters Edge\nBaytown\, LA 30314\nUnited States of America
+ADR;TYPE=HOME:;;42 Plantation St.;Baytown;LA;30314;United States of America
+LABEL;TYPE=HOME:42 Plantation St.\nBaytown\, LA 30314\nUnited States of America
+EMAIL:forrestgump@example.com
+REV:2008-04-24T19:52:43Z
+END:VCARD`
+
+var testWikipediav4 = `BEGIN:VCARD
+VERSION:4.0
+N:Gump;Forrest;;Mr.;
+FN:Forrest Gump
+ORG:Bubba Gump Shrimp Co.
+TITLE:Shrimp Man
+PHOTO;MEDIATYPE=image/gif:http://www.example.com/dir_photos/my_photo.gif
+TEL;TYPE=work,voice;VALUE=uri:tel:+1-111-555-1212
+TEL;TYPE=home,voice;VALUE=uri:tel:+1-404-555-1212
+ADR;TYPE=WORK;PREF=1;LABEL="100 Waters Edge\nBaytown\, LA 30314\nUnited States of America":;;100 Waters Edge;Baytown;LA;30314;United St
+ates of America
+ADR;TYPE=HOME;LABEL="42 Plantation St.\nBaytown\, LA 30314\nUnited States of America":;;42 Plantation St.;Baytown;LA;30314;United State
+s of America
+EMAIL:forrestgump@example.com
+REV:20080424T195243Z
+x-qq:21588891
+END:VCARD`
+
+var validTests = []struct {
+	s string
+}{
+	{testWikipediav3},
+	{testWikipediav4},
+}
+
+func TestFromVcard(t *testing.T) {
+	info := objects.UserInfo{User_id: "ede04443-b60f-4869-9040-20bd6b1e33c1"}
+	for _, test := range validTests {
+		r := strings.NewReader(test.s)
+		cards, err := ParseVcardFile(r)
+		if len(cards) != 1 {
+			t.Fatal("Expected only one vcard")
+		}
+		contact, err := FromVcard(&info, cards[0])
+		if err != nil {
+			t.Fatal("Expecting null error ", err)
+		}
+		if len(contact.Emails) == 0 {
+			t.Fatal("No email found in test vcard ")
+		}
+	}
+}

--- a/src/backend/main/go.main/contact/vcard.go
+++ b/src/backend/main/go.main/contact/vcard.go
@@ -1,0 +1,49 @@
+// Copyleft (ɔ) 2019 The Caliopen contributors.
+// Use of this source code is governed by a GNU AFFERO GENERAL PUBLIC
+// license (AGPL) that can be found in the LICENSE file.
+
+package contact
+
+import (
+	"bufio"
+	"bytes"
+	"github.com/emersion/go-vcard"
+	"io"
+	"strings"
+)
+
+func parseBuffer(buffer io.Reader) (vcard.Card, error) {
+	dec := vcard.NewDecoder(buffer)
+	for {
+		card, err := dec.Decode()
+		if err != nil {
+			return vcard.Card{}, err
+		}
+		return card, nil
+	}
+}
+
+// Parse .vcf .vcard file, returting list of Card objects
+func ParseVcardFile(file io.Reader) ([]vcard.Card, error) {
+	cards := make([]vcard.Card, 0, 5)
+
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanLines)
+
+	current := make([]string, 0, 1)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		current = append(current, line)
+		if line == "END:VCARD" {
+			text := strings.Join(current, "\n")
+			card, err := parseBuffer(bytes.NewBufferString(text))
+			if err != nil {
+				return cards, err
+			}
+			cards = append(cards, card)
+			current = make([]string, 0, 1)
+		}
+	}
+	return cards, nil
+}

--- a/src/backend/main/go.main/contact/vcard.go
+++ b/src/backend/main/go.main/contact/vcard.go
@@ -5,6 +5,7 @@
 package contact
 
 import (
+	"errors"
 	"github.com/emersion/go-vcard"
 	"io"
 )
@@ -23,6 +24,9 @@ func ParseVcardFile(file io.Reader) ([]vcard.Card, error) {
 			return []vcard.Card{}, err
 		}
 		cards = append(cards, card)
+	}
+	if len(cards) == 0 {
+		return cards, errors.New("No vcard found in file")
 	}
 	return cards, nil
 }

--- a/src/backend/main/go.main/contact/vcard.go
+++ b/src/backend/main/go.main/contact/vcard.go
@@ -12,38 +12,20 @@ import (
 	"strings"
 )
 
-func parseBuffer(buffer io.Reader) (vcard.Card, error) {
-	dec := vcard.NewDecoder(buffer)
-	for {
-		card, err := dec.Decode()
-		if err != nil {
-			return vcard.Card{}, err
-		}
-		return card, nil
-	}
-}
-
 // Parse .vcf .vcard file, returting list of Card objects
 func ParseVcardFile(file io.Reader) ([]vcard.Card, error) {
 	cards := make([]vcard.Card, 0, 5)
 
-	scanner := bufio.NewScanner(file)
-	scanner.Split(bufio.ScanLines)
+	dec := vcard.NewDecoder(file)
 
-	current := make([]string, 0, 1)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		current = append(current, line)
-		if line == "END:VCARD" {
-			text := strings.Join(current, "\n")
-			card, err := parseBuffer(bytes.NewBufferString(text))
-			if err != nil {
-				return cards, err
-			}
-			cards = append(cards, card)
-			current = make([]string, 0, 1)
+	for {
+		card, err := dec.Decode()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return &[]vcard.Card{}, err
 		}
+		cards = append(cards, card)
 	}
 	return cards, nil
 }

--- a/src/backend/main/go.main/contact/vcard.go
+++ b/src/backend/main/go.main/contact/vcard.go
@@ -5,11 +5,8 @@
 package contact
 
 import (
-	"bufio"
-	"bytes"
 	"github.com/emersion/go-vcard"
 	"io"
-	"strings"
 )
 
 // Parse .vcf .vcard file, returting list of Card objects
@@ -23,7 +20,7 @@ func ParseVcardFile(file io.Reader) ([]vcard.Card, error) {
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return &[]vcard.Card{}, err
+			return []vcard.Card{}, err
 		}
 		cards = append(cards, card)
 	}

--- a/src/backend/main/go.main/facilities/REST/RESTfacility.go
+++ b/src/backend/main/go.main/facilities/REST/RESTfacility.go
@@ -5,11 +5,9 @@
 package REST
 
 import (
-	"github.com/CaliOpen/Caliopen/src/backend/main/go.backends/cache"
-	"io"
-
 	. "github.com/CaliOpen/Caliopen/src/backend/defs/go-objects"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.backends"
+	"github.com/CaliOpen/Caliopen/src/backend/main/go.backends/cache"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.backends/index/elasticsearch"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.backends/store/cassandra"
 	"github.com/CaliOpen/Caliopen/src/backend/main/go.main/facilities/Notifications"
@@ -17,6 +15,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/nats-io/go-nats"
 	"github.com/tidwall/gjson"
+	"io"
 )
 
 type (
@@ -34,6 +33,7 @@ type (
 		DeleteContact(user *UserInfo, contactID string) error
 		ContactExists(userID, contactID string) bool
 		LookupContactByUri(userID, uri string) ([]*Contact, int64, error)
+		ImportVcardFile(info *UserInfo, file io.Reader) error
 		//identities
 		RetrieveContactIdentities(user_id, contact_id string) (identities []ContactIdentity, err error)
 		RetrieveLocalIdentities(user_id string) (identities []UserIdentity, err error)

--- a/src/backend/main/go.main/facilities/REST/contacts.go
+++ b/src/backend/main/go.main/facilities/REST/contacts.go
@@ -291,18 +291,18 @@ func (rest *RESTfacility) ImportVcardFile(info *UserInfo, file io.Reader) error 
 
 	importErrors := make([]error, 0, len(vcards))
 	for _, card := range vcards {
-		contact, err := contact.FromVcard(info, card)
+		c, err := contact.FromVcard(info, card)
 		if err != nil {
 			log.Warn("[ImportVcardFile] Error during vcard transformation ", err)
 			importErrors = append(importErrors, err)
 		} else {
-			err = rest.CreateContact(info, contact)
+			err = rest.CreateContact(info, c)
 			if err != nil {
 				log.Warn("[ImportVcardFile] Create contact failed with error ", err)
 				importErrors = append(importErrors, err)
 			} else {
-				if contact.PublicKeys != nil {
-					for _, key := range contact.PublicKeys {
+				if c.PublicKeys != nil {
+					for _, key := range c.PublicKeys {
 						err = rest.store.CreatePGPPubKey(&key)
 						if err != nil {
 							log.Warn("Create pgp public key failed ", err)

--- a/src/backend/main/go.main/facilities/REST/contacts.go
+++ b/src/backend/main/go.main/facilities/REST/contacts.go
@@ -313,6 +313,9 @@ func (rest *RESTfacility) ImportVcardFile(info *UserInfo, file io.Reader) error 
 			}
 		}
 	}
+	for _, err := range importErrors {
+		log.Warn("Import vcard error: ", err)
+	}
 	return nil
 }
 

--- a/src/backend/main/go.main/facilities/REST/contacts.go
+++ b/src/backend/main/go.main/facilities/REST/contacts.go
@@ -285,21 +285,22 @@ func (rest *RESTfacility) ContactExists(userID, contactID string) bool {
 func (rest *RESTfacility) ImportVcardFile(info *UserInfo, file io.Reader) error {
 	vcards, err := contact.ParseVcardFile(file)
 	if err != nil {
-		errors.New("can't process vcard file")
+		return err
 	}
+	log.Debug("[ImportVcardFile] Have parse ", len(vcards), " vcards")
 	parser := new(contact.ContactParser)
 	parser.UserId = UUID(uuid.FromStringOrNil(info.User_id))
 	for _, card := range vcards {
 		err := parser.AddVcard(card)
 		if err != nil {
-			log.Fatal("Processing contact failed ", err)
+			return err
 		}
 	}
 	errors := make([]error, 0, len(vcards))
 	for _, contact := range parser.Contacts {
-		log.Info("Importing contact ", contact.Title)
 		err = rest.CreateContact(info, &contact)
 		if err != nil {
+			log.Warn("[ImportVcardFile] Create contact failed with error ", err)
 			errors = append(errors, err)
 		}
 	}

--- a/src/backend/main/go.main/facilities/REST/contacts.go
+++ b/src/backend/main/go.main/facilities/REST/contacts.go
@@ -316,6 +316,9 @@ func (rest *RESTfacility) ImportVcardFile(info *UserInfo, file io.Reader) error 
 	for _, err := range importErrors {
 		log.Warn("Import vcard error: ", err)
 	}
+	if len(importErrors) == len(vcards) {
+		return errors.New("No vcard imported")
+	}
 	return nil
 }
 

--- a/src/backend/main/go.main/facilities/REST/contacts.go
+++ b/src/backend/main/go.main/facilities/REST/contacts.go
@@ -303,6 +303,14 @@ func (rest *RESTfacility) ImportVcardFile(info *UserInfo, file io.Reader) error 
 			log.Warn("[ImportVcardFile] Create contact failed with error ", err)
 			errors = append(errors, err)
 		}
+		if contact.PublicKeys != nil {
+			for _, key := range contact.PublicKeys {
+				err = rest.store.CreatePGPPubKey(&key)
+				if err != nil {
+					log.Warn("Create pgp public key failed ", err)
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/src/backend/main/go.main/facilities/REST/contacts.go
+++ b/src/backend/main/go.main/facilities/REST/contacts.go
@@ -302,12 +302,13 @@ func (rest *RESTfacility) ImportVcardFile(info *UserInfo, file io.Reader) error 
 		if err != nil {
 			log.Warn("[ImportVcardFile] Create contact failed with error ", err)
 			errors = append(errors, err)
-		}
-		if contact.PublicKeys != nil {
-			for _, key := range contact.PublicKeys {
-				err = rest.store.CreatePGPPubKey(&key)
-				if err != nil {
-					log.Warn("Create pgp public key failed ", err)
+		} else {
+			if contact.PublicKeys != nil {
+				for _, key := range contact.PublicKeys {
+					err = rest.store.CreatePGPPubKey(&key)
+					if err != nil {
+						log.Warn("Create pgp public key failed ", err)
+					}
 				}
 			}
 		}

--- a/src/backend/vendor/vendor.json
+++ b/src/backend/vendor/vendor.json
@@ -139,6 +139,12 @@
 			"revisionTime": "2016-06-06T18:21:33Z"
 		},
 		{
+			"checksumSHA1": "7hiLcyFx1AnUeixnLFAJgA/badQ=",
+			"path": "github.com/emersion/go-vcard",
+			"revision": "8856043f13c54edb075ad5121315e5e89c3f5bfa",
+			"revisionTime": "2019-01-05T22:58:39Z"
+		},
+		{
 			"checksumSHA1": "x2Km0Qy3WgJJnV19Zv25VwTJcBM=",
 			"path": "github.com/fsnotify/fsnotify",
 			"revision": "4da3e2cfbabc9f751898f250b49f2439785783a1",


### PR DESCRIPTION
Move POST /imports route for vcard file processing to apiv2.

This way we benefit contact entry point deduplication. For the moment contacts are rejected when we try to create them during a vcard file import.

A better logic is needed (dry run, merge/forgot/etc strategy, ..)

Only vcard format 3.0 is parsed nowaday.