### PR TITLE
Variable replacement for static "twitter" in identities.go

### DIFF
--- a/src/backend/main/go.main/facilities/REST/identities.go
+++ b/src/backend/main/go.main/facilities/REST/identities.go
@@ -243,7 +243,7 @@ func (rest *RESTfacility) DeleteUserIdentity(userId, identityId string) Caliopen
 		order := RemoteIDNatsMessage{
 			IdentityId: userIdentity.Id.String(),
 			Order:      "delete",
-			Protocol:   "twitter",
+			Protocol:   userIdentity.Protocol,
 			UserId:     userIdentity.UserId.String(),
 		}
 		jorder, jerr := json.Marshal(order)


### PR DESCRIPTION
Maybe the reason why vault doesn't let us remove Mastodon identities.