### PR TITLE
[backend] fix empty discussion list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- Empty discussion list.
+
 ## [0.26.0] 2023-04-04
 
 ### Changed

--- a/src/backend/main/go.backends/index/elasticsearch/discussions.go
+++ b/src/backend/main/go.backends/index/elasticsearch/discussions.go
@@ -24,7 +24,7 @@ func (es *ElasticSearchBackend) GetDiscussionsList(filter IndexSearch, withIL bo
 	search = filter.FilterQuery(search, withIL)
 	msgSource := elastic.NewFetchSourceContext(true)
 	msgSource.Include("date_sort", "subject", "participants", "body_plain", "body_html", "importance_level")
-	search.Aggregation("by_uris", elastic.NewTermsAggregation().Field("discussion_id.keyword").Size(10e3). // need to fetch all buckets to have an accurate buckets count
+	search.Aggregation("by_uris", elastic.NewTermsAggregation().Field("discussion_id").Size(10e3). // need to fetch all buckets to have an accurate buckets count
 														SubAggregation("sub_bucket", elastic.NewTopHitsAggregation().Sort("date_sort", false).Size(1).FetchSourceContext(msgSource)).
 														SubAggregation("unread_count", elastic.NewFilterAggregation().Filter(elastic.NewTermQuery("is_unread", true))).
 														SubAggregation("importance_level", elastic.NewTermsAggregation().Field("importance_level").Size(100).OrderByTermDesc()))


### PR DESCRIPTION
the sub aggregate term `discussion_id.keyword` might have been added by mistake

cf. 800388c47