### PR TITLE
Fix/backend/missing twitter screenname

### DIFF
--- a/src/backend/protocols/go.twitter/account.go
+++ b/src/backend/protocols/go.twitter/account.go
@@ -384,11 +384,13 @@ func (worker *AccountHandler) getAccountName(accountID string) (accountName stri
 	if err == nil {
 		var inCache bool
 		if accountName, inCache = worker.usersScreenNames[ID]; !inCache {
-			user, _, err := worker.twitterClient.Users.Show(&twitter.UserShowParams{UserID: ID})
+			user, resp, err := worker.twitterClient.Users.Show(&twitter.UserShowParams{UserID: ID})
 			if err == nil && user != nil {
 				(*worker).usersScreenNames[ID] = user.ScreenName
+				return user.ScreenName
+			} else {
+				log.WithError(err).Warnf("[AccountHandler] failed to getAccountName for twitter ID %s. Got user {%+v} and http response {%+v}", accountID, user, resp)
 			}
-			return user.ScreenName
 		}
 		return accountName
 	}

--- a/src/backend/protocols/go.twitter/account.go
+++ b/src/backend/protocols/go.twitter/account.go
@@ -101,16 +101,30 @@ func NewAccountHandler(userID, remoteID string, worker Worker) (accountHandler *
 	if accountHandler.twitterClient = twitter.NewClient(httpClient); accountHandler.twitterClient == nil {
 		return nil, errors.New("[NewWorker] twitter api failed to create http client")
 	}
+	var twitterID int64
+	var screenName string
+	accountHandler.usersScreenNames = map[int64]string{}
+
+	// try to cache account's ID and screenName
 	if twitterid, ok := remote.Infos["twitterid"]; ok && twitterid != "" {
 		accountHandler.userAccount.twitterID = twitterid
+		twitterID, _ = strconv.ParseInt(twitterid, 10, 64)
+		if twittername, ok := remote.Infos["screen_name"]; ok && twittername != "" {
+			screenName = twittername
+		} else {
+			screenName = accountHandler.getAccountName(twitterid)
+		}
 	} else {
 		twitterUser, _, e := accountHandler.twitterClient.Users.Show(&twitter.UserShowParams{ScreenName: accountHandler.userAccount.screenName})
 		if e == nil {
 			accountHandler.userAccount.twitterID = twitterUser.IDStr
+			twitterID = twitterUser.ID
+			screenName = twitterUser.ScreenName
 		}
 	}
-	accountHandler.usersScreenNames = map[int64]string{}
-
+	if twitterID != 0 && screenName != "" {
+		accountHandler.usersScreenNames[twitterID] = screenName
+	}
 	return
 }
 


### PR DESCRIPTION
fix for issue #1400.
Error is logged and message is not injected in stack if accountHandler failed to retrieve an account screen name.