### PR TITLE
fix clearCookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Index user contact without alias using a workaround to bad core/mixin classes design
 - Addresses emails parsing failed sometimes with strange values
 - Process better invalid or missing data and encoding problems in incoming message
+- Signout wasn't effective
 
 ## [0.20.0] 2019-05-15
 

--- a/src/frontend/web_application/package.json
+++ b/src/frontend/web_application/package.json
@@ -9,8 +9,9 @@
   },
   "scripts": {
     "start": "npm-run-all -l build:clean build:i18n --parallel --race start:dev:server start:dev:assets",
+    "start:hostname": "CALIOPEN_HOSTNAME=caliopen.local CALIOPEN_WEB_SERVER_HOSTNAME=caliopen.local npm-run-all start",
     "start:dev": "HAS_SSR=false npm-run-all -l build:clean build:i18n --parallel --race start:dev:server start:dev:assets",
-    "start:dev:server": "CALIOPEN_API_HOSTNAME=localhost CALIOPEN_WEB_SERVER_PORT=4001 CALIOPEN_WEB_SERVER_HOSTNAME=127.0.0.1 bin/dev-server",
+    "start:dev:server": "CALIOPEN_API_HOSTNAME=localhost CALIOPEN_WEB_SERVER_PORT=4001 bin/dev-server",
     "start:dev:assets": "NODE_ENV=development CALIOPEN_MOTD='credentials: dev / 123456' webpack-dev-server --host 0.0.0.0 --progress --config webpack/webpack.config.browser.js --port 4000",
     "start:prod": "NODE_ENV=production ./bin/server",
     "start:mock-api": "../../../devtools/api-mock/bin/start",

--- a/src/frontend/web_application/server/auth/lib/cookie.js
+++ b/src/frontend/web_application/server/auth/lib/cookie.js
@@ -8,8 +8,14 @@ export const COOKIE_OPTIONS = {
   path: '/',
 };
 
+const getCookieOptions = () => {
+  const { hostname } = getConfig();
+
+  return { ...COOKIE_OPTIONS, domain: hostname };
+};
+
 export const authenticate = (res, { user }) => new Promise((resolve, reject) => {
-  const { seal: { secret }, hostname } = getConfig();
+  const { seal: { secret } } = getConfig();
 
   encode(
     user,
@@ -18,9 +24,11 @@ export const authenticate = (res, { user }) => new Promise((resolve, reject) => 
       if (err || !sealed) {
         return reject('Unexpected Error');
       }
-      res.cookie(COOKIE_NAME, sealed, { ...COOKIE_OPTIONS, domain: hostname });
+      res.cookie(COOKIE_NAME, sealed, getCookieOptions());
 
       return resolve();
     }
   );
 });
+
+export const invalidate = res => res.clearCookie(COOKIE_NAME, getCookieOptions());

--- a/src/frontend/web_application/server/auth/router/signin.js
+++ b/src/frontend/web_application/server/auth/router/signin.js
@@ -1,7 +1,7 @@
 import proxy from 'express-http-proxy';
 import { getApiHost } from '../../config';
 
-const { COOKIE_NAME, authenticate } = require('../lib/cookie');
+const { authenticate, invalidate } = require('../lib/cookie');
 
 const createLoginRouting = (router) => {
   const target = getApiHost();
@@ -24,7 +24,7 @@ const createLoginRouting = (router) => {
   }));
 
   router.get('/signout', (req, res) => {
-    res.clearCookie(COOKIE_NAME);
+    invalidate(res);
     const redirect = (() => {
       const parts = req.originalUrl.split('redirect=');
 

--- a/src/frontend/web_application/webpack/webpack.config.browser.js
+++ b/src/frontend/web_application/webpack/webpack.config.browser.js
@@ -78,6 +78,9 @@ const configureDevServer = () => {
 
   return {
     devServer: {
+      // using a hostname like caliopen.local, it requires this:
+      // https://github.com/webpack/webpack-dev-server/issues/1604
+      disableHostCheck: true,
       contentBase: false,
       hot: false,
       inline: true,


### PR DESCRIPTION
it must use same configuration as res.cookie

+ add new dev helper, start:hostname script to make `caliopen.local` available

but using this, ServiceWorker won't be activated since it requires SSL

fix #1427 