### PR TITLE
Change send button icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move vcard file import route on apiv2 to use contact uniqueness and lookups principles
 - Re-enable import contacts via vcard file.
 - New messages notification is not displayed anymore, it is now automatically loaded.
+- Send button icon in advanced form.
 
 ### Fixed
 

--- a/src/frontend/web_application/src/modules/draftMessage/components/DraftMessage/presenter.jsx
+++ b/src/frontend/web_application/src/modules/draftMessage/components/DraftMessage/presenter.jsx
@@ -647,11 +647,7 @@ class DraftMessage extends Component {
             disabled={!canSend}
           >
             {this.state.isSending && (<Spinner display="inline" theme="bright" />)}
-            {!this.state.isSending && (<Icon type="laptop" />)}
-            {' '}
-            ---
-            {' '}
-            <Icon type="user" />
+            {!this.state.isSending && (<Icon type="paper-plane" />)}
             {' '}
             <Trans id="draft-message.action.send">Send</Trans>
           </Button>


### PR DESCRIPTION
Change send button icon on advanced draft form for a more legible one (and consistent with quick draft) :
![image](https://user-images.githubusercontent.com/4181623/58885376-5d721800-86e2-11e9-93c0-85372ac9d9b3.png)

This is nothing, but it keeped bothering me for some time.