### PR TITLE
[WIP][frontend/encryption] Replaces `array.includes()` by custom func for compatibility.

### DIFF
--- a/src/frontend/web_application/src/modules/encryption/services/keyring/remoteKeys.js
+++ b/src/frontend/web_application/src/modules/encryption/services/keyring/remoteKeys.js
@@ -1,6 +1,7 @@
 import { selectKeys } from '../../selectors/publicKey';
 
-const intersect = (arr1, arr2) => arr1.some(value => arr2.includes(value));
+const includes = (array, value) => array.some(v => v === value);
+const intersect = (arr1, arr2) => arr1.some(value => includes(arr2, value));
 
 
 // XXX: refactor as a redux selector: const keysSelector = (state, { contactIds }) => {};
@@ -25,4 +26,4 @@ export const filterKeysByAddress = (keys, addresses) => keys
   .filter(({ emails }) => intersect(emails, addresses));
 
 export const checkEachAddressHasKey = (addresses, keys) => addresses
-  .every(address => keys.some(({ emails }) => emails.includes(address)));
+  .every(address => keys.some(({ emails }) => includes(emails, address)));


### PR DESCRIPTION
May lead to unwanted participants key check failures on some older and/or Microsoft browsers, thus unencrypted mails.

Edit/WIP : found some more.